### PR TITLE
Pixel Shift: nudge overlay to mitigate OLED burn-in

### DIFF
--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -345,6 +345,12 @@ pub struct OverlaySettings {
     pub polling_rate: u64,
     #[serde(rename = "isLoggingEnabled")]
     pub is_logging_enabled: bool,
+    // Burn-in mitigation: when true the overlay is nudged a few pixels on a
+    // slow cycle (applied entirely on the JS side). `default` keeps older save
+    // files loading cleanly. Must live here or serde drops it on save (see the
+    // struct comment above).
+    #[serde(rename = "pixelShift", default)]
+    pub pixel_shift: bool,
     pub sensors: SensorsConfig,
 }
 
@@ -375,6 +381,7 @@ impl Default for OverlaySettings {
             label_font_weight: 500,
             polling_rate: 500,
             is_logging_enabled: false,
+            pixel_shift: false,
             sensors: SensorsConfig::default(),
         }
     }

--- a/tauri-app/src/OverlayApp.tsx
+++ b/tauri-app/src/OverlayApp.tsx
@@ -75,6 +75,11 @@ export default function OverlayApp() {
   >(null);
   const [monitors, setMonitors] = useState<MonitorInfo[]>([]);
   const [isDragging, setIsDragging] = useState(false);
+  // Pixel Shift: current nudge offset (physical px) and a handle to re-run the
+  // positioning pass. The offset is folded into apply() only — never persisted —
+  // so the saved position can never accumulate drift.
+  const pixelShiftOffset = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const applyPositionRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     document.documentElement.style.background = "transparent";
@@ -149,9 +154,19 @@ export default function OverlayApp() {
         x = p.x;
         y = p.y;
       }
+      // Pixel Shift nudge. Re-clamp after offsetting so a shifted HUD can never
+      // leave the monitor — at a corner anchor the outward side simply clips,
+      // which keeps the motion biased inward.
+      const off = pixelShiftOffset.current;
+      if (off.x !== 0 || off.y !== 0) {
+        const shifted = clampToMonitor(x + off.x, y + off.y, hudW, hudH, monitor);
+        x = shifted.x;
+        y = shifted.y;
+      }
       setOverlayPosition(x, y);
     };
 
+    applyPositionRef.current = apply;
     apply();
     const ro = new ResizeObserver(apply);
     ro.observe(el);
@@ -167,6 +182,42 @@ export default function OverlayApp() {
     settings.positionIndex,
     monitors,
   ]);
+
+  // Pixel Shift — slowly nudge the HUD a few pixels to spread OLED wear. The
+  // offset follows a Lissajous path (incommensurate X/Y frequencies) so it
+  // fills a small box over time rather than cycling the same handful of points.
+  // Each tick moves <=1px, which is imperceptible; the offset is applied only
+  // through apply()/applyPositionRef, so the persisted position never changes.
+  useEffect(() => {
+    const resetOffset = () => {
+      if (pixelShiftOffset.current.x !== 0 || pixelShiftOffset.current.y !== 0) {
+        pixelShiftOffset.current = { x: 0, y: 0 };
+        applyPositionRef.current();
+      }
+    };
+    if (!settings.pixelShift) {
+      resetOffset();
+      return;
+    }
+    const AMPLITUDE = 6; // logical px per axis (12px span), scaled by DPI below
+    const TICK_MS = 3000; // one small step every 3s
+    const D_PHASE = 0.1; // keeps each step <=1px at this amplitude
+    const RATIO = Math.SQRT2; // incommensurate -> path fills the box over time
+    let phase = 0;
+    const id = setInterval(() => {
+      // Never fight an in-progress drag (apply() also early-returns then).
+      if (dragStart.current) return;
+      phase += D_PHASE;
+      const dpr = window.devicePixelRatio || 1;
+      const nx = Math.round(AMPLITUDE * Math.sin(phase) * dpr);
+      const ny = Math.round(AMPLITUDE * Math.sin(phase * RATIO) * dpr);
+      if (nx !== pixelShiftOffset.current.x || ny !== pixelShiftOffset.current.y) {
+        pixelShiftOffset.current = { x: nx, y: ny };
+        applyPositionRef.current();
+      }
+    }, TICK_MS);
+    return () => clearInterval(id);
+  }, [settings.pixelShift]);
 
   // Manual drag. startDragging() needed an async dynamic import that lost the
   // button-down window on Windows before WM_NCLBUTTONDOWN could post, so drag

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -47,6 +47,8 @@ function SectionCard({
 function GeneralSection() {
   const startMinimized = useSettingsStore((s) => s.preferences.startMinimized);
   const updatePreferences = useSettingsStore((s) => s.updatePreferences);
+  const pixelShift = useSettingsStore((s) => s.settings.pixelShift);
+  const updateSettings = useSettingsStore((s) => s.updateSettings);
   const [startWithWindows, setStartWithWindows] = React.useState(false);
   // Rapid toggles fire concurrent setAutoStart calls that can resolve out
   // of order, leaving the checkbox out of sync with the OS registry.
@@ -68,12 +70,6 @@ function GeneralSection() {
       .catch(() => setStartWithWindows(!enabled))
       .finally(() => setAutoStartPending(false));
   };
-
-  // Pixel Shift — UI only for now. Local state so the toggle is interactive;
-  // not yet persisted or applied to the overlay.
-  // TODO: replace with API data — wire to a persisted pixelShift setting and
-  // the overlay shift behavior (see docs wiring plan).
-  const [pixelShift, setPixelShift] = React.useState(false);
 
   return (
     <SectionCard title="General">
@@ -112,7 +108,7 @@ function GeneralSection() {
           </div>
           <Switch
             checked={pixelShift}
-            onCheckedChange={setPixelShift}
+            onCheckedChange={(v) => updateSettings({ pixelShift: v })}
             aria-label="Pixel Shift"
           />
         </div>

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { Checkbox } from "@/components/shadcn/checkbox";
 import { RadioGroup } from "@/components/shadcn/radio-group";
+import { Switch } from "@/components/shadcn/switch";
 import {
   Select,
   SelectContent,
@@ -17,6 +18,7 @@ import type { TemperatureUnit } from "@/lib/types";
 import {
   BrowserUpdatedIcon,
   ChevronRightIcon,
+  ComputerIcon,
   DiscordIcon,
   InfoIcon,
   ThemePreviewDark,
@@ -67,26 +69,53 @@ function GeneralSection() {
       .finally(() => setAutoStartPending(false));
   };
 
+  // Pixel Shift — UI only for now. Local state so the toggle is interactive;
+  // not yet persisted or applied to the overlay.
+  // TODO: replace with API data — wire to a persisted pixelShift setting and
+  // the overlay shift behavior (see docs wiring plan).
+  const [pixelShift, setPixelShift] = React.useState(false);
+
   return (
     <SectionCard title="General">
-      <div className="flex flex-col gap-3">
-        <label className="flex cursor-pointer items-center gap-2 text-[14px] font-medium text-foreground">
-          <Checkbox
-            checked={startWithWindows}
-            disabled={autoStartPending}
-            onCheckedChange={(v) => handleStartWithWindows(v === true)}
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-3">
+          <label className="flex cursor-pointer items-center gap-2 text-[14px] font-medium text-foreground">
+            <Checkbox
+              checked={startWithWindows}
+              disabled={autoStartPending}
+              onCheckedChange={(v) => handleStartWithWindows(v === true)}
+            />
+            Start with windows
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-[14px] font-medium text-foreground">
+            <Checkbox
+              checked={startMinimized}
+              onCheckedChange={(v) =>
+                updatePreferences({ startMinimized: v === true })
+              }
+            />
+            Start minimized
+          </label>
+        </div>
+        <div className="h-px w-full bg-[var(--borderSubtle)]" />
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-[100px] border border-[var(--borderBold)] bg-[var(--bgSurfaceRaised)]">
+            <ComputerIcon className="size-5 text-[var(--textParagraph1)]" />
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-[6px]">
+            <span className="text-[14px] font-medium text-[var(--textHeading)]">
+              Pixel Shift
+            </span>
+            <span className="text-[14px] font-normal text-[var(--textParagraph1)]">
+              Shifts the overlay periodically to avoid OLED burn-in.
+            </span>
+          </div>
+          <Switch
+            checked={pixelShift}
+            onCheckedChange={setPixelShift}
+            aria-label="Pixel Shift"
           />
-          Start with windows
-        </label>
-        <label className="flex cursor-pointer items-center gap-2 text-[14px] font-medium text-foreground">
-          <Checkbox
-            checked={startMinimized}
-            onCheckedChange={(v) =>
-              updatePreferences({ startMinimized: v === true })
-            }
-          />
-          Start minimized
-        </label>
+        </div>
       </div>
     </SectionCard>
   );

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -339,10 +339,7 @@ function FeedbackPrompt() {
     <section className="flex w-full items-center justify-between gap-3 rounded-[12px] bg-[var(--bgSurfaceRaised)] p-5">
       <div className="flex flex-col gap-[6px]">
         <span className="text-body-sm-medium text-[var(--textHeading)]">
-          Encountered an issue or have suggestions?
-        </span>
-        <span className="text-body-sm-regular text-[var(--textParagraph2)]">
-          We&apos;d love to hear from you!
+          Have an issue or suggestions? We want to hear!
         </span>
       </div>
       <button
@@ -389,7 +386,7 @@ export function SettingsTab() {
           />
         </div>
         <div className="flex items-center justify-between text-[12px] font-medium text-subtle-foreground">
-          <span>Built by Crispy Studio</span>
+          <span>Built by Team Crispy</span>
           <span>Version v{appVersion} beta</span>
         </div>
       </div>

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -95,7 +95,7 @@ function GeneralSection() {
         </div>
         <div className="h-px w-full bg-[var(--borderSubtle)]" />
         <div className="flex items-center gap-3">
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-[100px] border border-[var(--borderBold)] bg-[var(--bgSurfaceRaised)]">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-[var(--cornerRound)] border border-[var(--borderBold)] bg-[var(--bgSurfaceRaised)]">
             <ComputerIcon className="size-5 text-[var(--textParagraph1)]" />
           </div>
           <div className="flex min-w-0 flex-1 flex-col gap-[6px]">

--- a/tauri-app/src/components/settings/settings/icons.tsx
+++ b/tauri-app/src/components/settings/settings/icons.tsx
@@ -91,6 +91,39 @@ export function BrowserUpdatedIcon({ className }: IconProps) {
   );
 }
 
+// Computer / monitor icon — Figma node 2524:5178 (Pixel Shift row). 20px,
+// 1.5 stroke in currentColor. Geometry copied verbatim from the Figma export
+// (viewBox kept at the source 18.1667 units so paths stay exact).
+export function ComputerIcon({ className }: IconProps) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 18.1667 18.1667"
+      fill="none"
+      className={className}
+      aria-hidden
+    >
+      <g stroke="currentColor" strokeWidth="1.5">
+        <path
+          d="M10.75 0.75H7.41667C4.68398 0.75 3.31763 0.75 2.34909 1.42818C1.99076 1.67909 1.67909 1.99076 1.42818 2.34909C0.75 3.31763 0.75 4.68398 0.75 7.41667C0.75 10.1494 0.75 11.5157 1.42818 12.4842C1.67909 12.8426 1.99076 13.1542 2.34909 13.4052C3.31763 14.0833 4.68398 14.0833 7.41667 14.0833H10.75C13.4827 14.0833 14.849 14.0833 15.8176 13.4052C16.1759 13.1542 16.4876 12.8426 16.7385 12.4842C17.4167 11.5157 17.4167 10.1494 17.4167 7.41667C17.4167 4.68398 17.4167 3.31763 16.7385 2.34909C16.4876 1.99076 16.1759 1.67909 15.8176 1.42818C14.849 0.75 13.4827 0.75 10.75 0.75Z"
+          strokeLinecap="round"
+        />
+        <path
+          d="M8.25 11.5833H9.91667"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M11.1667 17.4167L10.9038 17.0676C10.3111 16.2807 10.1641 15.0787 10.539 14.0833M7 17.4167L7.26292 17.0676C7.85561 16.2807 8.00255 15.0787 7.62769 14.0833"
+          strokeLinecap="round"
+        />
+        <path d="M4.91667 17.4167H13.25" strokeLinecap="round" />
+      </g>
+    </svg>
+  );
+}
+
 // Info icon — Figma node 2075:8803 (Material Symbols rounded filled, 16px).
 export function InfoIcon({ className }: IconProps) {
   return (

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -107,6 +107,9 @@ export interface OverlaySettings {
   labelFontWeight: number;
   pollingRate: number;
   isLoggingEnabled: boolean;
+  // When true, the overlay is nudged a few pixels on a slow cycle to spread
+  // OLED wear (burn-in mitigation). See pixel-shift logic in OverlayApp.
+  pixelShift: boolean;
   sensors: SensorsConfig;
 }
 
@@ -185,6 +188,7 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   labelFontWeight: 500,
   pollingRate: 500,
   isLoggingEnabled: false,
+  pixelShift: false,
   sensors: {
     framerate: { isEnabled: true, customReadingId: "", targetAppName: "" },
     frametime: { isEnabled: true, customReadingId: "" },


### PR DESCRIPTION
**Feature: Pixel Shift** (Settings → General)

## Summary

Adds a **Pixel Shift** setting (Settings → General) that periodically nudges the overlay a few pixels to mitigate OLED burn-in. The HUD is static and always-on, which is a classic burn-in risk; shifting it spreads the load across more subpixels while staying imperceptible.

## Changes

- **UI:** New Pixel Shift row in the General section (monitor icon, title, description, switch), matching Figma. Icon is an inline SVG.
- **Setting:** `pixelShift` added to `OverlaySettings` (TS interface + defaults) and the Rust struct/`Default` (required so serde does not drop it on the save round-trip). Defaults to `false`.
- **Behavior:** When enabled, the overlay position is offset along a slow Lissajous path (amplitude ±6 logical px, 1px steps every ~3s). The offset is folded into the existing positioning pass and re-clamped to the monitor, so:
  - the saved position never changes (no drift),
  - the HUD can never move off-screen (corner anchors clip inward),
  - it applies in preset, custom, and locked positions, and is skipped during drag.
- No new Tauri command; reuses `set_overlay_position`.

## Testing

- `tsc`, ESLint, `cargo check` — clean
- `vite build` and full `tauri build` (release) — pass; NSIS installer produced
- Runtime: launched the release build with the setting on; overlay nudges a few px and returns to base (no drift), verified by sampling the window position over time
- Backward compatibility: existing `settings.json` without `pixelShift` loads correctly (defaults to off)
- Dark mode: icon and row render correctly (tokens resolve to dark values)