### PR TITLE
Stats settings: power sensors, update banner, DS tokens

### DIFF
--- a/tauri-app/src/components/overlay/CpuSection.tsx
+++ b/tauri-app/src/components/overlay/CpuSection.tsx
@@ -71,12 +71,22 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
         )
       )}
       {cpuConsumption.isEnabled && (
-        <div className="flex items-baseline gap-0.5">
-          <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
-            {formatValue(cpuPowerVal)}
-          </span>
-          <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>W</span>
-        </div>
+        showProgress ? (
+          <Progress
+            value={cpuPowerVal}
+            max={cpuConsumption.boundaries.high}
+            label={formatValue(cpuPowerVal)}
+            unit="W"
+            boundaries={cpuConsumption.boundaries}
+          />
+        ) : (
+          <div className="flex items-baseline gap-0.5">
+            <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+              {formatValue(cpuPowerVal)}
+            </span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>W</span>
+          </div>
+        )
       )}
     </Pill>
   );

--- a/tauri-app/src/components/overlay/GpuSection.tsx
+++ b/tauri-app/src/components/overlay/GpuSection.tsx
@@ -103,12 +103,22 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
         )
       )}
       {gpuConsumption.isEnabled && (
-        <div className="flex items-baseline gap-0.5">
-          <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
-            {formatValue(gpuPowerVal)}
-          </span>
-          <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>W</span>
-        </div>
+        showProgress ? (
+          <Progress
+            value={gpuPowerVal}
+            max={gpuConsumption.boundaries.high}
+            label={formatValue(gpuPowerVal)}
+            unit="W"
+            boundaries={gpuConsumption.boundaries}
+          />
+        ) : (
+          <div className="flex items-baseline gap-0.5">
+            <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+              {formatValue(gpuPowerVal)}
+            </span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>W</span>
+          </div>
+        )
       )}
     </Pill>
   );

--- a/tauri-app/src/components/settings/stats/CpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/CpuSection.tsx
@@ -21,8 +21,9 @@ export function CpuSection({ sensors, hardwares }: Props) {
   const settings = useSettingsStore((s) => s.settings);
   const updateSensor = useSettingsStore((s) => s.updateSensor);
   const updateBoundary = useSettingsStore((s) => s.updateBoundary);
-  const { cpuUsage, cpuTemp } = settings.sensors;
-  const anyEnabled = cpuUsage.isEnabled || cpuTemp.isEnabled;
+  const { cpuUsage, cpuTemp, cpuConsumption } = settings.sensors;
+  const anyEnabled =
+    cpuUsage.isEnabled || cpuTemp.isEnabled || cpuConsumption.isEnabled;
 
   const cpuHwIds = new Set(
     hardwares.filter((h) => h.hardwareType === HardwareType.Cpu).map((h) => h.identifier),
@@ -33,20 +34,31 @@ export function CpuSection({ sensors, hardwares }: Props) {
   const cpuTempSensors = sensors.filter(
     (s) => cpuHwIds.has(s.hardwareIdentifier) && s.sensorType === SensorType.Temperature,
   );
+  const cpuPowerSensors = sensors.filter(
+    (s) => cpuHwIds.has(s.hardwareIdentifier) && s.sensorType === SensorType.Power,
+  );
 
-  const prevState = useRef<{ cpuUsage: boolean; cpuTemp: boolean } | null>(null);
+  const prevState = useRef<{
+    cpuUsage: boolean;
+    cpuTemp: boolean;
+    cpuConsumption: boolean;
+  } | null>(null);
 
   const handleMaster = (enabled: boolean) => {
     if (!enabled) {
-      prevState.current = { cpuUsage: cpuUsage.isEnabled, cpuTemp: cpuTemp.isEnabled };
+      prevState.current = {
+        cpuUsage: cpuUsage.isEnabled,
+        cpuTemp: cpuTemp.isEnabled,
+        cpuConsumption: cpuConsumption.isEnabled,
+      };
       updateSensor("cpuUsage", { isEnabled: false });
       updateSensor("cpuTemp", { isEnabled: false });
-      // Clear removed-from-UI sensors so upgraders don't see ghost metrics.
       updateSensor("cpuConsumption", { isEnabled: false });
     } else {
       const prev = prevState.current;
       updateSensor("cpuUsage", { isEnabled: prev ? prev.cpuUsage : true });
       updateSensor("cpuTemp", { isEnabled: prev ? prev.cpuTemp : true });
+      updateSensor("cpuConsumption", { isEnabled: prev ? prev.cpuConsumption : true });
     }
   };
 
@@ -116,6 +128,45 @@ export function CpuSection({ sensors, hardwares }: Props) {
             <TempRangeControl
               boundaries={cpuTemp.boundaries}
               onChange={(b) => updateBoundary("cpuTemp", b)}
+              unit="°"
+              max={120}
+            />
+          </div>
+        </SubCollapsible>
+
+        <SubCollapsible
+          label="CPU Power"
+          checked={cpuConsumption.isEnabled}
+          onCheckedChange={(v) => updateSensor("cpuConsumption", { isEnabled: v })}
+        >
+          <div className="flex flex-col gap-4">
+            {cpuPowerSensors.length > 0 && (
+              <Select
+                value={cpuConsumption.customReadingId}
+                onValueChange={(v) =>
+                  updateSensor("cpuConsumption", { customReadingId: v })
+                }
+              >
+                <SelectTrigger className="h-10 rounded-[8px] bg-card text-[14px]">
+                  <span className="flex items-center gap-2">
+                    <span className="text-[14px] font-normal text-muted-foreground">Sensor:</span>
+                    <SelectValue placeholder="Select" />
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  {cpuPowerSensors.map((s) => (
+                    <SelectItem key={s.identifier} value={s.identifier}>
+                      {s.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <TempRangeControl
+              boundaries={cpuConsumption.boundaries}
+              onChange={(b) => updateBoundary("cpuConsumption", b)}
+              unit="W"
+              max={300}
             />
           </div>
         </SubCollapsible>

--- a/tauri-app/src/components/settings/stats/CpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/CpuSection.tsx
@@ -1,15 +1,9 @@
 import { useRef } from "react";
-import type { Sensor, Hardware } from "@/lib/types";
-import { SensorType, HardwareType } from "@/lib/types";
+import type { Hardware, Sensor } from "@/lib/types";
+import { HardwareType, SensorType } from "@/lib/types";
 import { useSettingsStore } from "@/stores/settings-store";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/shadcn/select";
 import { SectionCard, SubCollapsible } from "./SectionCard";
+import { SensorSelect } from "./SensorSelect";
 import { TempRangeControl } from "./TempRangeControl";
 
 interface Props {
@@ -73,24 +67,11 @@ export function CpuSection({ sensors, hardwares }: Props) {
         >
           <div className="flex flex-col gap-4">
             {cpuLoadSensors.length > 0 && (
-              <Select
+              <SensorSelect
                 value={cpuUsage.customReadingId}
-                onValueChange={(v) => updateSensor("cpuUsage", { customReadingId: v })}
-              >
-                <SelectTrigger className="h-10 rounded-[8px] bg-card text-[14px]">
-                  <span className="flex items-center gap-2">
-                    <span className="text-[14px] font-normal text-muted-foreground">Sensor:</span>
-                    <SelectValue placeholder="Select" />
-                  </span>
-                </SelectTrigger>
-                <SelectContent>
-                  {cpuLoadSensors.map((s) => (
-                    <SelectItem key={s.identifier} value={s.identifier}>
-                      {s.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                options={cpuLoadSensors}
+                onChange={(v) => updateSensor("cpuUsage", { customReadingId: v })}
+              />
             )}
             <TempRangeControl
               boundaries={cpuUsage.boundaries}
@@ -106,24 +87,11 @@ export function CpuSection({ sensors, hardwares }: Props) {
         >
           <div className="flex flex-col gap-4">
             {cpuTempSensors.length > 0 && (
-              <Select
+              <SensorSelect
                 value={cpuTemp.customReadingId}
-                onValueChange={(v) => updateSensor("cpuTemp", { customReadingId: v })}
-              >
-                <SelectTrigger className="h-10 rounded-[8px] bg-card text-[14px]">
-                  <span className="flex items-center gap-2">
-                    <span className="text-[14px] font-normal text-muted-foreground">Sensor:</span>
-                    <SelectValue placeholder="Select" />
-                  </span>
-                </SelectTrigger>
-                <SelectContent>
-                  {cpuTempSensors.map((s) => (
-                    <SelectItem key={s.identifier} value={s.identifier}>
-                      {s.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                options={cpuTempSensors}
+                onChange={(v) => updateSensor("cpuTemp", { customReadingId: v })}
+              />
             )}
             <TempRangeControl
               boundaries={cpuTemp.boundaries}
@@ -141,26 +109,13 @@ export function CpuSection({ sensors, hardwares }: Props) {
         >
           <div className="flex flex-col gap-4">
             {cpuPowerSensors.length > 0 && (
-              <Select
+              <SensorSelect
                 value={cpuConsumption.customReadingId}
-                onValueChange={(v) =>
+                options={cpuPowerSensors}
+                onChange={(v) =>
                   updateSensor("cpuConsumption", { customReadingId: v })
                 }
-              >
-                <SelectTrigger className="h-10 rounded-[8px] bg-card text-[14px]">
-                  <span className="flex items-center gap-2">
-                    <span className="text-[14px] font-normal text-muted-foreground">Sensor:</span>
-                    <SelectValue placeholder="Select" />
-                  </span>
-                </SelectTrigger>
-                <SelectContent>
-                  {cpuPowerSensors.map((s) => (
-                    <SelectItem key={s.identifier} value={s.identifier}>
-                      {s.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              />
             )}
             <TempRangeControl
               boundaries={cpuConsumption.boundaries}

--- a/tauri-app/src/components/settings/stats/GpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/GpuSection.tsx
@@ -27,7 +27,7 @@ export function GpuSection({ sensors, hardwares }: Props) {
   const settings = useSettingsStore((s) => s.settings);
   const updateSensor = useSettingsStore((s) => s.updateSensor);
   const updateBoundary = useSettingsStore((s) => s.updateBoundary);
-  const { gpuUsage, gpuTemp, vramUsage } = settings.sensors;
+  const { gpuUsage, gpuTemp, gpuConsumption, vramUsage } = settings.sensors;
 
   const gpuHwIds = new Set(
     hardwares.filter((h) => GPU_HW_TYPES.includes(h.hardwareType)).map((h) => h.identifier),
@@ -38,6 +38,9 @@ export function GpuSection({ sensors, hardwares }: Props) {
   const gpuTempSensors = sensors.filter(
     (s) => gpuHwIds.has(s.hardwareIdentifier) && s.sensorType === SensorType.Temperature,
   );
+  const gpuPowerSensors = sensors.filter(
+    (s) => gpuHwIds.has(s.hardwareIdentifier) && s.sensorType === SensorType.Power,
+  );
   // VRAM usage is a load-type sensor whose name indicates memory.
   const vramSensors = sensors.filter(
     (s) =>
@@ -46,11 +49,16 @@ export function GpuSection({ sensors, hardwares }: Props) {
       s.name.toLowerCase().includes("memory"),
   );
 
-  const anyEnabled = gpuUsage.isEnabled || gpuTemp.isEnabled || vramUsage.isEnabled;
+  const anyEnabled =
+    gpuUsage.isEnabled ||
+    gpuTemp.isEnabled ||
+    gpuConsumption.isEnabled ||
+    vramUsage.isEnabled;
 
   const prevState = useRef<{
     gpuUsage: boolean;
     gpuTemp: boolean;
+    gpuConsumption: boolean;
     vramUsage: boolean;
   } | null>(null);
 
@@ -59,18 +67,20 @@ export function GpuSection({ sensors, hardwares }: Props) {
       prevState.current = {
         gpuUsage: gpuUsage.isEnabled,
         gpuTemp: gpuTemp.isEnabled,
+        gpuConsumption: gpuConsumption.isEnabled,
         vramUsage: vramUsage.isEnabled,
       };
       updateSensor("gpuUsage", { isEnabled: false });
       updateSensor("gpuTemp", { isEnabled: false });
-      updateSensor("vramUsage", { isEnabled: false });
-      // Clear removed-from-UI sensors so upgraders don't see ghost metrics.
-      updateSensor("totalVramUsed", { isEnabled: false });
       updateSensor("gpuConsumption", { isEnabled: false });
+      updateSensor("vramUsage", { isEnabled: false });
+      // Clear removed-from-UI sensor so upgraders don't see ghost metrics.
+      updateSensor("totalVramUsed", { isEnabled: false });
     } else {
       const prev = prevState.current;
       updateSensor("gpuUsage", { isEnabled: prev ? prev.gpuUsage : true });
       updateSensor("gpuTemp", { isEnabled: prev ? prev.gpuTemp : true });
+      updateSensor("gpuConsumption", { isEnabled: prev ? prev.gpuConsumption : true });
       updateSensor("vramUsage", { isEnabled: prev ? prev.vramUsage : true });
     }
   };
@@ -115,6 +125,30 @@ export function GpuSection({ sensors, hardwares }: Props) {
             <TempRangeControl
               boundaries={gpuTemp.boundaries}
               onChange={(b) => updateBoundary("gpuTemp", b)}
+              unit="°"
+              max={120}
+            />
+          </div>
+        </SubCollapsible>
+
+        <SubCollapsible
+          label="GPU Power"
+          checked={gpuConsumption.isEnabled}
+          onCheckedChange={(v) => updateSensor("gpuConsumption", { isEnabled: v })}
+        >
+          <div className="flex flex-col gap-4">
+            {gpuPowerSensors.length > 0 && (
+              <SensorSelect
+                value={gpuConsumption.customReadingId}
+                options={gpuPowerSensors}
+                onChange={(v) => updateSensor("gpuConsumption", { customReadingId: v })}
+              />
+            )}
+            <TempRangeControl
+              boundaries={gpuConsumption.boundaries}
+              onChange={(b) => updateBoundary("gpuConsumption", b)}
+              unit="W"
+              max={600}
             />
           </div>
         </SubCollapsible>

--- a/tauri-app/src/components/settings/stats/GpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/GpuSection.tsx
@@ -1,15 +1,9 @@
 import { useRef } from "react";
-import type { Sensor, Hardware } from "@/lib/types";
+import type { Hardware, Sensor } from "@/lib/types";
 import { HardwareType, SensorType } from "@/lib/types";
 import { useSettingsStore } from "@/stores/settings-store";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/shadcn/select";
 import { SectionCard, SubCollapsible } from "./SectionCard";
+import { SensorSelect } from "./SensorSelect";
 import { TempRangeControl } from "./TempRangeControl";
 
 interface Props {
@@ -177,30 +171,3 @@ export function GpuSection({ sensors, hardwares }: Props) {
   );
 }
 
-function SensorSelect({
-  value,
-  options,
-  onChange,
-}: {
-  value: string;
-  options: Sensor[];
-  onChange: (v: string) => void;
-}) {
-  return (
-    <Select value={value} onValueChange={onChange}>
-      <SelectTrigger className="h-10 rounded-[8px] bg-card text-[14px]">
-        <span className="flex items-center gap-2">
-          <span className="text-[14px] font-normal text-muted-foreground">Sensor:</span>
-          <SelectValue placeholder="Select" />
-        </span>
-      </SelectTrigger>
-      <SelectContent>
-        {options.map((s) => (
-          <SelectItem key={s.identifier} value={s.identifier}>
-            {s.name}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}

--- a/tauri-app/src/components/settings/stats/SensorSelect.tsx
+++ b/tauri-app/src/components/settings/stats/SensorSelect.tsx
@@ -1,0 +1,39 @@
+import type { Sensor } from "@/lib/types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/shadcn/select";
+
+interface Props {
+  value: string;
+  options: Sensor[];
+  onChange: (v: string) => void;
+}
+
+/**
+ * Sensor picker used by every SubCollapsible across the stats settings.
+ * Trigger reads "Sensor: <name>" and the dropdown lists the hardware-filtered
+ * sensors passed in `options`.
+ */
+export function SensorSelect({ value, options, onChange }: Props) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="h-10 rounded-[8px] bg-card text-[14px]">
+        <span className="flex items-center gap-2">
+          <span className="text-[14px] font-normal text-muted-foreground">Sensor:</span>
+          <SelectValue placeholder="Select" />
+        </span>
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((s) => (
+          <SelectItem key={s.identifier} value={s.identifier}>
+            {s.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/tauri-app/src/components/settings/stats/StatsTab.tsx
+++ b/tauri-app/src/components/settings/stats/StatsTab.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useSettingsStore } from "@/stores/settings-store";
 import { HotkeyBar } from "./HotkeyBar";
 import { FpsSection } from "./FpsSection";
@@ -6,11 +7,23 @@ import { CpuSection } from "./CpuSection";
 import { RamSection } from "./RamSection";
 import { NetworkSection } from "./NetworkSection";
 import { MonitorSection } from "./MonitorSection";
+import { UpdateBanner, type UpdateStatus } from "./UpdateBanner";
 
 export function StatsTab() {
   const sensorData = useSettingsStore((s) => s.sensorData);
   const sensors = sensorData?.sensors ?? [];
   const hardwares = sensorData?.hardwares ?? [];
+
+  // TODO: replace with updater API. Mocked locally so the banner UI can be
+  // exercised end-to-end (idle → downloading → complete).
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>("idle");
+  const updateVersion = "2.0.0";
+
+  useEffect(() => {
+    if (updateStatus !== "downloading") return;
+    const t = setTimeout(() => setUpdateStatus("complete"), 3000);
+    return () => clearTimeout(t);
+  }, [updateStatus]);
 
   return (
     <div className="flex h-full w-full flex-col gap-4">
@@ -21,6 +34,20 @@ export function StatsTab() {
       <RamSection />
       <NetworkSection sensors={sensors} hardwares={hardwares} />
       <MonitorSection />
+      {updateStatus && (
+        <UpdateBanner
+          className="sticky bottom-4 z-10 mt-auto"
+          status={updateStatus}
+          version={updateVersion}
+          onLater={() => setUpdateStatus(null)}
+          onUpdate={() => setUpdateStatus("downloading")}
+          onCancel={() => setUpdateStatus("idle")}
+          onInstall={() => {
+            // TODO: replace with updater API — trigger Tauri updater install + relaunch.
+            setUpdateStatus(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/tauri-app/src/components/settings/stats/StatsTab.tsx
+++ b/tauri-app/src/components/settings/stats/StatsTab.tsx
@@ -17,6 +17,7 @@ export function StatsTab() {
   // TODO: replace with updater API. Mocked locally so the banner UI can be
   // exercised end-to-end (idle → downloading → complete).
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>("idle");
+  // TODO: replace with updater API data
   const updateVersion = "2.0.0";
 
   useEffect(() => {

--- a/tauri-app/src/components/settings/stats/TempRangeControl.tsx
+++ b/tauri-app/src/components/settings/stats/TempRangeControl.tsx
@@ -1,28 +1,32 @@
 import { Info } from "lucide-react";
 import type { Boundaries } from "@/lib/types";
 
-const CLAMP = (v: number, min = 0, max = 100) =>
+const CLAMP = (v: number, min: number, max: number) =>
   Math.max(min, Math.min(max, v));
 
 /**
- * 3-segment temp range control from Figma GPU Usage / CPU Usage card.
- * Boundaries.low = upper bound of Low segment (= min of Medium).
- * Boundaries.medium = upper bound of Medium segment (= min of High).
- * Boundaries.high = upper bound of High (max). Typically 100.
+ * 3-segment range control from Figma. Defaults to a 0-100% scale (GPU/CPU
+ * usage); pass `unit` + `max` to reuse for °C temperatures, watts, etc.
+ * Boundaries.low / .medium are the upper bounds of the Low / Medium segments.
+ * Boundaries.high is the absolute max.
  */
 export function TempRangeControl({
   boundaries,
   onChange,
+  unit = "%",
+  max = 100,
 }: {
   boundaries: Boundaries;
   onChange: (b: Boundaries) => void;
+  unit?: string;
+  max?: number;
 }) {
   const lowMin = 0;
   const lowMax = boundaries.low;
   const medMin = boundaries.low;
   const medMax = boundaries.medium;
   const highMin = boundaries.medium;
-  const highMax = boundaries.high || 100;
+  const highMax = boundaries.high || max;
 
   const setLowMax = (v: number) => {
     const lv = CLAMP(v, 0, boundaries.medium - 1);
@@ -33,16 +37,16 @@ export function TempRangeControl({
     onChange({ ...boundaries, medium: mv });
   };
   const setHighMax = (v: number) => {
-    const hv = CLAMP(v, boundaries.medium + 1, 100);
+    const hv = CLAMP(v, boundaries.medium + 1, max);
     onChange({ ...boundaries, high: hv });
   };
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex gap-4">
-        <RangeSegment color="#17B26A" label="Low" min={lowMin} max={lowMax} readOnlyMin onMaxChange={setLowMax} />
-        <RangeSegment color="#FEC84B" label="Medium" min={medMin} max={medMax} readOnlyMin onMaxChange={setMedMax} />
-        <RangeSegment color="#F04438" label="High" min={highMin} max={highMax} readOnlyMin onMaxChange={setHighMax} />
+        <RangeSegment color="#17B26A" label="Low" min={lowMin} max={lowMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setLowMax} />
+        <RangeSegment color="#FEC84B" label="Medium" min={medMin} max={medMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setMedMax} />
+        <RangeSegment color="#F04438" label="High" min={highMin} max={highMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setHighMax} />
       </div>
       <div className="flex items-center gap-1">
         <Info className="size-4 text-muted-foreground" strokeWidth={2} />
@@ -59,6 +63,8 @@ function RangeSegment({
   label,
   min,
   max,
+  unit,
+  inputMax,
   readOnlyMin,
   onMaxChange,
 }: {
@@ -66,6 +72,8 @@ function RangeSegment({
   label: string;
   min: number;
   max: number;
+  unit: string;
+  inputMax: number;
   readOnlyMin?: boolean;
   onMaxChange: (v: number) => void;
 }) {
@@ -76,9 +84,11 @@ function RangeSegment({
         <span className="text-[14px] font-medium text-foreground">{label}</span>
       </div>
       <div className="flex">
-        <PctInput value={min} readOnly={readOnlyMin} muted className="rounded-l-[8px]" />
-        <PctInput
+        <ValueInput value={min} unit={unit} inputMax={inputMax} readOnly={readOnlyMin} muted className="rounded-l-[8px]" />
+        <ValueInput
           value={max}
+          unit={unit}
+          inputMax={inputMax}
           onChange={onMaxChange}
           className="-ml-px rounded-r-[8px]"
         />
@@ -87,14 +97,18 @@ function RangeSegment({
   );
 }
 
-function PctInput({
+function ValueInput({
   value,
+  unit,
+  inputMax,
   onChange,
   readOnly,
   muted,
   className,
 }: {
   value: number;
+  unit: string;
+  inputMax: number;
   onChange?: (v: number) => void;
   readOnly?: boolean;
   muted?: boolean;
@@ -107,13 +121,13 @@ function PctInput({
       <input
         type="number"
         min={0}
-        max={100}
+        max={inputMax}
         value={Number.isFinite(value) ? value : 0}
         readOnly={readOnly}
         onChange={(e) => onChange?.(parseInt(e.target.value || "0", 10))}
         className="w-full bg-transparent text-[14px] font-medium text-foreground outline-none read-only:text-muted-foreground"
       />
-      <span className="text-[14px] font-medium text-muted-foreground">%</span>
+      <span className="text-[14px] font-medium text-muted-foreground">{unit}</span>
     </div>
   );
 }

--- a/tauri-app/src/components/settings/stats/UpdateBanner.tsx
+++ b/tauri-app/src/components/settings/stats/UpdateBanner.tsx
@@ -1,3 +1,12 @@
+import { Button } from "@/app/components/Button";
+import {
+  ToastBanner,
+  ToastBannerActions,
+  ToastBannerContent,
+  ToastBannerDescription,
+  ToastBannerIcon,
+  ToastBannerTitle,
+} from "@/app/components/ToastBanner";
 import { cn } from "@/lib/utils";
 
 export type UpdateStatus = "idle" | "downloading" | "complete";
@@ -13,14 +22,10 @@ interface Props {
 }
 
 /**
- * Bottom-pinned floating banner shown when a new version is available.
- * Three states (idle / downloading / complete) share the outer pill shell;
- * the icon, title, and right-side actions swap per state.
+ * Bottom-pinned banner shown when a new version is available.
+ * Three states (idle / downloading / complete) share the outer ToastBanner
+ * shell; the icon, title, and right-side actions swap per state.
  * Matches Figma frames 2338:3496 / 2338:3809 / 2338:4118.
- *
- * Uses raw color values because the DS token CSS (src/app/globals.css with its
- * --bgBrand / --cornerRound / typography classes) is not imported into the main
- * Vite entry, so DS classes silently no-op in this part of the tree.
  */
 export function UpdateBanner({
   status,
@@ -32,23 +37,21 @@ export function UpdateBanner({
   className,
 }: Props) {
   return (
-    <div
-      role="status"
-      className={cn(
-        "mx-auto flex h-[68px] w-full max-w-[499px] items-center gap-3 rounded-full bg-[#0C111D] px-4 py-[14px] shadow-[0_4px_24px_rgba(0,0,0,0.24)]",
-        className,
-      )}
+    <ToastBanner
+      className={cn("mx-auto h-[68px] w-full max-w-[499px]", className)}
     >
-      <StatusIcon status={status} />
-      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-        <p className="truncate text-[14px] font-medium leading-[17px] text-white">
-          {titleFor(status)}
-        </p>
-        <p className="truncate text-[12px] font-medium leading-[15px] text-[#94969C]">
-          v{version}
-        </p>
-      </div>
-      <div className="flex shrink-0 items-center">
+      {status === "downloading" ? (
+        <ProgressSpinner />
+      ) : (
+        <ToastBannerIcon>
+          {status === "idle" ? <CloudDownloadIcon /> : <DownloadDoneIcon />}
+        </ToastBannerIcon>
+      )}
+      <ToastBannerContent>
+        <ToastBannerTitle>{titleFor(status)}</ToastBannerTitle>
+        <ToastBannerDescription>v{version}</ToastBannerDescription>
+      </ToastBannerContent>
+      <ToastBannerActions className="gap-0">
         {status === "downloading" ? (
           <GhostButton onClick={onCancel} tight>
             Cancel
@@ -56,15 +59,17 @@ export function UpdateBanner({
         ) : (
           <>
             <GhostButton onClick={onLater}>Later</GhostButton>
-            <PrimaryButton
+            <Button
+              variant="filled-white"
+              size="sm"
               onClick={status === "idle" ? onUpdate : onInstall}
             >
               {status === "idle" ? "Update now" : "Install now"}
-            </PrimaryButton>
+            </Button>
           </>
         )}
-      </div>
-    </div>
+      </ToastBannerActions>
+    </ToastBanner>
   );
 }
 
@@ -77,15 +82,6 @@ function titleFor(status: UpdateStatus) {
     case "complete":
       return "Update ready to install";
   }
-}
-
-function StatusIcon({ status }: { status: UpdateStatus }) {
-  if (status === "downloading") return <ProgressSpinner />;
-  return (
-    <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[#161B26] text-white">
-      {status === "idle" ? <CloudDownloadIcon /> : <DownloadDoneIcon />}
-    </div>
-  );
 }
 
 function GhostButton({
@@ -102,27 +98,9 @@ function GhostButton({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex h-10 cursor-pointer items-center justify-center whitespace-nowrap rounded-full text-[14px] font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40",
-        tight ? "px-3" : "px-5",
+        "flex h-10 cursor-pointer items-center justify-center whitespace-nowrap rounded-[var(--cornerRound)] text-body-sm-medium text-[var(--textInverse)] transition-colors duration-150 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40",
+        tight ? "px-[var(--spacingS)]" : "px-[var(--spacingL)]",
       )}
-    >
-      {children}
-    </button>
-  );
-}
-
-function PrimaryButton({
-  children,
-  onClick,
-}: {
-  children: React.ReactNode;
-  onClick?: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex h-10 cursor-pointer items-center justify-center whitespace-nowrap rounded-full bg-white px-5 text-[14px] font-medium text-[#0C111D] transition-colors hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
     >
       {children}
     </button>
@@ -145,16 +123,17 @@ function ProgressSpinner() {
           cx="20"
           cy="20"
           r={radius}
-          stroke="#FFFFFF"
+          stroke="currentColor"
           strokeOpacity="0.1"
           strokeWidth="3"
           fill="none"
+          className="text-[var(--textInverse)]"
         />
         <circle
           cx="20"
           cy="20"
           r={radius}
-          stroke="#17B26A"
+          stroke="var(--iconSuccess)"
           strokeWidth="3"
           fill="none"
           strokeDasharray={`${arc} ${circumference - arc}`}

--- a/tauri-app/src/components/settings/stats/UpdateBanner.tsx
+++ b/tauri-app/src/components/settings/stats/UpdateBanner.tsx
@@ -1,0 +1,203 @@
+import { cn } from "@/lib/utils";
+
+export type UpdateStatus = "idle" | "downloading" | "complete";
+
+interface Props {
+  status: UpdateStatus;
+  version: string;
+  onLater?: () => void;
+  onUpdate?: () => void;
+  onCancel?: () => void;
+  onInstall?: () => void;
+  className?: string;
+}
+
+/**
+ * Bottom-pinned floating banner shown when a new version is available.
+ * Three states (idle / downloading / complete) share the outer pill shell;
+ * the icon, title, and right-side actions swap per state.
+ * Matches Figma frames 2338:3496 / 2338:3809 / 2338:4118.
+ *
+ * Uses raw color values because the DS token CSS (src/app/globals.css with its
+ * --bgBrand / --cornerRound / typography classes) is not imported into the main
+ * Vite entry, so DS classes silently no-op in this part of the tree.
+ */
+export function UpdateBanner({
+  status,
+  version,
+  onLater,
+  onUpdate,
+  onCancel,
+  onInstall,
+  className,
+}: Props) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        "mx-auto flex h-[68px] w-full max-w-[499px] items-center gap-3 rounded-full bg-[#0C111D] px-4 py-[14px] shadow-[0_4px_24px_rgba(0,0,0,0.24)]",
+        className,
+      )}
+    >
+      <StatusIcon status={status} />
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <p className="truncate text-[14px] font-medium leading-[17px] text-white">
+          {titleFor(status)}
+        </p>
+        <p className="truncate text-[12px] font-medium leading-[15px] text-[#94969C]">
+          v{version}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center">
+        {status === "downloading" ? (
+          <GhostButton onClick={onCancel} tight>
+            Cancel
+          </GhostButton>
+        ) : (
+          <>
+            <GhostButton onClick={onLater}>Later</GhostButton>
+            <PrimaryButton
+              onClick={status === "idle" ? onUpdate : onInstall}
+            >
+              {status === "idle" ? "Update now" : "Install now"}
+            </PrimaryButton>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function titleFor(status: UpdateStatus) {
+  switch (status) {
+    case "idle":
+      return "New update available";
+    case "downloading":
+      return "Downloading update...";
+    case "complete":
+      return "Update ready to install";
+  }
+}
+
+function StatusIcon({ status }: { status: UpdateStatus }) {
+  if (status === "downloading") return <ProgressSpinner />;
+  return (
+    <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[#161B26] text-white">
+      {status === "idle" ? <CloudDownloadIcon /> : <DownloadDoneIcon />}
+    </div>
+  );
+}
+
+function GhostButton({
+  children,
+  onClick,
+  tight,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  tight?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex h-10 cursor-pointer items-center justify-center whitespace-nowrap rounded-full text-[14px] font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40",
+        tight ? "px-3" : "px-5",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function PrimaryButton({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex h-10 cursor-pointer items-center justify-center whitespace-nowrap rounded-full bg-white px-5 text-[14px] font-medium text-[#0C111D] transition-colors hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+    >
+      {children}
+    </button>
+  );
+}
+
+function ProgressSpinner() {
+  const radius = 17;
+  const circumference = 2 * Math.PI * radius;
+  const arc = circumference * 0.25;
+  return (
+    <div className="flex size-10 shrink-0 items-center justify-center">
+      <svg
+        className="size-10 animate-spin"
+        viewBox="0 0 40 40"
+        role="status"
+        aria-label="Downloading"
+      >
+        <circle
+          cx="20"
+          cy="20"
+          r={radius}
+          stroke="#FFFFFF"
+          strokeOpacity="0.1"
+          strokeWidth="3"
+          fill="none"
+        />
+        <circle
+          cx="20"
+          cy="20"
+          r={radius}
+          stroke="#17B26A"
+          strokeWidth="3"
+          fill="none"
+          strokeDasharray={`${arc} ${circumference - arc}`}
+          strokeLinecap="round"
+          transform="rotate(-90 20 20)"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function CloudDownloadIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 37 27"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M16.8176 13.5382V3.36352C14.6874 3.75593 13.0336 4.786 11.8564 6.45375C10.6792 8.12149 10.0906 9.83829 10.0906 11.6041H9.24967C7.62397 11.6041 6.23652 12.1787 5.08732 13.3279C3.93812 14.4771 3.36352 15.8646 3.36352 17.4903C3.36352 19.116 3.93812 20.5034 5.08732 21.6526C6.23652 22.8018 7.62397 23.3764 9.24967 23.3764H29.4308C30.608 23.3764 31.603 22.97 32.4159 22.1572C33.2287 21.3443 33.6352 20.3493 33.6352 19.172C33.6352 17.9948 33.2287 16.9998 32.4159 16.1869C31.603 15.3741 30.608 14.9677 29.4308 14.9677H26.9081V11.6041C26.9081 10.2587 26.5998 9.00441 25.9832 7.8412C25.3665 6.67798 24.5537 5.68995 23.5446 4.8771V0.967011C25.6188 1.94804 27.2585 3.39855 28.4638 5.31856C29.669 7.23857 30.2717 9.33376 30.2717 11.6041C32.2057 11.8284 33.8104 12.6622 35.0857 14.1057C36.361 15.5493 36.9987 17.238 36.9987 19.172C36.9987 21.2742 36.2629 23.0611 34.7914 24.5327C33.3198 26.0042 31.533 26.74 29.4308 26.74H9.24967C6.699 26.74 4.51973 25.857 2.71184 24.0912C0.903945 22.3253 0 20.1671 0 17.6164C0 15.4301 0.658689 13.4821 1.97607 11.7723C3.29344 10.0625 5.01725 8.96938 7.14747 8.49288C7.62397 6.47477 8.81522 4.55476 10.7212 2.73286C12.6272 0.910952 14.6593 0 16.8176 0C17.7426 0 18.5344 0.329344 19.1931 0.988033C19.8518 1.64672 20.1811 2.43855 20.1811 3.36352V13.5382L21.6947 12.0666C22.003 11.7583 22.3884 11.6041 22.8509 11.6041C23.3134 11.6041 23.7128 11.7723 24.0491 12.1087C24.3575 12.417 24.5116 12.8094 24.5116 13.2859C24.5116 13.7624 24.3575 14.1548 24.0491 14.4631L19.6766 18.8357C19.3402 19.172 18.9478 19.3402 18.4993 19.3402C18.0509 19.3402 17.6585 19.172 17.3221 18.8357L12.9495 14.4631C12.6412 14.1548 12.48 13.7694 12.466 13.3069C12.452 12.8444 12.6132 12.445 12.9495 12.1087C13.2579 11.8003 13.6433 11.6392 14.1057 11.6252C14.5682 11.6111 14.9677 11.7583 15.304 12.0666L16.8176 13.5382Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function DownloadDoneIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 26 26"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M8.77167 14.5833L22.855 0.5C23.1883 0.166667 23.5842 0 24.0425 0C24.5008 0 24.8967 0.166667 25.23 0.5C25.5633 0.833333 25.73 1.22917 25.73 1.6875C25.73 2.14583 25.5633 2.54167 25.23 2.875L9.93833 18.1667C9.605 18.5 9.21611 18.6667 8.77167 18.6667C8.32722 18.6667 7.93833 18.5 7.605 18.1667L0.48 11.0417C0.146667 10.7083 -0.0130556 10.3125 0.000833333 9.85417C0.0147222 9.39583 0.188333 9 0.521667 8.66667C0.855 8.33333 1.25083 8.16667 1.70917 8.16667C2.1675 8.16667 2.56333 8.33333 2.89667 8.66667L8.77167 14.5833ZM2.855 26C2.38278 26 1.98694 25.8403 1.6675 25.5208C1.34806 25.2014 1.18833 24.8056 1.18833 24.3333C1.18833 23.8611 1.34806 23.4653 1.6675 23.1458C1.98694 22.8264 2.38278 22.6667 2.855 22.6667H22.855C23.3272 22.6667 23.7231 22.8264 24.0425 23.1458C24.3619 23.4653 24.5217 23.8611 24.5217 24.3333C24.5217 24.8056 24.3619 25.2014 24.0425 25.5208C23.7231 25.8403 23.3272 26 22.855 26H2.855Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/tauri-app/src/index.css
+++ b/tauri-app/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "./app/globals.css";
 
 @custom-variant dark (&:is([data-theme="dark"] *));
 

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -67,11 +67,11 @@ export interface SensorsConfig {
   frametime: SensorConfig;
   cpuTemp: GraphSensorConfig;
   cpuUsage: GraphSensorConfig;
-  cpuConsumption: SensorConfig;
+  cpuConsumption: GraphSensorConfig;
   gpuTemp: GraphSensorConfig;
   gpuUsage: GraphSensorConfig;
   vramUsage: GraphSensorConfig;
-  gpuConsumption: SensorConfig;
+  gpuConsumption: GraphSensorConfig;
   totalVramUsed: SensorConfig;
   ramUsage: GraphSensorConfig;
   upRate: SensorConfig;
@@ -183,11 +183,11 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
     frametime: { isEnabled: true, customReadingId: "" },
     cpuTemp: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     cpuUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    cpuConsumption: { isEnabled: true, customReadingId: "" },
+    cpuConsumption: { isEnabled: true, customReadingId: "", boundaries: { low: 65, medium: 95, high: 125 } },
     gpuTemp: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     gpuUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     vramUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    gpuConsumption: { isEnabled: true, customReadingId: "" },
+    gpuConsumption: { isEnabled: true, customReadingId: "", boundaries: { low: 150, medium: 250, high: 350 } },
     totalVramUsed: { isEnabled: true, customReadingId: "" },
     ramUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     upRate: { isEnabled: true, customReadingId: "" },

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -201,11 +201,21 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   loadSettings: async () => {
     try {
       const saved = await tauri.getSettings();
+      // Per-sensor merge so newly-added fields (e.g. boundaries on power
+      // configs) hydrate onto older saves that pre-date them.
+      const mergedSensors = { ...DEFAULT_SETTINGS.sensors };
+      const savedSensors = (saved?.sensors ?? {}) as Partial<OverlaySettings["sensors"]>;
+      for (const key of Object.keys(DEFAULT_SETTINGS.sensors) as (keyof OverlaySettings["sensors"])[]) {
+        mergedSensors[key] = {
+          ...DEFAULT_SETTINGS.sensors[key],
+          ...(savedSensors[key] ?? {}),
+        } as OverlaySettings["sensors"][typeof key];
+      }
       const settings: OverlaySettings = saved
         ? {
             ...DEFAULT_SETTINGS,
             ...saved,
-            sensors: { ...DEFAULT_SETTINGS.sensors, ...(saved.sensors ?? {}) },
+            sensors: mergedSensors,
           }
         : { ...DEFAULT_SETTINGS };
       // No UI exposes isPositionLocked, so a stale `true` from an older


### PR DESCRIPTION
## Summary

Brings the Stats settings tab in line with the Figma design (`2338:1539`) and adds the new update banner.

- **Power sensors in Stats settings.** New "GPU Power" and "CPU Power" `SubCollapsible` rows with sensor selects and Low/Medium/High range controls in watts. The store already had `cpuConsumption` / `gpuConsumption` wired into the overlay — only the settings UI was missing.
- **Temperature ranges show °, power ranges show W.** `TempRangeControl` is now parameterized with `unit` + `max` props (defaults preserve `%`/`100` for existing callers). GPU/CPU temperature uses `unit="°"` / `max=120`, GPU Power uses `unit="W"` / `max=600`, CPU Power uses `unit="W"` / `max=300`.
- **Type upgrade.** `cpuConsumption` / `gpuConsumption` go from `SensorConfig` → `GraphSensorConfig`, picking up the `boundaries` field. Defaults: CPU `65/95/125W`, GPU `150/250/350W`. `loadSettings` now does a per-sensor merge so older saves missing the new field hydrate cleanly.
- **Overlay renders power with the Progress ring** when `showProgress` is on, driven by the same boundaries the user configures in settings. Without this, the watts thresholds in the UI had no visual effect.
- **CPU section ordering** is now `Usage → Temperature → Power`.
- **Update banner.** New `UpdateBanner` component covering the three Figma states (`2338:3496` idle / `2338:3809` downloading / `2338:4118` complete). Sticky-pinned at the bottom of the Stats scroll viewport. Mock state machine for now (idle → 3 s mock timer → complete); the install handler is stubbed with a TODO for the Tauri updater.
- **DS tokens wired into the main tree.** `src/index.css` now imports `app/globals.css`, so DS variables (`--bgBrand`, `--cornerRound`, `--shadow-large`, etc.) and typography classes (`.text-body-sm-medium`) are available everywhere. `UpdateBanner` uses the `ToastBanner` and `Button` DS primitives instead of raw hex, so it participates in dark-mode theming.
- **Shared `SensorSelect` helper** pulled out of `GpuSection` into its own file. Removes three near-duplicate `<Select>` blocks from `CpuSection`.

## Test plan

- [ ] Stats tab: GPU section shows `Usage / Temperature / Power / VRAM Usage` in that order, each with a sensor select and a range control whose unit matches the metric.
- [ ] Stats tab: CPU section shows `Usage / Temperature / Power` in that order.
- [ ] Toggling the section master switch off/on preserves the previous per-row checkbox state (including the new Power rows).
- [ ] Update banner: idle → click "Update now" → switches to downloading with green spinning ring → after ~3 s shows "Update ready to install" → "Install now" dismisses. "Cancel" while downloading returns to idle. "Later" dismisses.
- [ ] Banner is pinned at the bottom of the Stats scroll viewport, not flowing inline.
- [ ] Overlay (run with sensor data): with `progressType=circular`, CPU Power and GPU Power render as a ring whose color flips at the configured Low/Medium/High thresholds. With `progressType=none`, the plain numeric value still shows.
- [ ] Dark mode toggle: banner background and text invert correctly (was hardcoded hex before the DS refactor; now uses `--bgBrand` / `--textInverse`).
- [ ] Existing GPU Usage / CPU Usage / VRAM range controls still show `%` and clamp to `0–100`.
- [ ] Older saved settings (without `boundaries` on the power configs) load without runtime errors and pick up the default boundaries.

## Figma

- Stats settings section: `2338:1539`
- Update banner — idle: `2338:3496`
- Update banner — downloading: `2338:3809`
- Update banner — complete: `2338:4118`