### PR TITLE
chore: release 2.2.2

### DIFF
--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleanmeter",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.2.2",
   "type": "module",
   "scripts": {
     "build:tokens": "node sd.config.js",

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "cleanmeter"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "byteorder",
  "dirs",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cleanmeter"
-version = "2.2.1"
+version = "2.2.2"
 description = "Gaming performance overlay"
 authors = ["Cleanmeter"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui/toolkits/refs/heads/main/tauri/schema.json",
   "productName": "Cleanmeter",
   "identifier": "com.cleanmeter.desktop",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump 2.2.1 -> 2.2.2 across package.json, tauri.conf.json, Cargo.toml, Cargo.lock.

Ships the changes already merged to main since the 2.2.1 release:
- Overlay custom-position clamp fix (PR #14 branch follow-up)
- Cleanmeter rebrand + Settings dark mode + gated features (#14)
- DS component-token migration + ProgressBar/Toggle refresh (#15)

Tagging v2.2.2 after merge triggers the release workflow.