### PR TITLE
Figma v1.1 polish across Stats / Style / Settings / Help

### DIFF
--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -12,6 +12,7 @@
         "@fluentui/react-icons": "^2.0.321",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
@@ -3409,6 +3410,60 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -21,6 +21,7 @@
     "@fluentui/react-icons": "^2.0.321",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",

--- a/tauri-app/src/components/settings/help/FaqSection.tsx
+++ b/tauri-app/src/components/settings/help/FaqSection.tsx
@@ -42,11 +42,15 @@ const FAQ_ITEMS: FaqItem[] = [
       </>
     ),
   },
+  {
+    question: "What are the current limitations?",
+    answer: "Does not support exclusive full screen.",
+  },
 ];
 
 export function FaqSection() {
   return (
-    <section className="flex w-full flex-col gap-5 rounded-[12px] bg-card px-5 pb-6 pt-5">
+    <section className="flex w-full flex-col gap-5 rounded-[12px] bg-[var(--bgSurfaceRaised)] px-5 pb-6 pt-5">
       <h2 className="text-[13px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
         Frequently asked questions
       </h2>

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@/components/shadcn/select";
 import { cn } from "@/lib/utils";
+import { getAutoStart, setAutoStart } from "@/lib/tauri";
 import { useSettingsStore } from "@/stores/settings-store";
 import type { TemperatureUnit } from "@/lib/types";
 import {
@@ -30,7 +31,7 @@ function SectionCard({
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex w-full flex-col gap-5 rounded-[12px] bg-card p-5">
+    <section className="flex w-full flex-col gap-5 rounded-[12px] bg-[var(--bgSurfaceRaised)] p-5">
       <h2 className="text-[13px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
         {title}
       </h2>
@@ -42,8 +43,20 @@ function SectionCard({
 function GeneralSection() {
   const startMinimized = useSettingsStore((s) => s.preferences.startMinimized);
   const updatePreferences = useSettingsStore((s) => s.updatePreferences);
-  // TODO: wire startWithWindows to preferences/autostart
   const [startWithWindows, setStartWithWindows] = React.useState(false);
+
+  React.useEffect(() => {
+    getAutoStart()
+      .then((v) => {
+        if (v !== undefined) setStartWithWindows(v);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleStartWithWindows = (enabled: boolean) => {
+    setStartWithWindows(enabled);
+    setAutoStart(enabled).catch(() => setStartWithWindows(!enabled));
+  };
 
   return (
     <SectionCard title="General">
@@ -51,7 +64,7 @@ function GeneralSection() {
         <label className="flex cursor-pointer items-center gap-2 text-[14px] font-medium text-foreground">
           <Checkbox
             checked={startWithWindows}
-            onCheckedChange={(v) => setStartWithWindows(v === true)}
+            onCheckedChange={(v) => handleStartWithWindows(v === true)}
           />
           Start with windows
         </label>
@@ -136,7 +149,7 @@ function PollingRateSection() {
             updateSettings({ pollingRate: parseInt(v, 10) })
           }
         >
-          <SelectTrigger className="w-full rounded-[8px] font-medium">
+          <SelectTrigger className="w-full rounded-[8px] border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] font-medium shadow-[0_1px_2px_rgba(16,24,40,0.05)]">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -169,30 +182,50 @@ const THEME_OPTIONS: {
 ];
 
 function AppearanceSection() {
-  const isDarkTheme = useSettingsStore((s) => s.settings.isDarkTheme);
+  const themeMode = useSettingsStore((s) => s.settings.themeMode);
   const updateSettings = useSettingsStore((s) => s.updateSettings);
-  // TODO: wire "System" to OS theme preference; store currently only has isDarkTheme
-  const [theme, setTheme] = React.useState<ThemeChoice>(
-    isDarkTheme ? "dark" : "light",
-  );
+
+  React.useEffect(() => {
+    if (themeMode !== "system") return;
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const apply = (matches: boolean) => {
+      if (useSettingsStore.getState().settings.isDarkTheme !== matches) {
+        updateSettings({ isDarkTheme: matches });
+      }
+    };
+    apply(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => apply(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, [themeMode, updateSettings]);
+
+  const handleThemeChange = (value: ThemeChoice) => {
+    if (value === "light") {
+      updateSettings({ themeMode: "light", isDarkTheme: false });
+    } else if (value === "dark") {
+      updateSettings({ themeMode: "dark", isDarkTheme: true });
+    } else {
+      const prefersDark =
+        typeof window !== "undefined" &&
+        !!window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches;
+      updateSettings({ themeMode: "system", isDarkTheme: prefersDark });
+    }
+  };
 
   return (
     <SectionCard title="Appearance">
       <div className="flex gap-3">
         {THEME_OPTIONS.map(({ value, label, Preview }) => {
-          const selected = theme === value;
+          const selected = themeMode === value;
           return (
             <button
               key={value}
               type="button"
-              onClick={() => {
-                setTheme(value);
-                if (value === "light" || value === "dark") {
-                  updateSettings({ isDarkTheme: value === "dark" });
-                }
-              }}
+              onClick={() => handleThemeChange(value)}
               className={cn(
-                "flex flex-1 flex-col overflow-hidden rounded-[8px] bg-card transition-shadow duration-150",
+                "flex flex-1 flex-col overflow-hidden rounded-[8px] bg-[var(--bgSurfaceRaised)] transition-shadow duration-150",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
               )}
               style={{
@@ -230,8 +263,8 @@ function FooterLinkButton({
       target="_blank"
       rel="noreferrer"
       className={cn(
-        "flex flex-1 items-center justify-between gap-3 rounded-[12px] border border-border/50 p-3",
-        "transition-colors hover:border-border",
+        "flex flex-1 items-center justify-between gap-3 rounded-[12px] border border-[var(--borderBolder)]/50 p-3",
+        "transition-colors hover:border-[var(--borderBolder)]",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
       )}
     >

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -44,6 +44,10 @@ function GeneralSection() {
   const startMinimized = useSettingsStore((s) => s.preferences.startMinimized);
   const updatePreferences = useSettingsStore((s) => s.updatePreferences);
   const [startWithWindows, setStartWithWindows] = React.useState(false);
+  // Rapid toggles fire concurrent setAutoStart calls that can resolve out
+  // of order, leaving the checkbox out of sync with the OS registry.
+  // Gate clicks while one is in flight.
+  const [autoStartPending, setAutoStartPending] = React.useState(false);
 
   React.useEffect(() => {
     getAutoStart()
@@ -54,8 +58,11 @@ function GeneralSection() {
   }, []);
 
   const handleStartWithWindows = (enabled: boolean) => {
+    setAutoStartPending(true);
     setStartWithWindows(enabled);
-    setAutoStart(enabled).catch(() => setStartWithWindows(!enabled));
+    setAutoStart(enabled)
+      .catch(() => setStartWithWindows(!enabled))
+      .finally(() => setAutoStartPending(false));
   };
 
   return (
@@ -64,6 +71,7 @@ function GeneralSection() {
         <label className="flex cursor-pointer items-center gap-2 text-[14px] font-medium text-foreground">
           <Checkbox
             checked={startWithWindows}
+            disabled={autoStartPending}
             onCheckedChange={(v) => handleStartWithWindows(v === true)}
           />
           Start with windows

--- a/tauri-app/src/components/settings/stats/CpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/CpuSection.tsx
@@ -68,6 +68,7 @@ export function CpuSection({ sensors, hardwares }: Props) {
           <div className="flex flex-col gap-4">
             {cpuLoadSensors.length > 0 && (
               <SensorSelect
+                label="CPU Usage"
                 value={cpuUsage.customReadingId}
                 options={cpuLoadSensors}
                 onChange={(v) => updateSensor("cpuUsage", { customReadingId: v })}
@@ -88,6 +89,7 @@ export function CpuSection({ sensors, hardwares }: Props) {
           <div className="flex flex-col gap-4">
             {cpuTempSensors.length > 0 && (
               <SensorSelect
+                label="CPU Temperature"
                 value={cpuTemp.customReadingId}
                 options={cpuTempSensors}
                 onChange={(v) => updateSensor("cpuTemp", { customReadingId: v })}
@@ -110,6 +112,7 @@ export function CpuSection({ sensors, hardwares }: Props) {
           <div className="flex flex-col gap-4">
             {cpuPowerSensors.length > 0 && (
               <SensorSelect
+                label="CPU Power"
                 value={cpuConsumption.customReadingId}
                 options={cpuPowerSensors}
                 onChange={(v) =>

--- a/tauri-app/src/components/settings/stats/GpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/GpuSection.tsx
@@ -91,6 +91,7 @@ export function GpuSection({ sensors, hardwares }: Props) {
           <div className="flex flex-col gap-4">
             {gpuLoadSensors.length > 0 && (
               <SensorSelect
+                label="GPU Usage"
                 value={gpuUsage.customReadingId}
                 options={gpuLoadSensors}
                 onChange={(v) => updateSensor("gpuUsage", { customReadingId: v })}
@@ -111,6 +112,7 @@ export function GpuSection({ sensors, hardwares }: Props) {
           <div className="flex flex-col gap-4">
             {gpuTempSensors.length > 0 && (
               <SensorSelect
+                label="GPU Temperature"
                 value={gpuTemp.customReadingId}
                 options={gpuTempSensors}
                 onChange={(v) => updateSensor("gpuTemp", { customReadingId: v })}
@@ -133,6 +135,7 @@ export function GpuSection({ sensors, hardwares }: Props) {
           <div className="flex flex-col gap-4">
             {gpuPowerSensors.length > 0 && (
               <SensorSelect
+                label="GPU Power"
                 value={gpuConsumption.customReadingId}
                 options={gpuPowerSensors}
                 onChange={(v) => updateSensor("gpuConsumption", { customReadingId: v })}
@@ -155,6 +158,7 @@ export function GpuSection({ sensors, hardwares }: Props) {
           <div className="flex flex-col gap-4">
             {vramSensors.length > 0 && (
               <SensorSelect
+                label="VRAM Usage"
                 value={vramUsage.customReadingId}
                 options={vramSensors}
                 onChange={(v) => updateSensor("vramUsage", { customReadingId: v })}

--- a/tauri-app/src/components/settings/stats/RamSection.tsx
+++ b/tauri-app/src/components/settings/stats/RamSection.tsx
@@ -7,6 +7,9 @@ export function RamSection() {
   const updateSensor = useSettingsStore((s) => s.updateSensor);
   const updateBoundary = useSettingsStore((s) => s.updateBoundary);
   const { ramUsage } = settings.sensors;
+  // RAM Usage has no sensor selector to fall back on, so when graphs are
+  // disabled the expanded row would be empty — render the row flat instead.
+  const graphEnabled = settings.progressType !== "none";
 
   return (
     <SectionCard
@@ -18,6 +21,7 @@ export function RamSection() {
         label="RAM Usage"
         checked={ramUsage.isEnabled}
         onCheckedChange={(v) => updateSensor("ramUsage", { isEnabled: v })}
+        expandable={graphEnabled}
       >
         <TempRangeControl
           boundaries={ramUsage.boundaries}

--- a/tauri-app/src/components/settings/stats/SectionCard.tsx
+++ b/tauri-app/src/components/settings/stats/SectionCard.tsx
@@ -29,7 +29,7 @@ export function SectionCard({
   return (
     <section
       className={cn(
-        "flex w-full flex-col gap-5 rounded-[12px] bg-card p-5",
+        "flex w-full flex-col gap-5 rounded-[12px] bg-[var(--bgSurfaceRaised)] p-5",
         className,
       )}
     >
@@ -41,7 +41,10 @@ export function SectionCard({
           <Switch checked={!!enabled} onCheckedChange={onToggle} />
         )}
       </div>
-      {children}
+      {/* When the section has a toggle and it's off, hide the body entirely
+          to match Figma "Stats / Off" — header row only. Sections without a
+          toggle (Monitor) always show their content. */}
+      {(onToggle === undefined || enabled) && children}
     </section>
   );
 }
@@ -57,12 +60,17 @@ export function SubCollapsible({
   checked,
   onCheckedChange,
   defaultOpen = false,
+  expandable = true,
   children,
 }: {
   label: string;
   checked: boolean;
   onCheckedChange: (v: boolean) => void;
   defaultOpen?: boolean;
+  // When false, renders a flat row with no chevron and no expand panel —
+  // used when the expanded content would otherwise be empty (e.g. RAM Usage
+  // with graphs disabled has nothing to show below the row).
+  expandable?: boolean;
   children?: React.ReactNode;
 }) {
   const [open, setOpen] = React.useState(defaultOpen && checked);
@@ -71,6 +79,23 @@ export function SubCollapsible({
   React.useEffect(() => {
     if (!checked && open) setOpen(false);
   }, [checked, open]);
+  // Also collapse if the row becomes non-expandable so state doesn't get stuck.
+  React.useEffect(() => {
+    if (!expandable && open) setOpen(false);
+  }, [expandable, open]);
+
+  if (!expandable) {
+    return (
+      <div className="flex items-center gap-2">
+        <Checkbox
+          checked={checked}
+          onCheckedChange={(v) => onCheckedChange(v === true)}
+        />
+        <span className="text-[14px] font-medium text-foreground">{label}</span>
+      </div>
+    );
+  }
+
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="flex flex-col gap-2">
       <div className="flex items-center gap-2">

--- a/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
+++ b/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
@@ -84,7 +84,7 @@ export function SensorPickerModal({
   const [shown, setShown] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  const rowRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const listRef = useRef<HTMLDivElement>(null);
 
   // Two-phase open/close so an exit transition can play before unmounting.
   useEffect(() => {
@@ -119,17 +119,18 @@ export function SensorPickerModal({
     [options, q],
   );
 
-  // Highlight the current selection when modal opens; clamp to filtered range
-  // when the search query narrows the list.
+  // Seed the highlight at the currently-selected row on open.
   useEffect(() => {
     if (!open) return;
-    const idx = filtered.findIndex((s) => s.identifier === value);
+    const idx = options.findIndex((s) => s.identifier === value);
     setActiveIndex(idx >= 0 ? idx : 0);
-  }, [open, value, filtered]);
+  }, [open, value, options]);
 
+  // Every keystroke re-narrows the list. Snap to the top match so Enter
+  // selects what the user is reading at the top.
   useEffect(() => {
-    if (activeIndex >= filtered.length) setActiveIndex(Math.max(0, filtered.length - 1));
-  }, [filtered.length, activeIndex]);
+    setActiveIndex(0);
+  }, [query]);
 
   const handleSelect = (id: string) => {
     onChange(id);
@@ -139,17 +140,17 @@ export function SensorPickerModal({
   const onListKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setActiveIndex((i) => {
-        const next = Math.min(filtered.length - 1, i + 1);
-        rowRefs.current[next]?.scrollIntoView({ block: "nearest" });
-        return next;
+      const next = Math.min(filtered.length - 1, activeIndex + 1);
+      setActiveIndex(next);
+      (listRef.current?.children[next] as HTMLElement | undefined)?.scrollIntoView({
+        block: "nearest",
       });
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      setActiveIndex((i) => {
-        const next = Math.max(0, i - 1);
-        rowRefs.current[next]?.scrollIntoView({ block: "nearest" });
-        return next;
+      const next = Math.max(0, activeIndex - 1);
+      setActiveIndex(next);
+      (listRef.current?.children[next] as HTMLElement | undefined)?.scrollIntoView({
+        block: "nearest",
       });
     } else if (e.key === "Enter" && filtered[activeIndex]) {
       e.preventDefault();
@@ -231,7 +232,10 @@ export function SensorPickerModal({
             />
           </div>
         </div>
-        <div className="flex max-h-[308px] flex-col gap-[2px] overflow-y-auto bg-[var(--bgSurfaceRaised)] p-2">
+        <div
+          ref={listRef}
+          className="flex max-h-[308px] flex-col gap-[2px] overflow-y-auto bg-[var(--bgSurfaceRaised)] p-2"
+        >
           {filtered.length === 0 ? (
             <div className="flex h-20 items-center justify-center text-[14px] font-medium text-[var(--textDisabled)]">
               No sensors match.
@@ -243,9 +247,6 @@ export function SensorPickerModal({
               return (
                 <button
                   key={s.identifier}
-                  ref={(el) => {
-                    rowRefs.current[i] = el;
-                  }}
                   type="button"
                   onClick={() => handleSelect(s.identifier)}
                   onMouseEnter={() => setActiveIndex(i)}

--- a/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
+++ b/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Sensor } from "@/lib/types";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/shadcn/dialog";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -80,38 +88,14 @@ export function SensorPickerModal({
   onChange,
 }: Props) {
   const [query, setQuery] = useState("");
-  const [rendered, setRendered] = useState(open);
-  const [shown, setShown] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  // Two-phase open/close so an exit transition can play before unmounting.
+  // Reset the search field whenever the modal closes.
   useEffect(() => {
-    if (open) {
-      setRendered(true);
-      const raf = requestAnimationFrame(() => setShown(true));
-      return () => cancelAnimationFrame(raf);
-    }
-    setShown(false);
-    const t = setTimeout(() => setRendered(false), 180);
-    return () => clearTimeout(t);
+    if (!open) setQuery("");
   }, [open]);
-
-  // ESC closes; reset query on close; autofocus search (skipped on touch
-  // devices to avoid spawning the on-screen keyboard).
-  useEffect(() => {
-    if (!open) {
-      setQuery("");
-      return;
-    }
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onOpenChange(false);
-    };
-    window.addEventListener("keydown", onKey);
-    if (!isTouchDevice) inputRef.current?.focus();
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onOpenChange]);
 
   const q = query.trim().toLowerCase();
   const filtered = useMemo(
@@ -158,119 +142,118 @@ export function SensorPickerModal({
     }
   };
 
-  if (!rendered) return null;
-
   return (
-    <div
-      className="fixed inset-x-0 bottom-0 top-[52px] z-50 flex items-start justify-center"
-      onMouseDown={() => onOpenChange(false)}
-    >
-      <div
-        aria-hidden
-        className={cn(
-          "absolute inset-0 bg-[var(--bgBrand)] transition-opacity duration-200 ease-out motion-reduce:transition-none",
-          shown ? "opacity-50" : "opacity-0",
-        )}
-      />
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label={title}
-        className={cn(
-          "relative mx-6 mt-[25px] flex w-full max-w-[603px] flex-col overflow-hidden rounded-[12px]",
-          "transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none",
-          shown ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",
-        )}
-        onMouseDown={(e) => e.stopPropagation()}
-      >
-        <div className="flex flex-col gap-4 border-b border-[var(--borderSubtle)] bg-[var(--bgSurfaceRaised)] p-5">
-          <div className="flex items-center justify-between">
-            <h2 className="text-[16px] font-medium leading-none text-[var(--textHeading)]">
-              {title}
-            </h2>
-            <button
-              type="button"
-              onClick={() => onOpenChange(false)}
-              aria-label="Close"
-              className={cn(
-                "relative flex size-5 items-center justify-center text-[var(--iconBolderActive)]",
-                "transition-transform duration-100 active:scale-[0.92] motion-reduce:transition-none",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-[4px]",
-                // 44×44 invisible hit area (Emil): pseudo-element extends touch target.
-                "before:absolute before:inset-[-12px] before:content-['']",
-                "[touch-action:manipulation]",
-              )}
-            >
-              <CloseIcon className="size-5" />
-            </button>
-          </div>
-          <div className="relative">
-            <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-5 -translate-y-1/2 text-[var(--iconBolderActive)]" />
-            <input
-              ref={inputRef}
-              type="search"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={onListKeyDown}
-              placeholder="Search sensor"
-              spellCheck={false}
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              data-1p-ignore
-              data-lpignore="true"
-              aria-label="Search sensor"
-              className={cn(
-                "h-10 w-full rounded-[8px] border border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] pl-10 pr-3 py-2",
-                "text-[14px] font-medium text-[var(--textHeading)] outline-none",
-                "placeholder:text-[var(--textDisabled)]",
-                "shadow-[0_1px_2px_rgba(16,24,40,0.05)]",
-                "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
-                // Hide the browser's native clear button on type=search
-                "[&::-webkit-search-cancel-button]:hidden",
-              )}
-            />
-          </div>
-        </div>
-        <div
-          ref={listRef}
-          className="flex max-h-[308px] flex-col gap-[2px] overflow-y-auto bg-[var(--bgSurfaceRaised)] p-2"
-        >
-          {filtered.length === 0 ? (
-            <div className="flex h-20 items-center justify-center text-[14px] font-medium text-[var(--textDisabled)]">
-              No sensors match.
-            </div>
-          ) : (
-            filtered.map((s, i) => {
-              const selected = s.identifier === value;
-              const highlighted = selected || i === activeIndex;
-              return (
-                <button
-                  key={s.identifier}
-                  type="button"
-                  onClick={() => handleSelect(s.identifier)}
-                  onMouseEnter={() => setActiveIndex(i)}
-                  className={cn(
-                    "flex h-10 items-center justify-between gap-2 rounded-[8px] px-3 py-2 text-left",
-                    "transition-[background-color,transform] duration-100 ease-out motion-reduce:transition-none",
-                    "active:scale-[0.98]",
-                    "[touch-action:manipulation]",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
-                    highlighted && "bg-[var(--bgSurfaceSunkenSubtle)]",
-                  )}
-                >
-                  <span className="truncate text-[14px] font-medium text-[var(--textHeading)]">
-                    {s.name}
-                  </span>
-                  {selected && (
-                    <CheckIcon className="size-5 shrink-0 text-[var(--iconBolderActive)]" />
-                  )}
-                </button>
-              );
-            })
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        {/* Overlay sits below the 52px title bar so the bar stays interactive */}
+        <DialogOverlay className="top-[52px]" />
+        <DialogContent
+          aria-describedby={undefined}
+          // Top-anchored layout matches the existing Figma frame (52px title
+          // bar + 25px gap). max-w-[603px] caps width; mx-6 reproduces the
+          // 24px gutters by sizing to viewport minus 48px.
+          className={cn(
+            "left-1/2 top-[77px] -translate-x-1/2 translate-y-0",
+            "grid w-[calc(100%-48px)] max-w-[603px] grid-rows-[auto_1fr] gap-0 overflow-hidden",
+            "rounded-[12px] bg-[var(--bgSurfaceRaised)] shadow-lg",
+            "data-[state=open]:slide-in-from-top-2 data-[state=closed]:slide-out-to-top-2",
           )}
-        </div>
-      </div>
-    </div>
+          onOpenAutoFocus={(e) => {
+            // Default focus would land on the close button. Aim at the search
+            // input instead — except on touch where that pops the soft keyboard.
+            if (isTouchDevice) {
+              e.preventDefault();
+              return;
+            }
+            e.preventDefault();
+            inputRef.current?.focus();
+          }}
+        >
+          <div className="flex flex-col gap-4 border-b border-[var(--borderSubtle)] bg-[var(--bgSurfaceRaised)] p-5">
+            <div className="flex items-center justify-between">
+              <DialogTitle>{title}</DialogTitle>
+              <DialogClose
+                aria-label="Close"
+                className={cn(
+                  "relative flex size-5 items-center justify-center text-[var(--iconBolderActive)]",
+                  "transition-transform duration-100 active:scale-[0.92] motion-reduce:transition-none",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-[4px]",
+                  // 44×44 invisible hit area (Emil): pseudo-element extends touch target.
+                  "before:absolute before:inset-[-12px] before:content-['']",
+                  "[touch-action:manipulation]",
+                )}
+              >
+                <CloseIcon className="size-5" />
+              </DialogClose>
+            </div>
+            <div className="relative">
+              <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-5 -translate-y-1/2 text-[var(--iconBolderActive)]" />
+              <input
+                ref={inputRef}
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={onListKeyDown}
+                placeholder="Search sensor"
+                spellCheck={false}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                data-1p-ignore
+                data-lpignore="true"
+                aria-label="Search sensor"
+                className={cn(
+                  "h-10 w-full rounded-[8px] border border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] pl-10 pr-3 py-2",
+                  "text-[14px] font-medium text-[var(--textHeading)] outline-none",
+                  "placeholder:text-[var(--textDisabled)]",
+                  "shadow-[0_1px_2px_rgba(16,24,40,0.05)]",
+                  "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                  // Hide the browser's native clear button on type=search
+                  "[&::-webkit-search-cancel-button]:hidden",
+                )}
+              />
+            </div>
+          </div>
+          <div
+            ref={listRef}
+            className="flex max-h-[308px] flex-col gap-[2px] overflow-y-auto bg-[var(--bgSurfaceRaised)] p-2"
+          >
+            {filtered.length === 0 ? (
+              <div className="flex h-20 items-center justify-center text-[14px] font-medium text-[var(--textDisabled)]">
+                No sensors match.
+              </div>
+            ) : (
+              filtered.map((s, i) => {
+                const selected = s.identifier === value;
+                const highlighted = selected || i === activeIndex;
+                return (
+                  <button
+                    key={s.identifier}
+                    type="button"
+                    onClick={() => handleSelect(s.identifier)}
+                    onMouseEnter={() => setActiveIndex(i)}
+                    className={cn(
+                      "flex h-10 items-center justify-between gap-2 rounded-[8px] px-3 py-2 text-left",
+                      "transition-[background-color,transform] duration-100 ease-out motion-reduce:transition-none",
+                      "active:scale-[0.98]",
+                      "[touch-action:manipulation]",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                      highlighted && "bg-[var(--bgSurfaceSunkenSubtle)]",
+                    )}
+                  >
+                    <span className="truncate text-[14px] font-medium text-[var(--textHeading)]">
+                      {s.name}
+                    </span>
+                    {selected && (
+                      <CheckIcon className="size-5 shrink-0 text-[var(--iconBolderActive)]" />
+                    )}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
   );
 }

--- a/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
+++ b/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Sensor } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  value: string;
+  options: Sensor[];
+  onChange: (v: string) => void;
+}
+
+// Icons exported from Figma 2353:2207 (close), 2353:2211 (search),
+// 2353:2224 (check). All 20×20 with currentColor fill.
+
+function CloseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      className={className}
+      aria-hidden
+    >
+      <path
+        d="M10.0007 11.1673L5.91732 15.2507C5.76454 15.4034 5.5701 15.4798 5.33398 15.4798C5.09787 15.4798 4.90343 15.4034 4.75065 15.2507C4.59787 15.0979 4.52148 14.9034 4.52148 14.6673C4.52148 14.4312 4.59787 14.2368 4.75065 14.084L8.83398 10.0007L4.75065 5.91732C4.59787 5.76454 4.52148 5.5701 4.52148 5.33398C4.52148 5.09787 4.59787 4.90343 4.75065 4.75065C4.90343 4.59787 5.09787 4.52148 5.33398 4.52148C5.5701 4.52148 5.76454 4.59787 5.91732 4.75065L10.0007 8.83398L14.084 4.75065C14.2368 4.59787 14.4312 4.52148 14.6673 4.52148C14.9034 4.52148 15.0979 4.59787 15.2507 4.75065C15.4034 4.90343 15.4798 5.09787 15.4798 5.33398C15.4798 5.5701 15.4034 5.76454 15.2507 5.91732L11.1673 10.0007L15.2507 14.084C15.4034 14.2368 15.4798 14.4312 15.4798 14.6673C15.4798 14.9034 15.4034 15.0979 15.2507 15.2507C15.0979 15.4034 14.9034 15.4798 14.6673 15.4798C14.4312 15.4798 14.2368 15.4034 14.084 15.2507L10.0007 11.1673Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      className={className}
+      aria-hidden
+    >
+      <path
+        d="M7.91667 13.3333C6.40278 13.3333 5.12153 12.809 4.07292 11.7604C3.02431 10.7118 2.5 9.43056 2.5 7.91667C2.5 6.40278 3.02431 5.12153 4.07292 4.07292C5.12153 3.02431 6.40278 2.5 7.91667 2.5C9.43056 2.5 10.7118 3.02431 11.7604 4.07292C12.809 5.12153 13.3333 6.40278 13.3333 7.91667C13.3333 8.52778 13.2361 9.10417 13.0417 9.64583C12.8472 10.1875 12.5833 10.6667 12.25 11.0833L16.9167 15.75C17.0694 15.9028 17.1458 16.0972 17.1458 16.3333C17.1458 16.5694 17.0694 16.7639 16.9167 16.9167C16.7639 17.0694 16.5694 17.1458 16.3333 17.1458C16.0972 17.1458 15.9028 17.0694 15.75 16.9167L11.0833 12.25C10.6667 12.5833 10.1875 12.8472 9.64583 13.0417C9.10417 13.2361 8.52778 13.3333 7.91667 13.3333ZM7.91667 11.6667C8.95833 11.6667 9.84375 11.3021 10.5729 10.5729C11.3021 9.84375 11.6667 8.95833 11.6667 7.91667C11.6667 6.875 11.3021 5.98958 10.5729 5.26042C9.84375 4.53125 8.95833 4.16667 7.91667 4.16667C6.875 4.16667 5.98958 4.53125 5.26042 5.26042C4.53125 5.98958 4.16667 6.875 4.16667 7.91667C4.16667 8.95833 4.53125 9.84375 5.26042 10.5729C5.98958 11.3021 6.875 11.6667 7.91667 11.6667Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      className={className}
+      aria-hidden
+    >
+      <path
+        d="M7.95745 12.625L15.0199 5.5625C15.1866 5.39583 15.3811 5.3125 15.6033 5.3125C15.8255 5.3125 16.0199 5.39583 16.1866 5.5625C16.3533 5.72917 16.4366 5.92708 16.4366 6.15625C16.4366 6.38542 16.3533 6.58333 16.1866 6.75L8.54078 14.4167C8.37411 14.5833 8.17967 14.6667 7.95745 14.6667C7.73523 14.6667 7.54078 14.5833 7.37411 14.4167L3.79078 10.8333C3.62411 10.6667 3.54425 10.4688 3.5512 10.2396C3.55814 10.0104 3.64495 9.8125 3.81161 9.64583C3.97828 9.47917 4.1762 9.39583 4.40536 9.39583C4.63453 9.39583 4.83245 9.47917 4.99911 9.64583L7.95745 12.625Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+const isTouchDevice =
+  typeof window !== "undefined" && "ontouchstart" in window;
+
+export function SensorPickerModal({
+  open,
+  onOpenChange,
+  title,
+  value,
+  options,
+  onChange,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [rendered, setRendered] = useState(open);
+  const [shown, setShown] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rowRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  // Two-phase open/close so an exit transition can play before unmounting.
+  useEffect(() => {
+    if (open) {
+      setRendered(true);
+      const raf = requestAnimationFrame(() => setShown(true));
+      return () => cancelAnimationFrame(raf);
+    }
+    setShown(false);
+    const t = setTimeout(() => setRendered(false), 180);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  // ESC closes; reset query on close; autofocus search (skipped on touch
+  // devices to avoid spawning the on-screen keyboard).
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      return;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onOpenChange(false);
+    };
+    window.addEventListener("keydown", onKey);
+    if (!isTouchDevice) inputRef.current?.focus();
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onOpenChange]);
+
+  const q = query.trim().toLowerCase();
+  const filtered = useMemo(
+    () => (q ? options.filter((o) => o.name.toLowerCase().includes(q)) : options),
+    [options, q],
+  );
+
+  // Highlight the current selection when modal opens; clamp to filtered range
+  // when the search query narrows the list.
+  useEffect(() => {
+    if (!open) return;
+    const idx = filtered.findIndex((s) => s.identifier === value);
+    setActiveIndex(idx >= 0 ? idx : 0);
+  }, [open, value, filtered]);
+
+  useEffect(() => {
+    if (activeIndex >= filtered.length) setActiveIndex(Math.max(0, filtered.length - 1));
+  }, [filtered.length, activeIndex]);
+
+  const handleSelect = (id: string) => {
+    onChange(id);
+    onOpenChange(false);
+  };
+
+  const onListKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => {
+        const next = Math.min(filtered.length - 1, i + 1);
+        rowRefs.current[next]?.scrollIntoView({ block: "nearest" });
+        return next;
+      });
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => {
+        const next = Math.max(0, i - 1);
+        rowRefs.current[next]?.scrollIntoView({ block: "nearest" });
+        return next;
+      });
+    } else if (e.key === "Enter" && filtered[activeIndex]) {
+      e.preventDefault();
+      handleSelect(filtered[activeIndex].identifier);
+    }
+  };
+
+  if (!rendered) return null;
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 top-[52px] z-50 flex items-start justify-center"
+      onMouseDown={() => onOpenChange(false)}
+    >
+      <div
+        aria-hidden
+        className={cn(
+          "absolute inset-0 bg-[var(--bgBrand)] transition-opacity duration-200 ease-out motion-reduce:transition-none",
+          shown ? "opacity-50" : "opacity-0",
+        )}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className={cn(
+          "relative mx-6 mt-[25px] flex w-full max-w-[603px] flex-col overflow-hidden rounded-[12px]",
+          "transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none",
+          shown ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",
+        )}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-col gap-4 border-b border-[var(--borderSubtle)] bg-[var(--bgSurfaceRaised)] p-5">
+          <div className="flex items-center justify-between">
+            <h2 className="text-[16px] font-medium leading-none text-[var(--textHeading)]">
+              {title}
+            </h2>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              aria-label="Close"
+              className={cn(
+                "relative flex size-5 items-center justify-center text-[var(--iconBolderActive)]",
+                "transition-transform duration-100 active:scale-[0.92] motion-reduce:transition-none",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-[4px]",
+                // 44×44 invisible hit area (Emil): pseudo-element extends touch target.
+                "before:absolute before:inset-[-12px] before:content-['']",
+                "[touch-action:manipulation]",
+              )}
+            >
+              <CloseIcon className="size-5" />
+            </button>
+          </div>
+          <div className="relative">
+            <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-5 -translate-y-1/2 text-[var(--iconBolderActive)]" />
+            <input
+              ref={inputRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={onListKeyDown}
+              placeholder="Search sensor"
+              spellCheck={false}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              data-1p-ignore
+              data-lpignore="true"
+              aria-label="Search sensor"
+              className={cn(
+                "h-10 w-full rounded-[8px] border border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] pl-10 pr-3 py-2",
+                "text-[14px] font-medium text-[var(--textHeading)] outline-none",
+                "placeholder:text-[var(--textDisabled)]",
+                "shadow-[0_1px_2px_rgba(16,24,40,0.05)]",
+                "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                // Hide the browser's native clear button on type=search
+                "[&::-webkit-search-cancel-button]:hidden",
+              )}
+            />
+          </div>
+        </div>
+        <div className="flex max-h-[308px] flex-col gap-[2px] overflow-y-auto bg-[var(--bgSurfaceRaised)] p-2">
+          {filtered.length === 0 ? (
+            <div className="flex h-20 items-center justify-center text-[14px] font-medium text-[var(--textDisabled)]">
+              No sensors match.
+            </div>
+          ) : (
+            filtered.map((s, i) => {
+              const selected = s.identifier === value;
+              const highlighted = selected || i === activeIndex;
+              return (
+                <button
+                  key={s.identifier}
+                  ref={(el) => {
+                    rowRefs.current[i] = el;
+                  }}
+                  type="button"
+                  onClick={() => handleSelect(s.identifier)}
+                  onMouseEnter={() => setActiveIndex(i)}
+                  className={cn(
+                    "flex h-10 items-center justify-between gap-2 rounded-[8px] px-3 py-2 text-left",
+                    "transition-[background-color,transform] duration-100 ease-out motion-reduce:transition-none",
+                    "active:scale-[0.98]",
+                    "[touch-action:manipulation]",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                    highlighted && "bg-[var(--bgSurfaceSunkenSubtle)]",
+                  )}
+                >
+                  <span className="truncate text-[14px] font-medium text-[var(--textHeading)]">
+                    {s.name}
+                  </span>
+                  {selected && (
+                    <CheckIcon className="size-5 shrink-0 text-[var(--iconBolderActive)]" />
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tauri-app/src/components/settings/stats/SensorSelect.tsx
+++ b/tauri-app/src/components/settings/stats/SensorSelect.tsx
@@ -1,39 +1,66 @@
+import { useState } from "react";
 import type { Sensor } from "@/lib/types";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/shadcn/select";
+import { SensorPickerModal } from "./SensorPickerModal";
 
 interface Props {
   value: string;
   options: Sensor[];
   onChange: (v: string) => void;
+  // Used in the modal title: "Select {label} sensor".
+  label: string;
+}
+
+// Chevron exported from Figma 2353:616 — 20×20, currentColor fill.
+function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      className={className}
+      aria-hidden
+    >
+      <path
+        d="M10.0007 11L13.2507 7.75C13.4034 7.59722 13.5979 7.52083 13.834 7.52083C14.0701 7.52083 14.2645 7.59722 14.4173 7.75C14.5701 7.90278 14.6465 8.09722 14.6465 8.33333C14.6465 8.56944 14.5701 8.76389 14.4173 8.91667L10.584 12.75C10.4173 12.9167 10.2229 13 10.0007 13C9.77843 13 9.58398 12.9167 9.41732 12.75L5.58398 8.91667C5.43121 8.76389 5.35482 8.56944 5.35482 8.33333C5.35482 8.09722 5.43121 7.90278 5.58398 7.75C5.73676 7.59722 5.93121 7.52083 6.16732 7.52083C6.40343 7.52083 6.59787 7.59722 6.75065 7.75L10.0007 11Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
 }
 
 /**
- * Sensor picker used by every SubCollapsible across the stats settings.
- * Trigger reads "Sensor: <name>" and the dropdown lists the hardware-filtered
- * sensors passed in `options`.
+ * Sensor picker trigger pill matched 1:1 to Figma 2353:612.
+ * Clicking opens SensorPickerModal — replaces the previous Radix Select dropdown.
  */
-export function SensorSelect({ value, options, onChange }: Props) {
+export function SensorSelect({ value, options, onChange, label }: Props) {
+  const [open, setOpen] = useState(false);
+  const currentName =
+    options.find((o) => o.identifier === value)?.name ?? "Select";
+
   return (
-    <Select value={value} onValueChange={onChange}>
-      <SelectTrigger className="h-10 rounded-[8px] bg-card text-[14px]">
-        <span className="flex items-center gap-2">
-          <span className="text-[14px] font-normal text-muted-foreground">Sensor:</span>
-          <SelectValue placeholder="Select" />
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex h-10 w-full items-center gap-2 rounded-[8px] border border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] px-3 py-2 text-left shadow-[0_1px_2px_rgba(16,24,40,0.05)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+      >
+        <span className="shrink-0 text-[14px] font-normal text-[var(--textParagraph1)]">
+          Sensor:
         </span>
-      </SelectTrigger>
-      <SelectContent>
-        {options.map((s) => (
-          <SelectItem key={s.identifier} value={s.identifier}>
-            {s.name}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+        <span className="flex-1 truncate text-[14px] font-medium text-[var(--textHeading)]">
+          {currentName}
+        </span>
+        <ChevronIcon className="size-5 shrink-0 text-[var(--iconBolderActive)]" />
+      </button>
+      <SensorPickerModal
+        open={open}
+        onOpenChange={setOpen}
+        title={`Select ${label} sensor`}
+        value={value}
+        options={options}
+        onChange={onChange}
+      />
+    </>
   );
 }

--- a/tauri-app/src/components/settings/stats/StatsTab.tsx
+++ b/tauri-app/src/components/settings/stats/StatsTab.tsx
@@ -35,6 +35,9 @@ export function StatsTab() {
       <RamSection />
       <NetworkSection sensors={sensors} hardwares={hardwares} />
       <MonitorSection />
+      <p className="text-label-sm-medium w-full text-right text-[var(--textDisabled)]">
+        May your frames be high, and temps be low.
+      </p>
       {updateStatus && (
         <UpdateBanner
           className="sticky bottom-4 z-10 mt-auto"

--- a/tauri-app/src/components/settings/stats/TempRangeControl.tsx
+++ b/tauri-app/src/components/settings/stats/TempRangeControl.tsx
@@ -1,5 +1,5 @@
-import { Info } from "lucide-react";
 import type { Boundaries } from "@/lib/types";
+import { useSettingsStore } from "@/stores/settings-store";
 
 const CLAMP = (v: number, min: number, max: number) =>
   Math.max(min, Math.min(max, v));
@@ -21,6 +21,11 @@ export function TempRangeControl({
   unit?: string;
   max?: number;
 }) {
+  const graphEnabled = useSettingsStore(
+    (s) => s.settings.progressType !== "none",
+  );
+  if (!graphEnabled) return null;
+
   const lowMin = 0;
   const lowMax = boundaries.low;
   const medMin = boundaries.low;
@@ -42,18 +47,10 @@ export function TempRangeControl({
   };
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex gap-4">
-        <RangeSegment color="#17B26A" label="Low" min={lowMin} max={lowMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setLowMax} />
-        <RangeSegment color="#FEC84B" label="Medium" min={medMin} max={medMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setMedMax} />
-        <RangeSegment color="#F04438" label="High" min={highMin} max={highMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setHighMax} />
-      </div>
-      <div className="flex items-center gap-1">
-        <Info className="size-4 text-muted-foreground" strokeWidth={2} />
-        <span className="text-[12px] font-medium text-muted-foreground">
-          Colors are visible only when the graph is enabled in the style settings
-        </span>
-      </div>
+    <div className="flex gap-4">
+      <RangeSegment color="#17B26A" label="Low" min={lowMin} max={lowMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setLowMax} />
+      <RangeSegment color="#FEC84B" label="Medium" min={medMin} max={medMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setMedMax} />
+      <RangeSegment color="#F04438" label="High" min={highMin} max={highMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setHighMax} />
     </div>
   );
 }
@@ -116,7 +113,7 @@ function ValueInput({
 }) {
   return (
     <div
-      className={`flex h-10 flex-1 items-center border border-border px-3 ${muted ? "bg-sub-card" : "bg-card"} ${className ?? ""}`}
+      className={`flex h-10 flex-1 items-center border border-[var(--borderBolder)] px-3 ${muted ? "bg-sub-card" : "bg-[var(--bgSurfaceRaised)]"} ${className ?? ""}`}
     >
       <input
         type="number"

--- a/tauri-app/src/components/settings/style/CollapsibleCard.tsx
+++ b/tauri-app/src/components/settings/style/CollapsibleCard.tsx
@@ -29,7 +29,7 @@ export function CollapsibleCard({
     <Collapsible
       open={open}
       onOpenChange={setOpen}
-      className="flex w-full flex-col gap-5 rounded-[12px] bg-card p-5"
+      className="flex w-full flex-col gap-5 rounded-[12px] bg-[var(--bgSurfaceRaised)] p-5"
     >
       <div className="flex items-center gap-3">
         <span className="flex-1 text-[13px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">

--- a/tauri-app/src/components/settings/style/FontCard.tsx
+++ b/tauri-app/src/components/settings/style/FontCard.tsx
@@ -28,7 +28,7 @@ function weightLabel(value: number) {
 }
 
 const triggerClasses = cn(
-  "h-10 flex-1 rounded-[8px] border-[#CECFD2] bg-card px-3 py-2 font-medium",
+  "h-10 flex-1 rounded-[8px] border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] px-3 py-2 font-medium",
   "shadow-[0px_1px_1px_0px_rgba(16,24,40,0.05)]",
   "text-[14px] text-[#0C111D] [&_svg]:size-5 [&_svg]:opacity-100",
 );

--- a/tauri-app/src/components/settings/style/GraphTypePicker.tsx
+++ b/tauri-app/src/components/settings/style/GraphTypePicker.tsx
@@ -62,7 +62,7 @@ function GraphTile({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex flex-1 items-center gap-3 rounded-[8px] bg-card p-1 text-left",
+        "flex flex-1 items-center gap-3 rounded-[8px] bg-[var(--bgSurfaceRaised)] p-1 text-left",
         "transition-shadow duration-150 motion-reduce:transition-none",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
       )}

--- a/tauri-app/src/components/settings/style/OrientationPicker.tsx
+++ b/tauri-app/src/components/settings/style/OrientationPicker.tsx
@@ -124,7 +124,7 @@ function OrientationTile({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex h-full flex-1 flex-col overflow-hidden rounded-[8px] bg-card text-left",
+        "flex h-full flex-1 flex-col overflow-hidden rounded-[8px] bg-[var(--bgSurfaceRaised)] text-left",
         "transition-shadow duration-150 motion-reduce:transition-none",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
       )}

--- a/tauri-app/src/components/settings/style/PositionGrid.tsx
+++ b/tauri-app/src/components/settings/style/PositionGrid.tsx
@@ -52,7 +52,7 @@ export function PositionGrid() {
       <div className="flex w-full flex-col gap-5">
         <div className="flex items-center gap-3">
           <div
-            className="flex size-10 shrink-0 items-center justify-center rounded-full bg-card text-foreground"
+            className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--bgSurfaceRaised)] text-foreground"
             style={{ boxShadow: "inset 0 0 0 1px rgba(206,207,210,0.5)" }}
           >
             <DragPanIcon className="size-5" />
@@ -71,52 +71,49 @@ export function PositionGrid() {
           />
         </div>
 
-        <div className="h-px w-full bg-[#ECECED]" aria-hidden />
+        {!useCustomPosition && (
+          <>
+            <div className="h-px w-full bg-[#ECECED]" aria-hidden />
 
-        <div
-          className={cn(
-            "grid grid-cols-3 gap-3 transition-opacity",
-            useCustomPosition && "pointer-events-none opacity-40",
-          )}
-          aria-disabled={useCustomPosition}
-        >
-          {PRESETS.map((p) => {
-            const selected = !useCustomPosition && positionIndex === p.index;
-            return (
-              <button
-                key={p.index}
-                type="button"
-                disabled={useCustomPosition}
-                onClick={() => updateSettings({ positionIndex: p.index })}
-                className={cn(
-                  "flex h-14 items-center gap-3 overflow-hidden rounded-[8px] bg-card pl-1 pr-3 py-1 text-left",
-                  "transition-shadow duration-150 motion-reduce:transition-none disabled:cursor-not-allowed",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
-                )}
-                style={{
-                  boxShadow: selected
-                    ? "inset 0 0 0 2px #0C111D, 0 4px 8px 0 rgba(0,0,0,0.02)"
-                    : "inset 0 0 0 1px rgba(206,207,210,0.5), 0 4px 8px 0 rgba(0,0,0,0.02)",
-                }}
-              >
-                <span className="relative size-12 shrink-0 rounded-[4px] bg-[#F5F5F6]">
-                  <span
+            <div className="grid grid-cols-3 gap-3">
+              {PRESETS.map((p) => {
+                const selected = positionIndex === p.index;
+                return (
+                  <button
+                    key={p.index}
+                    type="button"
+                    onClick={() => updateSettings({ positionIndex: p.index })}
                     className={cn(
-                      "absolute size-2",
-                      selected
-                        ? "rounded-full bg-foreground"
-                        : "rounded-[4px] bg-[#CECFD2]",
-                      p.pipClass,
+                      "flex h-14 items-center gap-3 overflow-hidden rounded-[8px] bg-[var(--bgSurfaceRaised)] pl-1 pr-3 py-1 text-left",
+                      "transition-shadow duration-150 motion-reduce:transition-none",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
                     )}
-                  />
-                </span>
-                <span className="truncate text-[14px] font-medium text-foreground">
-                  {p.label}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+                    style={{
+                      boxShadow: selected
+                        ? "inset 0 0 0 2px #0C111D, 0 4px 8px 0 rgba(0,0,0,0.02)"
+                        : "inset 0 0 0 1px rgba(206,207,210,0.5), 0 4px 8px 0 rgba(0,0,0,0.02)",
+                    }}
+                  >
+                    <span className="relative size-12 shrink-0 rounded-[4px] bg-[#F5F5F6]">
+                      <span
+                        className={cn(
+                          "absolute size-2",
+                          selected
+                            ? "rounded-full bg-foreground"
+                            : "rounded-[4px] bg-[#CECFD2]",
+                          p.pipClass,
+                        )}
+                      />
+                    </span>
+                    <span className="truncate text-[14px] font-medium text-foreground">
+                      {p.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        )}
       </div>
     </CollapsibleCard>
   );

--- a/tauri-app/src/components/shadcn/checkbox.tsx
+++ b/tauri-app/src/components/shadcn/checkbox.tsx
@@ -1,7 +1,30 @@
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+
+// Checkmark exported from Figma I2353:501;6914:107495 — native 11×8 viewBox,
+// path fills the box edge-to-edge so no off-center bias when centered inside
+// the parent. Replaces lucide-react `<Check />` whose 24×24 viewBox carried
+// a slight upward shift that was visible at small sizes.
+function CheckmarkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="11"
+      height="8"
+      viewBox="0 0 11 8"
+      fill="none"
+      className={className}
+      aria-hidden
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M10.8728 1.27279L4.2364 7.90919L0 3.67279L1.27279 2.4L4.2364 5.3636L9.6 0L10.8728 1.27279Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
 
 function Checkbox({
   className,
@@ -11,7 +34,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer size-[18px] shrink-0 rounded-[4px] border border-border bg-card",
+        "peer size-[18px] shrink-0 rounded-[4px] border border-[var(--bgSurfaceSunken)] bg-[var(--bgSurfaceRaised)]",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
         "disabled:cursor-not-allowed disabled:opacity-50",
         "data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-primary-foreground",
@@ -20,7 +43,7 @@ function Checkbox({
       {...props}
     >
       <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
-        <Check className="size-3.5" strokeWidth={3} />
+        <CheckmarkIcon />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/tauri-app/src/components/shadcn/dialog.tsx
+++ b/tauri-app/src/components/shadcn/dialog.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-[var(--bgBrand)]/50",
+        "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+        "motion-reduce:transition-none motion-reduce:animate-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPrimitive.Content
+      data-slot="dialog-content"
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-[12px] bg-[var(--bgSurfaceRaised)] shadow-lg",
+        "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+        "motion-reduce:transition-none motion-reduce:animate-none",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-[16px] font-medium leading-none text-[var(--textHeading)]", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-[14px] text-[var(--textBody)]", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogPortal,
+  DialogClose,
+  DialogOverlay,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+};

--- a/tauri-app/src/components/shadcn/switch.tsx
+++ b/tauri-app/src/components/shadcn/switch.tsx
@@ -12,7 +12,7 @@ function Switch({
       className={cn(
         "peer inline-flex h-[18px] w-[32px] shrink-0 items-center rounded-full p-[2px] outline-none transition-colors",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
-        "data-[state=checked]:bg-success data-[state=unchecked]:bg-switch-off",
+        "data-[state=checked]:bg-success data-[state=unchecked]:bg-[var(--bgSurfaceSunken)]",
         className,
       )}
       {...props}

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -218,6 +218,14 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
             sensors: mergedSensors,
           }
         : { ...DEFAULT_SETTINGS };
+      // The previously-rendered SettingsTab only wrote isDarkTheme, never
+      // themeMode — so old save files have no themeMode key and would
+      // resolve to DEFAULT_SETTINGS.themeMode ("light") after merge,
+      // showing the Light card highlighted while the app is actually dark.
+      // Seed themeMode from isDarkTheme on first load.
+      if (!saved?.themeMode) {
+        settings.themeMode = settings.isDarkTheme ? "dark" : "light";
+      }
       // No UI exposes isPositionLocked, so a stale `true` from an older
       // install would freeze the HUD with no way to recover — both the
       // React drag handlers and the cursor:grab style gate on !locked.


### PR DESCRIPTION
## Summary

Brings the four settings tabs to 1:1 with Figma `Software (New)` v1.1 / v1 frames. Five small, scoped commits — pick any single one apart cleanly without affecting the others.

| # | Commit | What |
|---|---|---|
| 1 | `feat(stats)` | Footer line, new sensor picker modal (replaces inline Radix Select dropdown), boundaries hide when graphs are disabled, RAM Usage renders flat with no expand panel when graphs are off, section card hides children when its toggle is off |
| 2 | `feat(settings)` | "Start with windows" now calls `set_auto_start` / `get_auto_start` (was local React state). "System" appearance option now watches `prefers-color-scheme: dark` and syncs `isDarkTheme`. Polling-rate dropdown trigger restyled to Figma surface + border + shadow tokens |
| 3 | `feat(style)` | Position card hides divider + 3×2 preset grid when "Use custom position" is on (matches Figma `/Custom position` variant, card height collapses 285→120). Style cards, tiles, and font trigger switched to `var(--bgSurfaceRaised)` / `var(--borderBolder)` |
| 4 | `feat(help)` | Append the "What are the current limitations? / Does not support exclusive full screen." entry verbatim from Figma `2338:1535` + `2338:1537` to the existing FAQ list (no removals). FAQ card uses `var(--bgSurfaceRaised)` |
| 5 | `fix(ds)` | Switch off-state and Checkbox unchecked ring switched from `#171717` / `--border` to `var(--bgSurfaceSunken)` (`#CECFD2`) per Figma `Bg/Surface Sunken`. Lucide `<Check />` swapped for the actual Figma checkmark SVG (`I2353:501;6914:107495`) — native 11×8 viewBox with edge-to-edge path so the tick lands true-centered inside the 18×18 box |

### Notes for review

- New file: `tauri-app/src/components/settings/stats/SensorPickerModal.tsx`. Built from scratch against Figma `2353:2202`; modal title is dynamic via the `label` prop now threaded through every `<SensorSelect>` call site in `CpuSection` and `GpuSection`.
- Sensor picker modal supports ArrowUp/Down + Enter from the search input (the search input is the focus target on open — mouse hover and keyboard cursor share one highlight state).
- `SubCollapsible` gains an `expandable` prop (default `true`). Only `RamSection` opts out — when graphs are off it has no sensor selector to fall back on, so flat-row rendering avoids an empty expand panel.
- No Rust changes. No dependency changes. No changes to `tauri.conf.json` (a dev-only transparency toggle made during testing was reverted before branching).
- `lucide-react` is no longer imported in `checkbox.tsx`; still used elsewhere in the codebase, not removed from deps.

## Test plan

- [ ] **Stats** — open each FPS / GPU / CPU / RAM / NETWORK section. Toggle the section pill off → header row only; toggle on → contents return.
- [ ] **Stats** — click any "Sensor: …" pill: modal slides + fades in 200ms; search filters by case-insensitive substring; ↑/↓ moves highlight, Enter selects, ESC / backdrop / X close.
- [ ] **Stats** — flip Style → Show Graph off, then return to Stats. Boundary Low/Med/High blocks gone across CPU/GPU/RAM. RAM Usage now renders as a flat row (no chevron). Toggle back on → boundaries return + RAM regains the expand chevron.
- [ ] **Settings** — toggle "Start with windows": value persists across app restart (writes to HKCU\Software\Microsoft\Windows\CurrentVersion\Run).
- [ ] **Settings** — click "System" appearance card; flip OS theme in Windows Settings → app should follow (light ↔ dark).
- [ ] **Settings** — polling rate dropdown: visible 1px gray border + subtle drop shadow.
- [ ] **Style** — Position card: toggle "Use custom position" on → 3×2 preset grid disappears; toggle off → reappears with last-selected preset highlighted.
- [ ] **Help** — FAQ list has 6 items; the new #6 reads "What are the current limitations? / Does not support exclusive full screen."
- [ ] **All tabs** — every Switch off-state should be light gray (not black). Every unchecked Checkbox should have a `#CECFD2` ring. Every checked Checkbox's tick should sit visually centered in the dark box.
- [ ] **Dark mode** — toggle Settings → Appearance → Dark. Section cards should use `#1f242f` (Bg/Surface Raised) instead of the previous `#171717`.