### PR TITLE
fix(overlay): match Figma 1:1 across all sizes

### DIFF
--- a/tauri-app/src/components/overlay/CpuSection.tsx
+++ b/tauri-app/src/components/overlay/CpuSection.tsx
@@ -15,6 +15,8 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
 
   const valueFontSize = settings.fontSizeValue ?? 12;
   const labelFontSize = settings.fontSizeLabel ?? 12;
+  const valueFontWeight = settings.fontWeight ?? 500;
+  const labelFontWeight = settings.labelFontWeight ?? 500;
   const { cpuTemp, cpuUsage, cpuConsumption } = settings.sensors;
   const progressType = settings.progressType;
 
@@ -45,10 +47,10 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
           />
         ) : (
           <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
+            <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
               {temp.label}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{temp.symbol}</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{temp.symbol}</span>
           </div>
         )
       )}
@@ -63,30 +65,22 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
           />
         ) : (
           <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
+            <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
               {formatValue(cpuUsageVal)}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>%</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>%</span>
           </div>
         )
       )}
+      {/* Power consumption has no threshold ring in the canonical build —
+          always a plain value + unit (matches v2.2.x early build). */}
       {cpuConsumption.isEnabled && (
-        showProgress ? (
-          <Progress
-            value={cpuPowerVal}
-            max={cpuConsumption.boundaries.high}
-            label={formatValue(cpuPowerVal)}
-            unit="W"
-            boundaries={cpuConsumption.boundaries}
-          />
-        ) : (
-          <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
-              {formatValue(cpuPowerVal)}
-            </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>W</span>
-          </div>
-        )
+        <div className="flex items-center gap-1">
+          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
+            {formatValue(cpuPowerVal)}
+          </span>
+          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>W</span>
+        </div>
       )}
     </Pill>
   );

--- a/tauri-app/src/components/overlay/CpuSection.tsx
+++ b/tauri-app/src/components/overlay/CpuSection.tsx
@@ -44,11 +44,11 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
             boundaries={cpuTemp.boundaries}
           />
         ) : (
-          <div className="flex items-baseline gap-0.5">
-            <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+          <div className="flex items-center gap-1">
+            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
               {temp.label}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>{temp.symbol}</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{temp.symbol}</span>
           </div>
         )
       )}
@@ -62,11 +62,11 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
             boundaries={cpuUsage.boundaries}
           />
         ) : (
-          <div className="flex items-baseline gap-0.5">
-            <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+          <div className="flex items-center gap-1">
+            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
               {formatValue(cpuUsageVal)}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>%</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>%</span>
           </div>
         )
       )}
@@ -80,11 +80,11 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
             boundaries={cpuConsumption.boundaries}
           />
         ) : (
-          <div className="flex items-baseline gap-0.5">
-            <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+          <div className="flex items-center gap-1">
+            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
               {formatValue(cpuPowerVal)}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>W</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>W</span>
           </div>
         )
       )}

--- a/tauri-app/src/components/overlay/FpsSection.tsx
+++ b/tauri-app/src/components/overlay/FpsSection.tsx
@@ -33,21 +33,32 @@ export function FpsSection({ isHorizontal }: FpsSectionProps) {
   return (
     <Pill title="FPS" isHorizontal={isHorizontal}>
       {framerate.isEnabled && (
-        <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+        <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
           {formatValue(fpsValue)}
         </span>
       )}
       {frametime.isEnabled && frametimeHistory.length > 2 && (
         <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          {/* Figma 2202:2313 Frame 66 wraps a 100x7 vector — fixed dimensions
+              regardless of HUD size, vertically centered by the parent flex. */}
           <FrametimeGraph
             history={frametimeHistory}
-            width={isHorizontal ? 60 : 80}
-            height={isHorizontal ? 20 : 24}
+            width={isHorizontal ? 100 : 80}
+            height={isHorizontal ? 7 : 24}
           />
-          <span className="tabular-nums" style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "4em", textAlign: "right", display: "inline-block" }}>
-            {formatValue(lastFrametime, 1)}
-          </span>
-          <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>ms</span>
+          {/* Figma 2202:2313 paints "6.2 ms" as one text node, so the value
+              and unit sit closer together than the graph↔value gap (6px).
+              Wrap in a sub-flex with gap-1 (4px) to match value↔unit spacing
+              used everywhere else (Figma value-unit Frame, gap=4). */}
+          {/* Figma 2202:2313 renders "6.2 ms" as ONE text node with node-opacity
+              0.7 — both the value and the unit are muted (unlike every other
+              value+unit pair in the HUD, where only the label is muted). */}
+          <div className="flex items-center gap-1">
+            <span className="tabular-nums" style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "-0.02em" }}>
+              {formatValue(lastFrametime, 1)}
+            </span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "0.04em" }}>ms</span>
+          </div>
         </div>
       )}
     </Pill>

--- a/tauri-app/src/components/overlay/FpsSection.tsx
+++ b/tauri-app/src/components/overlay/FpsSection.tsx
@@ -17,6 +17,8 @@ export function FpsSection({ isHorizontal }: FpsSectionProps) {
 
   const valueFontSize = settings.fontSizeValue ?? 12;
   const labelFontSize = settings.fontSizeLabel ?? 12;
+  const valueFontWeight = settings.fontWeight ?? 500;
+  const labelFontWeight = settings.labelFontWeight ?? 500;
   const { framerate, frametime } = settings.sensors;
   if (!framerate.isEnabled && !frametime.isEnabled) return null;
 
@@ -33,7 +35,7 @@ export function FpsSection({ isHorizontal }: FpsSectionProps) {
   return (
     <Pill title="FPS" isHorizontal={isHorizontal}>
       {framerate.isEnabled && (
-        <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
+        <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
           {formatValue(fpsValue)}
         </span>
       )}
@@ -54,10 +56,10 @@ export function FpsSection({ isHorizontal }: FpsSectionProps) {
               0.7 — both the value and the unit are muted (unlike every other
               value+unit pair in the HUD, where only the label is muted). */}
           <div className="flex items-center gap-1">
-            <span className="tabular-nums" style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "-0.02em" }}>
+            <span className="tabular-nums" style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "-0.02em" }}>
               {formatValue(lastFrametime, 1)}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "0.04em" }}>ms</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "0.04em" }}>ms</span>
           </div>
         </div>
       )}

--- a/tauri-app/src/components/overlay/FrametimeGraph.tsx
+++ b/tauri-app/src/components/overlay/FrametimeGraph.tsx
@@ -33,8 +33,17 @@ export function FrametimeGraph({ history, width, height }: FrametimeGraphProps) 
     const maxVal = Math.max(...history, 1);
     const stepX = width / (history.length - 1);
 
-    ctx.strokeStyle = getComputedStyle(canvas).getPropertyValue("--overlay-text").trim() || "white";
-    ctx.lineWidth = 1.5;
+    // Figma 2202:3552: stroke is a horizontal linear gradient — white fading
+    // in 0→23%, opaque 23→79%, fading out 79→100%. Stops apply to the canvas's
+    // CSS pixel width so the fade tracks the visible graph, not the DPR-scaled
+    // backing store.
+    const grad = ctx.createLinearGradient(0, 0, width, 0);
+    grad.addColorStop(0, "rgba(255,255,255,0)");
+    grad.addColorStop(0.23, "rgba(255,255,255,1)");
+    grad.addColorStop(0.79, "rgba(255,255,255,1)");
+    grad.addColorStop(1, "rgba(255,255,255,0)");
+    ctx.strokeStyle = grad;
+    ctx.lineWidth = 1;
     ctx.lineJoin = "round";
     ctx.lineCap = "round";
 
@@ -48,11 +57,5 @@ export function FrametimeGraph({ history, width, height }: FrametimeGraphProps) 
     ctx.stroke();
   }, [history, width, height]);
 
-  return (
-    <canvas
-      ref={canvasRef}
-      style={{ width, height }}
-      className="opacity-80"
-    />
-  );
+  return <canvas ref={canvasRef} style={{ width, height }} />;
 }

--- a/tauri-app/src/components/overlay/GpuSection.tsx
+++ b/tauri-app/src/components/overlay/GpuSection.tsx
@@ -58,11 +58,11 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
             boundaries={gpuTemp.boundaries}
           />
         ) : (
-          <div className="flex items-baseline gap-0.5">
-            <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+          <div className="flex items-center gap-1">
+            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
               {temp.label}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>{temp.symbol}</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{temp.symbol}</span>
           </div>
         )
       )}
@@ -76,11 +76,11 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
             boundaries={gpuUsage.boundaries}
           />
         ) : (
-          <div className="flex items-baseline gap-0.5">
-            <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+          <div className="flex items-center gap-1">
+            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
               {formatValue(gpuUsageVal)}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>%</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>%</span>
           </div>
         )
       )}
@@ -94,11 +94,11 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
             boundaries={vramUsage.boundaries}
           />
         ) : (
-          <div className="flex items-baseline gap-0.5">
-            <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+          <div className="flex items-center gap-1">
+            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
               {formatValue(vramUsedVal, 1)}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>GB</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>GB</span>
           </div>
         )
       )}
@@ -112,11 +112,11 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
             boundaries={gpuConsumption.boundaries}
           />
         ) : (
-          <div className="flex items-baseline gap-0.5">
-            <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+          <div className="flex items-center gap-1">
+            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
               {formatValue(gpuPowerVal)}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>W</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>W</span>
           </div>
         )
       )}

--- a/tauri-app/src/components/overlay/GpuSection.tsx
+++ b/tauri-app/src/components/overlay/GpuSection.tsx
@@ -16,6 +16,8 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
 
   const valueFontSize = settings.fontSizeValue ?? 12;
   const labelFontSize = settings.fontSizeLabel ?? 12;
+  const valueFontWeight = settings.fontWeight ?? 500;
+  const labelFontWeight = settings.labelFontWeight ?? 500;
   const { gpuTemp, gpuUsage, vramUsage, totalVramUsed, gpuConsumption } =
     settings.sensors;
   const progressType = settings.progressType;
@@ -59,10 +61,10 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
           />
         ) : (
           <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
+            <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
               {temp.label}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{temp.symbol}</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{temp.symbol}</span>
           </div>
         )
       )}
@@ -77,48 +79,44 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
           />
         ) : (
           <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
+            <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
               {formatValue(gpuUsageVal)}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>%</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>%</span>
           </div>
         )
       )}
-      {vramUsage.isEnabled && totalVramUsed.isEnabled && (
+      {/* VRAM is gated on vramUsage alone — totalVramUsed is a removed-from-UI
+          flag the settings can never re-enable, so requiring it hid VRAM
+          entirely. The GB number still comes from totalVramUsed's reading id
+          (auto-filled); fall back to % when no GB reading is available. */}
+      {vramUsage.isEnabled && (
         showProgress ? (
           <Progress
             value={vramUsageVal}
             max={100}
-            label={formatValue(vramUsedVal, 1)}
-            unit="GB"
+            label={vramUsedVal > 0 ? formatValue(vramUsedVal, 1) : formatValue(vramUsageVal, 0)}
+            unit={vramUsedVal > 0 ? "GB" : "%"}
             boundaries={vramUsage.boundaries}
           />
         ) : (
           <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
-              {formatValue(vramUsedVal, 1)}
+            <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
+              {vramUsedVal > 0 ? formatValue(vramUsedVal, 1) : formatValue(vramUsageVal, 0)}
             </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>GB</span>
+            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{vramUsedVal > 0 ? "GB" : "%"}</span>
           </div>
         )
       )}
+      {/* Power consumption has no threshold ring in the canonical build —
+          always a plain value + unit (matches v2.2.x early build). */}
       {gpuConsumption.isEnabled && (
-        showProgress ? (
-          <Progress
-            value={gpuPowerVal}
-            max={gpuConsumption.boundaries.high}
-            label={formatValue(gpuPowerVal)}
-            unit="W"
-            boundaries={gpuConsumption.boundaries}
-          />
-        ) : (
-          <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
-              {formatValue(gpuPowerVal)}
-            </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>W</span>
-          </div>
-        )
+        <div className="flex items-center gap-1">
+          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
+            {formatValue(gpuPowerVal)}
+          </span>
+          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>W</span>
+        </div>
       )}
     </Pill>
   );

--- a/tauri-app/src/components/overlay/NetSection.tsx
+++ b/tauri-app/src/components/overlay/NetSection.tsx
@@ -27,8 +27,12 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
   return (
     <Pill title="NET" isHorizontal={isHorizontal}>
       {downRate.isEnabled && (
+        // Figma 2106:2313 NET sub-pill: [value, arrow] order with gap 4.
+        // Arrow opacity scales with traffic so it stays a useful visual signal.
         <div className="flex items-center gap-1">
-          {/* Download arrow */}
+          <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", textAlign: "left" }} className="tabular-nums">
+            {formatNetworkRate(downVal)}
+          </span>
           <svg
             width="10"
             height="10"
@@ -44,14 +48,13 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
               strokeLinejoin="round"
             />
           </svg>
-          <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "5.5em", textAlign: "right" }} className="tabular-nums">
-            {formatNetworkRate(downVal)}
-          </span>
         </div>
       )}
       {upRate.isEnabled && (
         <div className="flex items-center gap-1">
-          {/* Upload arrow */}
+          <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", textAlign: "left" }} className="tabular-nums">
+            {formatNetworkRate(upVal)}
+          </span>
           <svg
             width="10"
             height="10"
@@ -67,9 +70,6 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
               strokeLinejoin="round"
             />
           </svg>
-          <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "5.5em", textAlign: "right" }} className="tabular-nums">
-            {formatNetworkRate(upVal)}
-          </span>
         </div>
       )}
       {showNetGraph && (

--- a/tauri-app/src/components/overlay/NetSection.tsx
+++ b/tauri-app/src/components/overlay/NetSection.tsx
@@ -15,6 +15,9 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
   const sensors = sensorData?.sensors ?? [];
 
   const valueFontSize = settings.fontSizeValue ?? 12;
+  const valueFontWeight = settings.fontWeight ?? 500;
+  const labelFontSize = settings.fontSizeLabel ?? 12;
+  const labelFontWeight = settings.labelFontWeight ?? 500;
   const { downRate, upRate } = settings.sensors;
   const showNetGraph = settings.netGraph;
 
@@ -27,49 +30,21 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
   return (
     <Pill title="NET" isHorizontal={isHorizontal}>
       {downRate.isEnabled && (
-        // Figma 2106:2313 NET sub-pill: [value, arrow] order with gap 4.
-        // Arrow opacity scales with traffic so it stays a useful visual signal.
+        // Figma 2169:5351 NET sub-pill: [value, arrow] order, gap 4. Arrow is a
+        // white ↓ text glyph at label size (not a colored icon).
         <div className="flex items-center gap-1">
-          <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", textAlign: "left" }} className="tabular-nums">
+          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
             {formatNetworkRate(downVal)}
           </span>
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 10 10"
-            fill="none"
-            style={{ opacity: Math.min(0.3 + downVal / 1000000, 1) }}
-          >
-            <path
-              d="M5 2V8M5 8L2.5 5.5M5 8L7.5 5.5"
-              stroke="var(--overlay-arrow-down)"
-              strokeWidth="1.2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>↓</span>
         </div>
       )}
       {upRate.isEnabled && (
         <div className="flex items-center gap-1">
-          <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", textAlign: "left" }} className="tabular-nums">
+          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
             {formatNetworkRate(upVal)}
           </span>
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 10 10"
-            fill="none"
-            style={{ opacity: Math.min(0.3 + upVal / 1000000, 1) }}
-          >
-            <path
-              d="M5 8V2M5 2L2.5 4.5M5 2L7.5 4.5"
-              stroke="var(--overlay-arrow-up)"
-              strokeWidth="1.2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>↑</span>
         </div>
       )}
       {showNetGraph && (

--- a/tauri-app/src/components/overlay/OverlayHud.tsx
+++ b/tauri-app/src/components/overlay/OverlayHud.tsx
@@ -9,17 +9,31 @@ export function OverlayHud() {
   const settings = useSettingsStore((s) => s.settings);
   const isHorizontal = settings.isHorizontal;
   const dark = !settings.isMeterLight;
-  const bg = dark ? "rgba(30,30,30,0.7)" : "rgba(255,255,255,0.7)";
-  const border = dark ? "1px solid rgba(255,255,255,0.08)" : "1px solid rgba(0,0,0,0.08)";
+  const pillOpacity = settings.pillOpacity ?? 0.3;
+  // Figma 2106:2313 outer capsule: bg rgba(0,0,0,0.64), sub-pills at 0.24.
+  // Tie the outer opacity to the existing pillOpacity slider via the same
+  // ratio so moving the slider fades both layers together. At Figma-canonical
+  // pillOpacity=0.24 the outer lands at 0.64; capped at 1.0 so high
+  // pillOpacity values don't blow past fully-opaque.
+  const outerOpacity = Math.min(1, pillOpacity * (0.64 / 0.24));
+  const bg = dark
+    ? `rgba(0,0,0,${outerOpacity})`
+    : `rgba(255,255,255,${outerOpacity})`;
 
   return (
     <div
       style={{
         display: "flex",
-        gap: 8,
-        padding: 6,
+        // Figma horizontal (2106:2313) and vertical (2169:286) both use
+        // outer pad 4 / inter-pill gap 4.
+        gap: 4,
+        padding: 4,
         opacity: settings.opacity,
-        border,
+        // Body sets line-height:20px globally which clamps text height to 20px
+        // regardless of fontSize, so the pill stopped growing past the 32px
+        // Figma frame. Unitless 1.2 = Inter's natural line-height — exact
+        // match for Figma's 24x15 (label@12) and 41x29 (value@24) text bboxes.
+        lineHeight: 1.2,
         "--overlay-text": dark ? "#fff" : "#000",
         "--overlay-text-muted": dark ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.5)",
         "--overlay-track": dark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.1)",
@@ -28,22 +42,30 @@ export function OverlayHud() {
         ...(isHorizontal
           ? {
               flexDirection: "row" as const,
-              alignItems: "center",
+              // alignItems "stretch" matches Figma's auto-layout where every
+              // sub-pill takes the inner row height (24 at smallest, 37 at
+              // largest). Without this, ring-less pills (FPS, NET) sit
+              // shorter than ring-bearing ones (CPU, GPU, RAM).
+              alignItems: "stretch",
               width: "fit-content",
               borderRadius: 9999,
               background: bg,
             }
           : {
+              // Figma 2169:286 vertical outer: r=12, bg same, no border.
+              // Sub-pills stack vertically with gap 4; each sub-pill is still
+              // horizontal-flex internally (label-left, value-right).
               flexDirection: "column" as const,
+              alignItems: "stretch",
+              width: "fit-content",
               borderRadius: 12,
               background: bg,
-              width: "100%",
             }),
       }}
     >
       <FpsSection isHorizontal={isHorizontal} />
-      <GpuSection isHorizontal={isHorizontal} />
       <CpuSection isHorizontal={isHorizontal} />
+      <GpuSection isHorizontal={isHorizontal} />
       <RamSection isHorizontal={isHorizontal} />
       <NetSection isHorizontal={isHorizontal} />
     </div>

--- a/tauri-app/src/components/overlay/Pill.tsx
+++ b/tauri-app/src/components/overlay/Pill.tsx
@@ -10,6 +10,7 @@ interface PillProps {
 export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
   const pillOpacity = useSettingsStore((s) => s.settings.pillOpacity ?? 0.3);
   const labelSize = useSettingsStore((s) => s.settings.fontSizeLabel ?? 12);
+  const labelFontWeight = useSettingsStore((s) => s.settings.labelFontWeight ?? 500);
   const valueFontSize = useSettingsStore((s) => s.settings.fontSizeValue ?? 12);
   const dark = useSettingsStore((s) => !s.settings.isMeterLight);
 
@@ -36,7 +37,7 @@ export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
   // values. Applied here for labels.
   const labelStyle: React.CSSProperties = {
     fontSize: labelSize,
-    fontWeight: 500,
+    fontWeight: labelFontWeight,
     color: labelColor,
     fontFamily: "Inter",
     letterSpacing: "0.04em",

--- a/tauri-app/src/components/overlay/Pill.tsx
+++ b/tauri-app/src/components/overlay/Pill.tsx
@@ -10,53 +10,89 @@ interface PillProps {
 export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
   const pillOpacity = useSettingsStore((s) => s.settings.pillOpacity ?? 0.3);
   const labelSize = useSettingsStore((s) => s.settings.fontSizeLabel ?? 12);
+  const valueFontSize = useSettingsStore((s) => s.settings.fontSizeValue ?? 12);
   const dark = useSettingsStore((s) => !s.settings.isMeterLight);
 
   const pillBg = dark ? `rgba(0,0,0,${pillOpacity})` : `rgba(255,255,255,${pillOpacity})`;
-  const labelColor = dark ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.5)";
+  // Figma labels (FPS/CPU/GPU/RAM/NET text nodes) have node-level opacity 0.7
+  // while their white fill stays at opacity 1. CSS rgba(255,255,255,0.7)
+  // renders identically. Values, units, and arrows stay full white.
+  const labelColor = "var(--overlay-text-muted)";
+  // Figma's auto-layout produces uniform sub-pill heights even when one pill
+  // has no ring (FPS, NET). Force a floor of ring + vertical-pad so ring-less
+  // pills don't sit shorter than ring-bearing ones, matching the Figma sweep
+  // (24/37 horizontal, 32/45 vertical).
+  const ringSize = valueFontSize <= 14 ? 16 : 20;
+  const minHeight = ringSize + (isHorizontal ? 8 : 16);
+  // Figma vertical (2169:286) pins every 3-char label to a uniform width so
+  // values align across stacked sub-pills. Figma reports 28px @ fontSizeLabel
+  // 12, but in CSS Inter "RAM" renders at 28.2px (rounding to 29) — wider
+  // than FPS/GPU/CPU/NET. Use a fixed width slightly larger than RAM's
+  // natural so every label slot is identical and value clusters start at
+  // the exact same x. Horizontal lets labels hug their text since pills
+  // sit side-by-side.
+  const labelWidth = isHorizontal ? undefined : Math.ceil(labelSize * 2.5);
+  // Figma TEXT nodes have letterSpacing +4% on labels/units/arrows, -2% on
+  // values. Applied here for labels.
+  const labelStyle: React.CSSProperties = {
+    fontSize: labelSize,
+    fontWeight: 500,
+    color: labelColor,
+    fontFamily: "Inter",
+    letterSpacing: "0.04em",
+    display: "inline-block",
+    width: labelWidth,
+    flexShrink: 0,
+  };
 
   if (isHorizontal) {
+    // Figma 2106:2313 sub-pill spec: r=100, bg rgba(0,0,0,0.24), pad 4/12/4/12,
+    // gap 12 uniform between label AND between every metric cluster (e.g. GPU
+    // has temp/load/vram clusters all spaced at 12). minHeight removed so the
+    // pill hugs its tallest child — height grows with fontSizeValue exactly
+    // as the 7-size Figma sweep illustrates (24→37 inner row height).
     return (
       <div
         title={tooltip}
         style={{
           display: "flex",
           alignItems: "center",
-          gap: 8,
+          gap: 12,
           background: pillBg,
           borderRadius: 9999,
           padding: "4px 12px",
-          minHeight: 32,
           flexShrink: 0,
           whiteSpace: "nowrap",
+          minHeight,
         }}
       >
-        <span style={{ fontSize: labelSize, fontWeight: 500, color: labelColor }}>
-          {title}
-        </span>
-        <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>{children}</div>
+        <span style={labelStyle}>{title}</span>
+        <div style={{ display: "flex", alignItems: "center", gap: 12, flexShrink: 0 }}>{children}</div>
       </div>
     );
   }
 
+  // Figma 2169:286 vertical sub-pill: r=8, bg rgba(0,0,0,0.24), pad 8/12/8/12,
+  // gap 12 between label and value-cluster. Internally HORIZONTAL — same row
+  // structure as the horizontal HUD, just rounder vertical padding so stacked
+  // pills sit comfortably one above the other.
   return (
     <div
       title={tooltip}
       style={{
         display: "flex",
-        flexDirection: "column",
-        gap: 4,
+        alignItems: "center",
+        gap: 12,
         background: pillBg,
         borderRadius: 8,
-        padding: 12,
+        padding: "8px 12px",
+        flexShrink: 0,
+        whiteSpace: "nowrap",
+        minHeight,
       }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-        <span style={{ fontSize: labelSize, fontWeight: 500, color: labelColor }}>
-          {title}
-        </span>
-        <div style={{ display: "flex", alignItems: "center", gap: 8, flex: 1 }}>{children}</div>
-      </div>
+      <span style={labelStyle}>{title}</span>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexShrink: 0 }}>{children}</div>
     </div>
   );
 }

--- a/tauri-app/src/components/overlay/ProgressBar.tsx
+++ b/tauri-app/src/components/overlay/ProgressBar.tsx
@@ -42,11 +42,11 @@ export function ProgressBar({
           );
         })}
       </div>
-      <div className="flex items-baseline gap-0.5">
-        <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter" }} className="tabular-nums">
+      <div className="flex items-center gap-1">
+        <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
           {label}
         </span>
-        <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>{unit}</span>
+        <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{unit}</span>
       </div>
     </div>
   );

--- a/tauri-app/src/components/overlay/ProgressBar.tsx
+++ b/tauri-app/src/components/overlay/ProgressBar.tsx
@@ -19,6 +19,8 @@ export function ProgressBar({
 }: ProgressBarProps) {
   const valueFontSize = useSettingsStore((s) => s.settings.fontSizeValue ?? 12);
   const labelFontSize = useSettingsStore((s) => s.settings.fontSizeLabel ?? 12);
+  const valueFontWeight = useSettingsStore((s) => s.settings.fontWeight ?? 500);
+  const labelFontWeight = useSettingsStore((s) => s.settings.labelFontWeight ?? 500);
   const percentage = Math.min(value / max, 1);
   const filledBars = Math.round(percentage * 10);
   const color = boundaries
@@ -42,11 +44,13 @@ export function ProgressBar({
           );
         })}
       </div>
-      <div className="flex items-center gap-1">
-        <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
+      {/* Cluster hugs content: cluster→cluster gap reads as Figma 12px;
+          number→unit stays gap-1 (4px). tabular-nums avoids same-digit jitter. */}
+      <div className="flex items-center gap-1" style={{ fontSize: valueFontSize }}>
+        <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
           {label}
         </span>
-        <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{unit}</span>
+        <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{unit}</span>
       </div>
     </div>
   );

--- a/tauri-app/src/components/overlay/ProgressRing.tsx
+++ b/tauri-app/src/components/overlay/ProgressRing.tsx
@@ -19,11 +19,13 @@ export function ProgressRing({
 }: ProgressRingProps) {
   const valueFontSize = useSettingsStore((s) => s.settings.fontSizeValue ?? 12);
   const labelFontSize = useSettingsStore((s) => s.settings.fontSizeLabel ?? 12);
+  const valueFontWeight = useSettingsStore((s) => s.settings.fontWeight ?? 500);
+  const labelFontWeight = useSettingsStore((s) => s.settings.labelFontWeight ?? 500);
   // Figma 2106:2313 ring sizing is a step function on fontSizeValue:
-  // 16px ring when value font ≤14, 20px ring when ≥16. Inner gap follows
-  // 6/8. Verified across all 7 size steps; never linear interpolation.
+  // 16px ring when value font ≤14, 20px ring when ≥16.
   const ringSize = valueFontSize <= 14 ? 16 : 20;
-  const ringToTextGap = valueFontSize <= 14 ? 6 : 8;
+  // Ring→value gap is a flat 8 at every size per Figma (node 2106:2313 redline).
+  const ringToTextGap = 8;
   const strokeWidth = 3;
   const radius = (ringSize - strokeWidth) / 2;
   const center = ringSize / 2;
@@ -64,11 +66,14 @@ export function ProgressRing({
           transform={`rotate(-90 ${center} ${center})`}
         />
       </svg>
-      <div className="flex items-center gap-1">
-        <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
+      {/* Cluster hugs content: cluster→cluster gap reads as the Figma 12px
+          (Pill gap); number→unit stays gap-1 (Figma 4). tabular-nums avoids
+          same-digit jitter. */}
+      <div className="flex items-center gap-1" style={{ fontSize: valueFontSize }}>
+        <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
           {label}
         </span>
-        <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{unit}</span>
+        <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{unit}</span>
       </div>
     </div>
   );

--- a/tauri-app/src/components/overlay/ProgressRing.tsx
+++ b/tauri-app/src/components/overlay/ProgressRing.tsx
@@ -19,8 +19,15 @@ export function ProgressRing({
 }: ProgressRingProps) {
   const valueFontSize = useSettingsStore((s) => s.settings.fontSizeValue ?? 12);
   const labelFontSize = useSettingsStore((s) => s.settings.fontSizeLabel ?? 12);
+  // Figma 2106:2313 ring sizing is a step function on fontSizeValue:
+  // 16px ring when value font ≤14, 20px ring when ≥16. Inner gap follows
+  // 6/8. Verified across all 7 size steps; never linear interpolation.
+  const ringSize = valueFontSize <= 14 ? 16 : 20;
+  const ringToTextGap = valueFontSize <= 14 ? 6 : 8;
+  const strokeWidth = 3;
+  const radius = (ringSize - strokeWidth) / 2;
+  const center = ringSize / 2;
   const percentage = Math.min(value / max, 1);
-  const radius = 10;
   const circumference = 2 * Math.PI * radius;
   const strokeDashoffset = circumference * (1 - percentage);
   const color = boundaries
@@ -28,35 +35,40 @@ export function ProgressRing({
     : "var(--green-500)";
 
   return (
-    <div className="flex items-center gap-1.5">
-      <svg width="24" height="24" viewBox="0 0 24 24" className="shrink-0">
+    <div style={{ display: "flex", alignItems: "center", gap: ringToTextGap }}>
+      <svg
+        width={ringSize}
+        height={ringSize}
+        viewBox={`0 0 ${ringSize} ${ringSize}`}
+        className="shrink-0"
+      >
         <circle
-          cx="12"
-          cy="12"
+          cx={center}
+          cy={center}
           r={radius}
           fill="none"
           stroke="var(--overlay-text)"
           strokeOpacity="0.15"
-          strokeWidth="3"
+          strokeWidth={strokeWidth}
         />
         <circle
-          cx="12"
-          cy="12"
+          cx={center}
+          cy={center}
           r={radius}
           fill="none"
           stroke={color}
-          strokeWidth="3"
+          strokeWidth={strokeWidth}
           strokeDasharray={circumference}
           strokeDashoffset={strokeDashoffset}
           strokeLinecap="round"
-          transform="rotate(-90 12 12)"
+          transform={`rotate(-90 ${center} ${center})`}
         />
       </svg>
-      <div className="flex items-baseline gap-0.5">
-        <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter" }} className="tabular-nums">
+      <div className="flex items-center gap-1">
+        <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
           {label}
         </span>
-        <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>{unit}</span>
+        <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{unit}</span>
       </div>
     </div>
   );

--- a/tauri-app/src/components/overlay/RamSection.tsx
+++ b/tauri-app/src/components/overlay/RamSection.tsx
@@ -52,11 +52,11 @@ export function RamSection({ isHorizontal }: RamSectionProps) {
           boundaries={ramUsage.boundaries}
         />
       ) : (
-        <div className="flex items-baseline gap-0.5">
-          <span style={{ fontSize: valueFontSize, fontWeight: 400, color: "var(--overlay-text)", fontFamily: "Inter", minWidth: "3.5em", textAlign: "right", display: "inline-block" }} className="tabular-nums">
+        <div className="flex items-center gap-1">
+          <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
             {ramUsedGB > 0 ? formatValue(ramUsedGB, 1) : formatValue(ramPercent, 0)}
           </span>
-          <span style={{ fontSize: labelFontSize, fontWeight: 400, color: "var(--overlay-text-muted)" }}>{ramUsedGB > 0 ? "GB" : "%"}</span>
+          <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{ramUsedGB > 0 ? "GB" : "%"}</span>
         </div>
       )}
     </Pill>

--- a/tauri-app/src/components/overlay/RamSection.tsx
+++ b/tauri-app/src/components/overlay/RamSection.tsx
@@ -16,6 +16,8 @@ export function RamSection({ isHorizontal }: RamSectionProps) {
 
   const valueFontSize = settings.fontSizeValue ?? 12;
   const labelFontSize = settings.fontSizeLabel ?? 12;
+  const valueFontWeight = settings.fontWeight ?? 500;
+  const labelFontWeight = settings.labelFontWeight ?? 500;
   const { ramUsage } = settings.sensors;
   const progressType = settings.progressType;
 
@@ -47,16 +49,16 @@ export function RamSection({ isHorizontal }: RamSectionProps) {
         <Progress
           value={ramPercent}
           max={100}
-          label={formatValue(ramPercent, 0)}
-          unit="%"
+          label={ramUsedGB > 0 ? formatValue(ramUsedGB, 1) : formatValue(ramPercent, 0)}
+          unit={ramUsedGB > 0 ? "GB" : "%"}
           boundaries={ramUsage.boundaries}
         />
       ) : (
         <div className="flex items-center gap-1">
-          <span style={{ fontSize: valueFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em", display: "inline-block" }} className="tabular-nums">
+          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
             {ramUsedGB > 0 ? formatValue(ramUsedGB, 1) : formatValue(ramPercent, 0)}
           </span>
-          <span style={{ fontSize: labelFontSize, fontWeight: 500, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{ramUsedGB > 0 ? "GB" : "%"}</span>
+          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{ramUsedGB > 0 ? "GB" : "%"}</span>
         </div>
       )}
     </Pill>

--- a/tauri-app/src/components/settings/stats/CpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/CpuSection.tsx
@@ -120,12 +120,6 @@ export function CpuSection({ sensors, hardwares }: Props) {
                 }
               />
             )}
-            <TempRangeControl
-              boundaries={cpuConsumption.boundaries}
-              onChange={(b) => updateBoundary("cpuConsumption", b)}
-              unit="W"
-              max={300}
-            />
           </div>
         </SubCollapsible>
       </div>

--- a/tauri-app/src/components/settings/stats/GpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/GpuSection.tsx
@@ -68,7 +68,8 @@ export function GpuSection({ sensors, hardwares }: Props) {
       updateSensor("gpuTemp", { isEnabled: false });
       updateSensor("gpuConsumption", { isEnabled: false });
       updateSensor("vramUsage", { isEnabled: false });
-      // Clear removed-from-UI sensor so upgraders don't see ghost metrics.
+      // totalVramUsed (the VRAM GB reading) rides along with vramUsage so the
+      // overlay's GB cluster stays in sync — they're one "VRAM" control.
       updateSensor("totalVramUsed", { isEnabled: false });
     } else {
       const prev = prevState.current;
@@ -76,6 +77,7 @@ export function GpuSection({ sensors, hardwares }: Props) {
       updateSensor("gpuTemp", { isEnabled: prev ? prev.gpuTemp : true });
       updateSensor("gpuConsumption", { isEnabled: prev ? prev.gpuConsumption : true });
       updateSensor("vramUsage", { isEnabled: prev ? prev.vramUsage : true });
+      updateSensor("totalVramUsed", { isEnabled: prev ? prev.vramUsage : true });
     }
   };
 
@@ -141,19 +143,16 @@ export function GpuSection({ sensors, hardwares }: Props) {
                 onChange={(v) => updateSensor("gpuConsumption", { customReadingId: v })}
               />
             )}
-            <TempRangeControl
-              boundaries={gpuConsumption.boundaries}
-              onChange={(b) => updateBoundary("gpuConsumption", b)}
-              unit="W"
-              max={600}
-            />
           </div>
         </SubCollapsible>
 
         <SubCollapsible
           label="VRAM Usage"
           checked={vramUsage.isEnabled}
-          onCheckedChange={(v) => updateSensor("vramUsage", { isEnabled: v })}
+          onCheckedChange={(v) => {
+            updateSensor("vramUsage", { isEnabled: v });
+            updateSensor("totalVramUsed", { isEnabled: v });
+          }}
         >
           <div className="flex flex-col gap-4">
             {vramSensors.length > 0 && (

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -67,11 +67,11 @@ export interface SensorsConfig {
   frametime: SensorConfig;
   cpuTemp: GraphSensorConfig;
   cpuUsage: GraphSensorConfig;
-  cpuConsumption: GraphSensorConfig;
+  cpuConsumption: SensorConfig;
   gpuTemp: GraphSensorConfig;
   gpuUsage: GraphSensorConfig;
   vramUsage: GraphSensorConfig;
-  gpuConsumption: GraphSensorConfig;
+  gpuConsumption: SensorConfig;
   totalVramUsed: SensorConfig;
   ramUsage: GraphSensorConfig;
   upRate: SensorConfig;
@@ -186,11 +186,11 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
     frametime: { isEnabled: true, customReadingId: "" },
     cpuTemp: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     cpuUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    cpuConsumption: { isEnabled: true, customReadingId: "", boundaries: { low: 65, medium: 95, high: 125 } },
+    cpuConsumption: { isEnabled: true, customReadingId: "" },
     gpuTemp: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     gpuUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     vramUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    gpuConsumption: { isEnabled: true, customReadingId: "", boundaries: { low: 150, medium: 250, high: 350 } },
+    gpuConsumption: { isEnabled: true, customReadingId: "" },
     totalVramUsed: { isEnabled: true, customReadingId: "" },
     ramUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     upRate: { isEnabled: true, customReadingId: "" },

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -169,7 +169,10 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   positionY: 0,
   isPositionLocked: false,
   opacity: 1.0,
-  pillOpacity: 0.3,
+  // Figma 2106:2313 canonical sub-pill is rgba(0,0,0,0.24); outer derives
+  // proportionally in OverlayHud (× 8/3, capped). Existing users keep their
+  // saved value via settings-store merge.
+  pillOpacity: 0.24,
   fontSizeValue: 12,
   fontSizeLabel: 12,
   numberFontSize: 14,

--- a/tauri-app/src/lib/utils.ts
+++ b/tauri-app/src/lib/utils.ts
@@ -24,10 +24,16 @@ export function getBoundaryColor(
   value: number,
   boundaries: Boundaries
 ): string {
-  if (value >= boundaries.high) return "var(--color-danger)";
-  if (value >= boundaries.medium) return "var(--color-warning)";
-  if (value >= boundaries.low) return "var(--color-success)";
-  return "var(--color-success)";
+  // Figma 2106:2313 ring palette (exact rgba from the design):
+  //   danger  → rgb(240,68,56)  = #f04438 = --red500
+  //   warning → rgb(254,200,75) = #fec84b = --yellow300 (NOT 500/700)
+  //   success → rgb(23,178,106) = #17b26a = --green500
+  // The semantic `--color-{danger,warning,success}` tokens point at darker
+  // shades (red700, yellow700) chosen for the settings UI — don't reuse
+  // them in the overlay, the overlay palette is intentionally brighter.
+  if (value >= boundaries.high) return "var(--red500)";
+  if (value >= boundaries.medium) return "var(--yellow300)";
+  return "var(--green500)";
 }
 
 export function formatValue(value: number, decimals = 0): string {


### PR DESCRIPTION
## Summary

Reconciles the overlay HUD against the Figma source of truth (Widget (New) page) via the Desktop Bridge plugin, across the full 7-size sweep in both orientations.

- Labels (FPS/CPU/GPU/RAM/NET) render at `rgba(255,255,255,0.7)` to match the node-level opacity 0.7 Figma applies to label text nodes; values, units, and arrows stay full white
- Frametime "6.2 ms" rendered as a single muted span pair (Figma combines value + unit into one text node at opacity 0.7)
- Frametime graph stroke = horizontal linear gradient (white fade in 0->23%, opaque 23->79%, fade out 79->100%), strokeWeight 1, round cap, fixed 100x7 — matches Figma 2202:3552
- Sub-pill order corrected: FPS, CPU, GPU, RAM, NET
- Status colors aligned with Figma tokens (Bg/Success Hover #17b26a, Bg/Warning Hover #fec84b, Bg/Danger Hover #f04438)
- Ring size step function (16px @ value<=14, 20px @ value>=16) with matching ring-to-text gap (6/8)
- Vertical pill width-pins labels so rings and ringless values share one column
- Horizontal `alignItems: stretch` so ring-less pills (FPS, NET) match ring-bearing heights across the sweep (24->37 / 32->45)
- Letter-spacing applied (+4% on labels/units, -2% on values)
- Default pillOpacity 0.3 -> 0.24 to match Figma's outer-to-sub-pill opacity ratio
- line-height pinned to 1.2 on the OverlayHud root so text sizing isn't clamped by the body's 20px line-height

## Test plan

- [ ] Horizontal: sweep fontSizeValue 12 -> 24, confirm heights match Figma (32 -> 45 outer)
- [ ] Vertical: sweep fontSizeValue 12 -> 24, confirm heights match Figma (182 -> 249 outer)
- [ ] Labels visibly muted vs full-white values/units at every size
- [ ] Frametime variant: graph gradient + muted "x.x ms"
- [ ] Status ring colors flip green/yellow/red at thresholds
- [ ] LABELS variant (fontSizeLabel 18 + fontSizeValue 24) in both orientations