### PR TITLE
Fix feedback attachments: image mime, Figma chip icon, CI release config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,10 +141,30 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw "signtool failed for $exe" }
           }
 
+      - name: Ensure feedback secrets on tagged releases
+        # Feedback config is compile-time (option_env!) — a missing secret
+        # doesn't fail the build, it silently ships a release that errors
+        # "feedback portal not configured" on every submit. Fail loudly for
+        # tags; workflow_dispatch dev builds may still build without them.
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: pwsh
+        env:
+          FEEDBACK_PORTAL_URL: ${{ secrets.FEEDBACK_PORTAL_URL }}
+          FEEDBACK_WRITE_KEY: ${{ secrets.FEEDBACK_WRITE_KEY }}
+        run: |
+          if (-not $env:FEEDBACK_PORTAL_URL -or -not $env:FEEDBACK_WRITE_KEY) {
+            throw "FEEDBACK_PORTAL_URL / FEEDBACK_WRITE_KEY secrets are missing - a tagged release must ship with feedback enabled."
+          }
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Compile-time (option_env!) config for the in-app feedback command.
+          # Without these the release builds with feedback disabled
+          # ("feedback portal not configured" on every submit).
+          FEEDBACK_PORTAL_URL: ${{ secrets.FEEDBACK_PORTAL_URL }}
+          FEEDBACK_WRITE_KEY: ${{ secrets.FEEDBACK_WRITE_KEY }}
           # Tauri's signCommand reads this thumbprint to sign the
           # installer + main exe via the cert imported in the step above.
           # When unset (no cert configured / non-Windows), the signCommand

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleanmeter",
   "private": true,
-  "version": "2.2.3",
+  "version": "2.2.4",
   "type": "module",
   "scripts": {
     "build:tokens": "node sd.config.js",

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "cleanmeter"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "byteorder",
  "dirs",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cleanmeter"
-version = "2.2.3"
+version = "2.2.4"
 description = "Gaming performance overlay"
 authors = ["Cleanmeter"]
 edition = "2021"

--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -391,12 +391,33 @@ pub async fn submit_feedback(input: FeedbackInput) -> Result<(), String> {
         let bytes = tokio::fs::read(path)
             .await
             .map_err(|e| format!("read attachment: {e}"))?;
-        let filename = std::path::Path::new(path)
+        let file_path = std::path::Path::new(path);
+        let filename = file_path
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("attachment")
             .to_string();
-        let part = reqwest::multipart::Part::bytes(bytes).file_name(filename);
+        // The portal validates the part's content type against an image
+        // allowlist; reqwest defaults to application/octet-stream, so the
+        // mime must be set explicitly (extensions per pickImageAttachment).
+        let mime = match file_path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .as_deref()
+        {
+            Some("png") => "image/png",
+            Some("jpg") | Some("jpeg") => "image/jpeg",
+            Some("webp") => "image/webp",
+            Some("gif") => "image/gif",
+            // The portal would reject anything else anyway (opaque 400);
+            // fail fast with an actionable message instead.
+            _ => return Err("attachment must be a png, jpg, webp, or gif image".to_string()),
+        };
+        let part = reqwest::multipart::Part::bytes(bytes)
+            .file_name(filename)
+            .mime_str(mime)
+            .map_err(|e| format!("attachment mime: {e}"))?;
         form = form.part("attachment", part);
     }
 

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui/toolkits/refs/heads/main/tauri/schema.json",
   "productName": "Cleanmeter",
   "identifier": "com.cleanmeter.desktop",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",

--- a/tauri-app/src/components/settings/settings/FeedbackDialog.tsx
+++ b/tauri-app/src/components/settings/settings/FeedbackDialog.tsx
@@ -26,6 +26,18 @@ function CloseIcon({ className }: { className?: string }) {
   );
 }
 
+// File icon — Figma 2488:6236 (Material "description", 20×20, #1C1B1F — no token).
+function DescriptionIcon({ className }: { className?: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" className={className} aria-hidden>
+      <path
+        d="M7.5 15H12.5C12.7361 15 12.934 14.9201 13.0938 14.7604C13.2535 14.6007 13.3333 14.4028 13.3333 14.1667C13.3333 13.9306 13.2535 13.7326 13.0938 13.5729C12.934 13.4132 12.7361 13.3333 12.5 13.3333H7.5C7.26389 13.3333 7.06597 13.4132 6.90625 13.5729C6.74653 13.7326 6.66667 13.9306 6.66667 14.1667C6.66667 14.4028 6.74653 14.6007 6.90625 14.7604C7.06597 14.9201 7.26389 15 7.5 15ZM7.5 11.6667H12.5C12.7361 11.6667 12.934 11.5868 13.0938 11.4271C13.2535 11.2674 13.3333 11.0694 13.3333 10.8333C13.3333 10.5972 13.2535 10.3993 13.0938 10.2396C12.934 10.0799 12.7361 10 12.5 10H7.5C7.26389 10 7.06597 10.0799 6.90625 10.2396C6.74653 10.3993 6.66667 10.5972 6.66667 10.8333C6.66667 11.0694 6.74653 11.2674 6.90625 11.4271C7.06597 11.5868 7.26389 11.6667 7.5 11.6667ZM5 18.3333C4.54167 18.3333 4.14931 18.1701 3.82292 17.8437C3.49653 17.5174 3.33333 17.125 3.33333 16.6667V3.33333C3.33333 2.875 3.49653 2.48264 3.82292 2.15625C4.14931 1.82986 4.54167 1.66667 5 1.66667H10.9792C11.2014 1.66667 11.4132 1.70833 11.6146 1.79167C11.816 1.875 11.9931 1.99306 12.1458 2.14583L16.1875 6.1875C16.3403 6.34028 16.4583 6.51736 16.5417 6.71875C16.625 6.92014 16.6667 7.13194 16.6667 7.35417V16.6667C16.6667 17.125 16.5035 17.5174 16.1771 17.8437C15.8507 18.1701 15.4583 18.3333 15 18.3333H5ZM10.8333 6.66667V3.33333H5V16.6667H15V7.5H11.6667C11.4306 7.5 11.2326 7.42014 11.0729 7.26042C10.9132 7.10069 10.8333 6.90278 10.8333 6.66667Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
 // Add icon — Figma 2488:6010 (Material "add", 20×20).
 function PlusIcon({ className }: { className?: string }) {
   return (
@@ -146,19 +158,26 @@ export function FeedbackDialog({
               />
             </div>
 
-            {/* Attachment chip (shown once a file is picked) */}
+            {/* Attachment chip (shown once a file is picked) — Figma 2488:6214:
+                Input shell (h-40, 12px padding, 8px radius, borderBolder) with
+                description icon + filename + remove ✕. */}
             {attachment && (
-              <div className="flex items-center justify-between gap-2 rounded-[var(--cornerL)] border border-[var(--borderBolder)] px-3 py-2">
-                <span className="truncate text-body-sm-medium text-[var(--textHeading)]">
-                  {attachment.name}
-                </span>
+              <div className="flex h-10 items-center gap-[var(--spacingXxs)] rounded-[var(--cornerL)] border border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] p-[var(--spacingS)]">
+                <div className="flex min-w-0 flex-1 items-center gap-[var(--spacingXs)]">
+                  {/* #1C1B1F has no token (Figma literal) and won't adapt —
+                      follow the adjacent filename color in dark mode. */}
+                  <DescriptionIcon className="size-5 shrink-0 text-[#1C1B1F] dark:text-[var(--textHeading)]" />
+                  <span className="truncate text-body-sm-medium text-[var(--textHeading)]">
+                    {attachment.name}
+                  </span>
+                </div>
                 <button
                   type="button"
                   aria-label="Remove attachment"
                   onClick={() => setAttachment(null)}
                   className="flex size-5 shrink-0 items-center justify-center rounded-[4px] text-[var(--iconBolderActive)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
-                  <CloseIcon className="size-4" />
+                  <CloseIcon className="size-5" />
                 </button>
               </div>
             )}

--- a/tauri-app/src/components/settings/settings/FeedbackDialog.tsx
+++ b/tauri-app/src/components/settings/settings/FeedbackDialog.tsx
@@ -159,8 +159,8 @@ export function FeedbackDialog({
             </div>
 
             {/* Attachment chip (shown once a file is picked) — Figma 2488:6214:
-                Input shell (h-40, 12px padding, 8px radius, borderBolder) with
-                description icon + filename + remove ✕. */}
+                Input shell (40px height, 12px padding, 8px radius, borderBolder)
+                with description icon + filename + remove ✕. */}
             {attachment && (
               <div className="flex h-10 items-center gap-[var(--spacingXxs)] rounded-[var(--cornerL)] border border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] p-[var(--spacingS)]">
                 <div className="flex min-w-0 flex-1 items-center gap-[var(--spacingXs)]">


### PR DESCRIPTION
## What

- **fix(feedback):** attachment uploads always failed with 400 — the reqwest multipart part had no content type, so the portal's image allowlist rejected `application/octet-stream`. The mime is now derived from the file extension (same set the picker filters: png/jpg/jpeg/webp/gif); anything else fails fast with a clear error instead of an opaque portal 400.
- **fix(settings):** attachment chip now matches Figma 2488:6012 — added the missing description file icon (node 2488:6236) and aligned the chip to the input shell (h-40, 12px padding, token gaps, 20px remove icon). The icon hex (#1C1B1F) has no token, so dark mode follows the adjacent filename color.
- **ci:** tagged release builds now receive `FEEDBACK_PORTAL_URL`/`FEEDBACK_WRITE_KEY` (repo secrets, already set) and fail loudly if either is missing — `option_env!` would otherwise silently ship a release with feedback disabled.
- **chore:** version bump 2.2.3 → 2.2.4.

## Verification

- E2E on the live portal: app-invoked `submit_feedback` with a PNG → 201, row + thumbnail visible, streamed-back attachment hash-matches the original. Negative proof: same file as `application/octet-stream` → 400.
- Chip verified against Figma in Storybook (icon + filename + remove, input-shell metrics).
- `cargo check` and `tsc --noEmit` clean. Workflow YAML validated; the guard only runs on `refs/tags/*` so `workflow_dispatch` dev builds still build without secrets.