### PR TITLE
fix(bundle): drop empty *.json sidecar resource glob that broke v2.2.1 release

### DIFF
--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -83,8 +83,7 @@
     "resources": {
       "../../HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/*.exe": "./",
       "../../HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/*.dll": "./",
-      "../../HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/*.txt": "./",
-      "../../HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/*.json": "./"
+      "../../HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/*.txt": "./"
     }
   },
   "plugins": {}


### PR DESCRIPTION
The `v2.2.1` release build failed at the Tauri bundle step:

```
build.rs:37 panicked: glob pattern .../publish/*.json — didn't match any files
```

**Cause:** CI builds the HardwareMonitor sidecar with `--self-contained -p:PublishSingleFile=true`, which embeds `deps.json` + `runtimeconfig.json` into the single-file exe. The publish folder then has no standalone `*.json`, so Tauri's `publish/*.json` resource glob matched zero files and `tauri_build` panics (empty globs are fatal).

**Fix:** removed the `*.json` resource entry. The only json are dotnet-internal (no appsettings/custom config in the sidecar) and are embedded in the single-file exe, so they don't need separate bundling. The `*.exe`/`*.dll`/`*.txt` globs still match.

Note: a *non*-single-file local bundle would no longer ship runtimeconfig.json — but the release path (CI) is single-file, and `tauri dev` runs the sidecar from the publish folder directly.