### PR TITLE
chore: bump version to 2.2.1

### DIFF
--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cleanmeter",
-  "version": "2.2.1-preview-early-build",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cleanmeter",
-      "version": "2.2.1-preview-early-build",
+      "version": "2.2.1",
       "dependencies": {
         "@fluentui/react-components": "^9.73.4",
         "@fluentui/react-icons": "^2.0.321",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleanmeter",
   "private": true,
-  "version": "2.2.1-preview-early-build",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "build:tokens": "node sd.config.js",

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "cleanmeter"
-version = "2.2.1-preview-early-build"
+version = "2.2.1"
 dependencies = [
  "byteorder",
  "dirs",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cleanmeter"
-version = "2.2.1-preview-early-build"
+version = "2.2.1"
 description = "Gaming performance overlay"
 authors = ["CleanMeter"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui/toolkits/refs/heads/main/tauri/schema.json",
   "productName": "CleanMeter",
   "identifier": "com.cleanmeter.desktop",
-  "version": "2.2.1-preview-early-build",
+  "version": "2.2.1",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Promotes the rolling `2.2.1-preview-early-build` to a clean **2.2.1** release version (drops the `-preview-early-build` suffix) across package.json, package-lock.json, Cargo.toml, Cargo.lock, and tauri.conf.json.

Cut from current main (post PR #11). Tagging `v2.2.1` after merge triggers the build workflow to produce the signed Windows installer as a draft release.