### PR TITLE
fix(overlay): opacity controls pill alpha, NET unit as label, dedupe polling rates

### DIFF
--- a/tauri-app/src/OverlayApp.tsx
+++ b/tauri-app/src/OverlayApp.tsx
@@ -4,7 +4,6 @@ import { useSensorData } from "@/hooks/useSensorData";
 import { useSettingsStore } from "@/stores/settings-store";
 import {
   onSettingsChanged,
-  onSetOpacity,
   getMonitors,
   setOverlayPosition,
   setOverlaySize,
@@ -73,10 +72,9 @@ export default function OverlayApp() {
         useSettingsStore.setState({ settings: newSettings });
       });
       if (mounted) unlisteners.push(u1); else u1();
-      const u2 = await onSetOpacity((opacity) => {
-        document.documentElement.style.opacity = String(opacity);
-      });
-      if (mounted) unlisteners.push(u2); else u2();
+      // Opacity no longer dims the whole overlay — the Opacity setting drives
+      // the pill background alpha (see Pill.tsx). The legacy document-root
+      // opacity application was removed so the background and text stay opaque.
     };
     setup();
     return () => {

--- a/tauri-app/src/components/overlay/NetSection.tsx
+++ b/tauri-app/src/components/overlay/NetSection.tsx
@@ -27,6 +27,24 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
   const down = formatNetworkRateParts(findSensorById(sensors, downRate.customReadingId)?.value ?? 0);
   const up = formatNetworkRateParts(findSensorById(sensors, upRate.customReadingId)?.value ?? 0);
 
+  // Value vs label/unit styling — same split as the other sections (value
+  // hugs at -0.02em letterSpacing; unit/arrow use the label treatment at
+  // +0.04em). Extracted to avoid repeating the style object on every span.
+  const valueStyle: React.CSSProperties = {
+    fontSize: valueFontSize,
+    fontWeight: valueFontWeight,
+    color: "var(--overlay-text)",
+    fontFamily: "Inter",
+    letterSpacing: "-0.02em",
+  };
+  const labelStyle: React.CSSProperties = {
+    fontSize: labelFontSize,
+    fontWeight: labelFontWeight,
+    color: "var(--overlay-text)",
+    fontFamily: "Inter",
+    letterSpacing: "0.04em",
+  };
+
   return (
     <Pill title="NET" isHorizontal={isHorizontal}>
       {downRate.isEnabled && (
@@ -34,20 +52,16 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
         // rate unit (KB/s, MB/s) is a label — same styling as %, W, GB — not
         // part of the value. Arrow is a white ↓ text glyph at label size.
         <div className="flex items-center gap-1">
-          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
-            {down.value}
-          </span>
-          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{down.unit}</span>
-          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>↓</span>
+          <span style={valueStyle} className="tabular-nums">{down.value}</span>
+          <span style={labelStyle}>{down.unit}</span>
+          <span style={labelStyle}>↓</span>
         </div>
       )}
       {upRate.isEnabled && (
         <div className="flex items-center gap-1">
-          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
-            {up.value}
-          </span>
-          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{up.unit}</span>
-          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>↑</span>
+          <span style={valueStyle} className="tabular-nums">{up.value}</span>
+          <span style={labelStyle}>{up.unit}</span>
+          <span style={labelStyle}>↑</span>
         </div>
       )}
       {showNetGraph && (

--- a/tauri-app/src/components/overlay/NetSection.tsx
+++ b/tauri-app/src/components/overlay/NetSection.tsx
@@ -2,7 +2,7 @@ import { Pill } from "./Pill";
 import { NetGraph } from "./NetGraph";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useNetworkHistory } from "@/hooks/useSensorData";
-import { findSensorById, formatNetworkRate } from "@/lib/utils";
+import { findSensorById, formatNetworkRateParts } from "@/lib/utils";
 
 interface NetSectionProps {
   isHorizontal: boolean;
@@ -24,26 +24,29 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
   const anyEnabled = downRate.isEnabled || upRate.isEnabled || showNetGraph;
   if (!anyEnabled) return null;
 
-  const downVal = findSensorById(sensors, downRate.customReadingId)?.value ?? 0;
-  const upVal = findSensorById(sensors, upRate.customReadingId)?.value ?? 0;
+  const down = formatNetworkRateParts(findSensorById(sensors, downRate.customReadingId)?.value ?? 0);
+  const up = formatNetworkRateParts(findSensorById(sensors, upRate.customReadingId)?.value ?? 0);
 
   return (
     <Pill title="NET" isHorizontal={isHorizontal}>
       {downRate.isEnabled && (
-        // Figma 2169:5351 NET sub-pill: [value, arrow] order, gap 4. Arrow is a
-        // white ↓ text glyph at label size (not a colored icon).
+        // Figma 2169:5351 NET sub-pill: [value, unit, arrow] order, gap 4. The
+        // rate unit (KB/s, MB/s) is a label — same styling as %, W, GB — not
+        // part of the value. Arrow is a white ↓ text glyph at label size.
         <div className="flex items-center gap-1">
           <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
-            {formatNetworkRate(downVal)}
+            {down.value}
           </span>
+          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{down.unit}</span>
           <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>↓</span>
         </div>
       )}
       {upRate.isEnabled && (
         <div className="flex items-center gap-1">
           <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
-            {formatNetworkRate(upVal)}
+            {up.value}
           </span>
+          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{up.unit}</span>
           <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>↑</span>
         </div>
       )}

--- a/tauri-app/src/components/overlay/OverlayHud.tsx
+++ b/tauri-app/src/components/overlay/OverlayHud.tsx
@@ -22,7 +22,6 @@ export function OverlayHud() {
         // outer pad 4 / inter-pill gap 4.
         gap: 4,
         padding: 4,
-        opacity: settings.opacity,
         border,
         // Body sets line-height:20px globally which clamps text height to 20px
         // regardless of fontSize, so the pill stopped growing past the 32px

--- a/tauri-app/src/components/overlay/Pill.tsx
+++ b/tauri-app/src/components/overlay/Pill.tsx
@@ -8,13 +8,15 @@ interface PillProps {
 }
 
 export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
-  const pillOpacity = useSettingsStore((s) => s.settings.pillOpacity ?? 0.3);
+  // The Opacity slider drives the PILL background alpha only (max = solid
+  // black/white pills); the outer HUD background and text are unaffected.
+  const pillAlpha = useSettingsStore((s) => s.settings.opacity ?? 0.3);
   const labelSize = useSettingsStore((s) => s.settings.fontSizeLabel ?? 12);
   const labelFontWeight = useSettingsStore((s) => s.settings.labelFontWeight ?? 500);
   const valueFontSize = useSettingsStore((s) => s.settings.fontSizeValue ?? 12);
   const dark = useSettingsStore((s) => !s.settings.isMeterLight);
 
-  const pillBg = dark ? `rgba(0,0,0,${pillOpacity})` : `rgba(255,255,255,${pillOpacity})`;
+  const pillBg = dark ? `rgba(0,0,0,${pillAlpha})` : `rgba(255,255,255,${pillAlpha})`;
   // Figma labels (FPS/CPU/GPU/RAM/NET text nodes) have node-level opacity 0.7
   // while their white fill stays at opacity 1. CSS rgba(255,255,255,0.7)
   // renders identically. Values, units, and arrows stay full white.

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from "@/lib/utils";
 import { getAutoStart, setAutoStart } from "@/lib/tauri";
 import { useSettingsStore } from "@/stores/settings-store";
+import { POLLING_RATES } from "@/lib/types";
 import type { TemperatureUnit } from "@/lib/types";
 import {
   BrowserUpdatedIcon,
@@ -141,8 +142,6 @@ function TemperatureUnitsSection() {
     </SectionCard>
   );
 }
-
-const POLLING_RATES = [100, 250, 500, 1000];
 
 function PollingRateSection() {
   const pollingRate = useSettingsStore((s) => s.settings.pollingRate);

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -151,7 +151,10 @@ export interface AppPreferences {
 
 export type SensorKey = keyof SensorsConfig;
 
-export const POLLING_RATES = [33, 50, 100, 250, 300, 350, 400, 500] as const;
+// Polling intervals (ms) offered in Settings → Polling rate. Single source of
+// truth — the dropdown imports this. Lower = faster updates (numbers change
+// quicker), so HUD animation timings derive from the selected value.
+export const POLLING_RATES = [100, 250, 500, 1000] as const;
 
 export const DEFAULT_SETTINGS: OverlaySettings = {
   isDarkTheme: false,
@@ -168,10 +171,11 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   positionX: 0,
   positionY: 0,
   isPositionLocked: false,
-  opacity: 1.0,
-  // Pre-PR#8 sub-pill alpha. PR#8 had lowered this to 0.24 and derived the
-  // outer capsule from it; reverted to the prior look. Existing users keep
-  // their saved value via settings-store merge.
+  // Opacity now drives the pill background alpha (not whole-widget opacity).
+  // 0.3 = the Figma translucent-pill default; 1.0 (slider max) = solid pills.
+  opacity: 0.3,
+  // Legacy: pill alpha is now driven by `opacity` above. Kept on the settings
+  // shape (shared with the Rust struct) but no longer read by the UI.
   pillOpacity: 0.3,
   fontSizeValue: 12,
   fontSizeLabel: 12,

--- a/tauri-app/src/lib/utils.ts
+++ b/tauri-app/src/lib/utils.ts
@@ -56,10 +56,19 @@ export function formatBytes(bytes: number): string {
   return `${bytes.toFixed(0)} B`;
 }
 
+// Split form: the number and its rate unit, so the unit can be rendered with
+// the same label/unit styling as %, W, °C, GB (not as part of the value).
+export function formatNetworkRateParts(
+  bytesPerSec: number,
+): { value: string; unit: string } {
+  if (bytesPerSec >= 1048576) return { value: (bytesPerSec / 1048576).toFixed(1), unit: "MB/s" };
+  if (bytesPerSec >= 1024) return { value: (bytesPerSec / 1024).toFixed(1), unit: "KB/s" };
+  return { value: bytesPerSec.toFixed(0), unit: "B/s" };
+}
+
 export function formatNetworkRate(bytesPerSec: number): string {
-  if (bytesPerSec >= 1048576) return `${(bytesPerSec / 1048576).toFixed(1)} MB/s`;
-  if (bytesPerSec >= 1024) return `${(bytesPerSec / 1024).toFixed(1)} KB/s`;
-  return `${bytesPerSec.toFixed(0)} B/s`;
+  const { value, unit } = formatNetworkRateParts(bytesPerSec);
+  return `${value} ${unit}`;
 }
 
 export function findSensorByTypeAndHardware(


### PR DESCRIPTION
Three small overlay fixes (no behavior added beyond these — an animation spike was explored and fully reverted).

## Opacity → pill background only
The Opacity slider previously faded the **entire** widget (applied to the HUD container *and* the document root). It now drives the **pill background alpha only** — max = solid pills, lower = translucent pills — while the outer background and text stay fully opaque.

- Removed `opacity: settings.opacity` from the HUD container.
- Removed the `onSetOpacity` → `document.documentElement.style.opacity` listener (and its import) in `OverlayApp`.
- `Pill` reads `settings.opacity` for the pill bg alpha.
- Default `opacity` set to `0.3` (the Figma translucent-pill look) for fresh installs.

⚠️ Existing saved settings keep their `opacity` value, which now means pill alpha — a saved `1.0` will show solid pills until adjusted. `pillOpacity` is now unused by the UI but kept on the settings shape (shared with the Rust struct).

## NET unit is now a label
`KB/s` / `MB/s` / `B/s` was baked into the value string (value styling). It's now split out via `formatNetworkRateParts` and rendered with the same label/unit styling as `%`, `W`, `°C`, `GB`. The rate value and computation are unchanged.

## Polling-rate dedupe
`POLLING_RATES` is now a single source of truth in `types.ts` (`[100, 250, 500, 1000]` — the real UI list). `SettingsTab` imports it instead of a stale local copy that had drifted from a dead `[33, 50, …, 500]` export.

## Testing
- `tsc --noEmit` clean
- `vite build` clean
- No functionality changed in the sensor/reading path.