### PR TITLE
Migrate DS components to dedicated tokens + ProgressBar/Toggle refresh

### DIFF
--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -14,7 +14,8 @@
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build && node scripts/deploy-storybook.cjs"
+    "build-storybook": "storybook build",
+    "deploy-storybook": "node scripts/deploy-storybook.cjs"
   },
   "dependencies": {
     "@fluentui/react-components": "^9.73.4",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -14,7 +14,7 @@
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build && node scripts/deploy-storybook.cjs"
   },
   "dependencies": {
     "@fluentui/react-components": "^9.73.4",

--- a/tauri-app/scripts/deploy-storybook.cjs
+++ b/tauri-app/scripts/deploy-storybook.cjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const repoRoot = path.resolve(__dirname, "..");
+const staticDir = path.join(repoRoot, "storybook-static");
+const hostDir = path.join(repoRoot, "storybook-host");
+
+if (!fs.existsSync(staticDir)) {
+  console.error(
+    "[deploy-storybook] storybook-static/ not found. Run `storybook build` first."
+  );
+  process.exit(1);
+}
+
+function copyFile(src, dest) {
+  if (!fs.existsSync(src)) {
+    console.error(`[deploy-storybook] missing required file: ${src}`);
+    process.exit(1);
+  }
+  fs.copyFileSync(src, dest);
+}
+
+function copyDir(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDir(s, d);
+    else if (entry.isFile()) fs.copyFileSync(s, d);
+  }
+}
+
+copyFile(
+  path.join(hostDir, "package.json"),
+  path.join(staticDir, "package.json")
+);
+copyFile(
+  path.join(hostDir, "railway.json"),
+  path.join(staticDir, "railway.json")
+);
+
+const railwayTemplate = path.join(hostDir, ".railway");
+if (fs.existsSync(railwayTemplate)) {
+  copyDir(railwayTemplate, path.join(staticDir, ".railway"));
+} else {
+  console.warn(
+    "[deploy-storybook] storybook-host/.railway/ not found — first-time setup required."
+  );
+  console.warn(
+    "  Run `railway link` (or follow the setup checklist in the README) once,"
+  );
+  console.warn(
+    "  then copy the generated storybook-static/.railway/ into storybook-host/.railway/."
+  );
+}
+
+const result = spawnSync("railway", ["up", "--detach"], {
+  cwd: staticDir,
+  stdio: "inherit",
+  shell: true,
+});
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}

--- a/tauri-app/sd.config.js
+++ b/tauri-app/sd.config.js
@@ -275,7 +275,7 @@ function darkTokenFilter(token) {
   const pathFirst = token.path[0]?.toLowerCase() ?? "";
   // Include only semantic color categories that differ between themes
   const semanticGroups = [
-    "text", "bg", "icon", "border", "gradient", "plain",
+    "text", "bg", "icon", "border", "gradient", "plain", "component",
   ];
   return semanticGroups.some((g) => pathFirst.startsWith(g));
 }

--- a/tauri-app/src/app/components/Keycap.tsx
+++ b/tauri-app/src/app/components/Keycap.tsx
@@ -15,13 +15,13 @@ function Key({
   return (
     <kbd
       className={cn(
-        "relative flex h-8 items-center justify-center overflow-clip rounded-[5px] bg-[var(--bgBrand)] px-[5px] pb-[10px] pt-[8px]",
+        "relative flex h-8 items-center justify-center overflow-clip rounded-[5px] bg-[var(--componentKeycapsBg)] px-[5px] pb-[10px] pt-[8px]",
         className
       )}
       {...props}
     >
-      <span className="absolute inset-x-0 top-0 h-[29px] rounded-[5px] bg-gradient-to-b from-[var(--gradientStops1)] from-[11%] to-[var(--gradientStops2)]" />
-      <span className="relative text-label-md-regular text-[var(--textInverse)] tracking-[-0.26px]">
+      <span className="absolute inset-x-0 top-0 h-[29px] rounded-[5px] bg-gradient-to-b from-[var(--componentKeycapsGradientStops1)] from-[11%] to-[var(--componentKeycapsGradientStops2)]" />
+      <span className="relative text-label-md-regular text-[var(--componentKeycapsText)] tracking-[-0.26px]">
         {props.children}
       </span>
     </kbd>

--- a/tauri-app/src/app/components/NavigationTabs.tsx
+++ b/tauri-app/src/app/components/NavigationTabs.tsx
@@ -4,23 +4,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const tabVariants = cva(
-  "inline-flex flex-1 min-w-0 cursor-pointer items-center justify-center rounded-[var(--cornerRound)] text-body-md-medium transition-colors duration-150 shadow-focus-default",
+  "inline-flex flex-1 min-w-0 cursor-pointer items-center justify-center gap-[var(--spacingXxxs)] rounded-[var(--cornerRound)] pl-[var(--spacingM)] pr-[var(--spacingL)] py-[var(--spacingSx)] text-body-md-medium transition-colors duration-150 shadow-focus-default",
   {
     variants: {
       active: {
-        false:
-          "bg-transparent text-[var(--textParagraph1)] [&_[data-tab-icon]]:text-[var(--iconBolderActive)]",
-        true: "bg-[var(--bgSurfaceRaised)] text-[var(--textHeading)] drop-shadow-[0px_4px_4px_rgba(0,0,0,0.02)] [&_[data-tab-icon]]:text-[var(--iconBolder)]",
-      },
-      iconOnly: {
-        false:
-          "gap-[var(--spacingXxxs)] pl-[var(--spacingM)] pr-[var(--spacingL)] py-[var(--spacingSx)]",
-        true: "px-[var(--spacingL)] py-[var(--spacingSx)]",
+        false: "bg-transparent text-[var(--componentTabsInactiveForeground)]",
+        true: "bg-[var(--componentTabsActiveBg)] text-[var(--componentTabsActiveForeground)] shadow-[var(--shadow-card)]",
       },
     },
     defaultVariants: {
       active: false,
-      iconOnly: false,
     },
   }
 );
@@ -33,7 +26,6 @@ type TabProps = React.ComponentProps<"button"> &
 function Tab({
   className,
   active,
-  iconOnly,
   asChild = false,
   type,
   ...props
@@ -42,7 +34,7 @@ function Tab({
   return (
     <Comp
       type={asChild ? type : type ?? "button"}
-      className={cn(tabVariants({ active, iconOnly }), className)}
+      className={cn(tabVariants({ active }), className)}
       {...props}
     />
   );
@@ -85,7 +77,7 @@ function NavigationTabs({
   return (
     <Comp
       className={cn(
-        "flex items-center rounded-[var(--cornerRound)] border border-[var(--borderBold)] bg-[var(--bgSubtle)] p-[var(--spacingXxxs)]",
+        "flex items-center justify-center rounded-[var(--cornerRound)] border border-[var(--componentTabsBorder)] bg-[var(--componentTabsBg)] p-[var(--spacingXxxs)]",
         className
       )}
       {...props}
@@ -101,7 +93,7 @@ function NavigationTabsGroup({
   const Comp = asChild ? Slot : "div";
   return (
     <Comp
-      className={cn("flex flex-1 min-w-0 items-stretch", className)}
+      className={cn("flex flex-1 min-w-0 items-center", className)}
       {...props}
     />
   );

--- a/tauri-app/src/app/components/ProgressBar.tsx
+++ b/tauri-app/src/app/components/ProgressBar.tsx
@@ -87,10 +87,10 @@ function ProgressBar({ className, value = 0, onChange, "aria-label": ariaLabel, 
       className={cn("flex flex-col gap-[var(--spacingS)] w-full", className)}
       {...props}
     >
-      {/* Bar */}
+      {/* Bar — 20px hit area with an 8px-tall track centered inside */}
       <div
         ref={trackRef}
-        className="relative h-3 w-full cursor-pointer touch-none"
+        className="relative h-5 w-full cursor-pointer touch-none"
         role="slider"
         aria-valuenow={clamped}
         aria-valuemin={0}
@@ -102,23 +102,23 @@ function ProgressBar({ className, value = 0, onChange, "aria-label": ariaLabel, 
         onKeyDown={handleKeyDown}
       >
         {/* Track */}
-        <div className="absolute inset-0 rounded-[var(--cornerRound)] bg-[var(--bgSurfaceSunkenSubtle)]" />
+        <div className="absolute inset-x-0 top-1/2 h-2 -translate-y-1/2 rounded-[var(--cornerRound)] bg-[var(--bgSurfaceSunkenSubtle)]" />
 
         {/* Filled portion — stretches from left edge to the thumb center */}
         <div
-          className="absolute inset-y-0 left-0 rounded-[var(--cornerRound)] bg-[var(--bgBrand)]"
+          className="absolute top-1/2 left-0 h-2 -translate-y-1/2 rounded-[var(--cornerRound)] bg-[var(--bgBrand)]"
           style={{ width: `calc(10px + ${clamped}% * (100% - 20px) / 100%)` }}
         />
 
         {/* Dots & midpoint line — single layer on top of track + fill */}
-        <TrackDots />
+        <TrackDots value={clamped} />
 
         {/* Thumb indicator — positioned within the 10px-inset dot range */}
         <div
-          className="absolute top-1/2 z-20 size-[24px] -translate-x-1/2 -translate-y-1/2 pointer-events-none"
+          className="absolute top-1/2 z-20 size-[20px] -translate-x-1/2 -translate-y-1/2 pointer-events-none"
           style={{ left: `calc(10px + ${clamped}% * (100% - 20px) / 100%)` }}
         >
-          <div className="size-full rounded-[var(--cornerRound)] border-[2px] border-[var(--bgBrand)] bg-[var(--bgSurfaceRaised)] drop-shadow-[0_8px_12px_rgba(0,0,0,0.06)]" />
+          <div className="size-full rounded-[var(--cornerRound)] border-[2px] border-[var(--borderBrand)] bg-[var(--bgSurfaceRaised)] drop-shadow-[0_8px_12px_rgba(0,0,0,0.06)]" />
         </div>
       </div>
 
@@ -132,18 +132,27 @@ function ProgressBar({ className, value = 0, onChange, "aria-label": ariaLabel, 
   );
 }
 
-function TrackDots() {
+function TrackDots({ value }: { value: number }) {
+  const step = 100 / STEPS;
   return (
     <div className="absolute inset-x-[10px] top-1/2 z-10 flex -translate-y-1/2 items-center justify-between">
-      {Array.from({ length: DOT_COUNT }, (_, i) => (
-        <div
-          key={i}
-          className={cn(
-            "shrink-0 rounded-[var(--cornerRound)] bg-[var(--bgSurfaceSunken)]",
-            i === MIDPOINT ? "h-1.5 w-px" : "size-0.5"
-          )}
-        />
-      ))}
+      {Array.from({ length: DOT_COUNT }, (_, i) => {
+        const isMidpoint = i === MIDPOINT;
+        // Dots within the filled (black) portion use the brand-hover color;
+        // dots over the unfilled (gray) track use the sunken color. The center
+        // midpoint line always stays sunken, even when the fill passes it.
+        const filled = !isMidpoint && i * step < value;
+        return (
+          <div
+            key={i}
+            className={cn(
+              "shrink-0 rounded-[var(--cornerRound)]",
+              filled ? "bg-[var(--bgBrandHover)]" : "bg-[var(--bgSurfaceSunken)]",
+              isMidpoint ? "h-1.5 w-px" : "size-0.5"
+            )}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/tauri-app/src/app/components/Toggle.tsx
+++ b/tauri-app/src/app/components/Toggle.tsx
@@ -60,7 +60,7 @@ function Toggle({
       {/* Thumb */}
       <span
         className={cn(
-          "pointer-events-none size-4 shrink-0 rounded-full bg-[var(--bgSurfaceRaised)] shadow-[0px_4px_8px_0px_rgba(0,0,0,0.02)] transition-transform duration-150",
+          "pointer-events-none size-4 shrink-0 rounded-full bg-[var(--bgSurfaceOverlay)] shadow-[var(--shadow-card)] transition-transform duration-150",
           checked ? "translate-x-4" : "translate-x-0"
         )}
       />

--- a/tauri-app/src/app/tokens-dark.css
+++ b/tauri-app/src/app/tokens-dark.css
@@ -68,4 +68,13 @@
   --borderSuccessDarker: #067647;
   --gradientStops1: #f0f1f1;
   --gradientStops2: #ececed;
+  --componentKeycapsGradientStops1: #f0f1f1;
+  --componentKeycapsGradientStops2: #ececed;
+  --componentKeycapsBg: #cecfd2;
+  --componentKeycapsText: #0c111d;
+  --componentTabsBg: #1f242f;
+  --componentTabsActiveBg: #0c111d;
+  --componentTabsActiveForeground: #fafafa;
+  --componentTabsInactiveForeground: #94969c;
+  --componentTabsBorder: #5f61694d;
 }

--- a/tauri-app/src/app/tokens.css
+++ b/tauri-app/src/app/tokens.css
@@ -144,6 +144,15 @@
   --borderSuccessDarker: #067647;
   --gradientStops1: #404040;
   --gradientStops2: #303030;
+  --componentKeycapsGradientStops1: #404040;
+  --componentKeycapsGradientStops2: #303030;
+  --componentKeycapsBg: #0c111d;
+  --componentKeycapsText: #ffffff;
+  --componentTabsBg: #ececed;
+  --componentTabsActiveBg: #ffffff;
+  --componentTabsActiveForeground: #0c111d;
+  --componentTabsInactiveForeground: #61646c;
+  --componentTabsBorder: #cecfd280;
   --spacingXxxxs: 2px;
   --spacingS: 12px;
   --spacingXxl: 32px;

--- a/tauri-app/src/tokens/tokens.json
+++ b/tauri-app/src/tokens/tokens.json
@@ -1737,6 +1737,108 @@
         "$type": "color",
         "$value": "#303030"
       }
+    },
+    "Component": {
+      "Keycaps": {
+        "Gradient Stops": {
+          "1": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "#404040"
+          },
+          "2": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "#303030"
+          }
+        },
+        "BG": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.hiddenFromPublishing": false
+          },
+          "$type": "color",
+          "$value": "{Gray.950}"
+        },
+        "Text": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "TEXT_FILL"
+            ],
+            "com.figma.hiddenFromPublishing": false
+          },
+          "$type": "color",
+          "$value": "{Plain.White}"
+        }
+      },
+      "Tabs": {
+        "BG": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.hiddenFromPublishing": false
+          },
+          "$type": "color",
+          "$value": "{Gray.200}"
+        },
+        "Active": {
+          "BG": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "{Plain.White}"
+          },
+          "Foreground": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "{Gray.950}"
+          }
+        },
+        "Inactive": {
+          "Foreground": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "{Gray.600}"
+          }
+        },
+        "Border": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.hiddenFromPublishing": false
+          },
+          "$type": "color",
+          "$value": "#cecfd280"
+        }
+      }
     }
   },
   "Colors/Dark": {
@@ -2460,6 +2562,108 @@
         },
         "$type": "color",
         "$value": "#ececed"
+      }
+    },
+    "Component": {
+      "Keycaps": {
+        "Gradient Stops": {
+          "1": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "#f0f1f1"
+          },
+          "2": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "#ececed"
+          }
+        },
+        "BG": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.hiddenFromPublishing": false
+          },
+          "$type": "color",
+          "$value": "{Gray.300}"
+        },
+        "Text": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "TEXT_FILL"
+            ],
+            "com.figma.hiddenFromPublishing": false
+          },
+          "$type": "color",
+          "$value": "{Gray.950}"
+        }
+      },
+      "Tabs": {
+        "BG": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.hiddenFromPublishing": false
+          },
+          "$type": "color",
+          "$value": "{Gray.800}"
+        },
+        "Active": {
+          "BG": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "{Gray.950}"
+          },
+          "Foreground": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "{Gray.25}"
+          }
+        },
+        "Inactive": {
+          "Foreground": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ],
+              "com.figma.hiddenFromPublishing": false
+            },
+            "$type": "color",
+            "$value": "{Gray.400}"
+          }
+        },
+        "Border": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.hiddenFromPublishing": false
+          },
+          "$type": "color",
+          "$value": "#5f61694d"
+        }
       }
     }
   },

--- a/tauri-app/storybook-host/package.json
+++ b/tauri-app/storybook-host/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "storybook-host",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "http-server . -p $PORT --silent"
+  },
+  "dependencies": {
+    "http-server": "^14.1.1"
+  }
+}

--- a/tauri-app/storybook-host/railway.json
+++ b/tauri-app/storybook-host/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS"
+  },
+  "deploy": {
+    "startCommand": "npm start",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## Summary

Wires the DS components up to the new dedicated component tokens and refreshes ProgressBar/Toggle to match the latest Figma specs. Also fixes the token pipeline so component-category tokens are emitted into the dark theme.

## Changes

**Components**
- **NavigationTabs** — migrated to `--componentTabs*` tokens (bg, border, active bg/foreground, inactive foreground); active shadow uses the `--shadow-card` token; removed the unused `iconOnly` variant.
- **Keycap** — migrated to `--componentKeycaps*` tokens (bg, gradient stops, text).
- **Toggle** — thumb now uses `--bgSurfaceOverlay` (stays white in dark mode) and the `--shadow-card` token.
- **ProgressBar** — thinner 8px track (was 12px) and smaller 20px thumb (was 24px); thumb ring uses `--borderBrand`; dots are now two-tone (`--bgBrandHover` over the filled portion, `--bgSurfaceSunken` over the track) with the center midpoint line always staying sunken.

**Tokens**
- Added dedicated `Component/*` tokens (Tabs, Keycaps) for light and dark in `tokens.json`.
- Fixed `sd.config.js` `darkTokenFilter` to emit the `component` category into `tokens-dark.css` (previously only `text/bg/icon/border/gradient/plain` were included, so component tokens silently fell back to light values in dark mode). Rebuilt `tokens.css` / `tokens-dark.css`.

**Tooling**
- Added Storybook deploy script (`scripts/deploy-storybook.cjs`) and `storybook-host/` config.

## Testing
- Verified in Storybook in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
