### PR TITLE
fix(updater): stop sidecar before installing an update

### DIFF
--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -18,6 +18,54 @@ pub fn ui_debug_log(msg: String) {
     }
 }
 
+/// Tear down the HardwareMonitor sidecar before an in-app update installs.
+///
+/// The sidecar (and PresentMon) keep `HardwareMonitor.exe` / `presentmon.exe`
+/// open, and the supervisor in `lib.rs` respawns the sidecar within ~1s of it
+/// dying — so the updater's NSIS installer failed with "Error opening file for
+/// writing" when it tried to overwrite those files. Stop the supervisor first
+/// (so it can't respawn), then kill the processes and wait briefly for Windows
+/// to release the handles. Mirrors the Quit/exit teardown without exiting, so
+/// the updater can replace the files and relaunch.
+#[tauri::command]
+pub async fn prepare_for_update(app: AppHandle) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    // Stop the supervisor loop so it won't respawn the sidecar we're killing.
+    if let Some(running) = app.try_state::<std::sync::Arc<AtomicBool>>() {
+        running.store(false, Ordering::Relaxed);
+    }
+    #[cfg(windows)]
+    {
+        // taskkill + the handle-release wait block, so run them off the async
+        // runtime and await completion before the installer starts.
+        let app = app.clone();
+        let _ = tauri::async_runtime::spawn_blocking(move || {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            // Kill the tracked child first (graceful), then any strays.
+            if let Some(slot) = app
+                .try_state::<std::sync::Arc<std::sync::Mutex<Option<std::process::Child>>>>()
+            {
+                if let Ok(mut guard) = slot.lock() {
+                    if let Some(mut child) = guard.take() {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                    }
+                }
+            }
+            for image in ["HardwareMonitor.exe", "presentmon.exe"] {
+                let _ = std::process::Command::new("taskkill")
+                    .args(["/f", "/im", image])
+                    .creation_flags(CREATE_NO_WINDOW)
+                    .status();
+            }
+            // Let the OS release the file handles before the installer overwrites.
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        })
+        .await;
+    }
+}
+
 fn now_ms() -> u128 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -437,6 +437,7 @@ pub fn run() {
             commands::launch_hardware_monitor,
             commands::ui_debug_log,
             commands::submit_feedback,
+            commands::prepare_for_update,
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application")

--- a/tauri-app/src/lib/tauri.ts
+++ b/tauri-app/src/lib/tauri.ts
@@ -106,6 +106,15 @@ export const relaunchApp = async (): Promise<void> => {
   await relaunch();
 };
 
+// Stop the HardwareMonitor sidecar (+ PresentMon) and its supervisor so the
+// updater's installer can overwrite their files. Without this the running
+// sidecar holds HardwareMonitor.exe open and the install fails. Must be awaited
+// before downloadAndInstall.
+export const prepareForUpdate = async (): Promise<void> => {
+  if (isBrowser) return;
+  await safeInvoke("prepare_for_update");
+};
+
 // ─── Event Listeners ────────────────────────────────────────────
 
 export const onSensorData = (

--- a/tauri-app/src/stores/updater-store.ts
+++ b/tauri-app/src/stores/updater-store.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
-import { checkForUpdate, relaunchApp, type AppUpdate } from "@/lib/tauri";
+import {
+  checkForUpdate,
+  prepareForUpdate,
+  relaunchApp,
+  type AppUpdate,
+} from "@/lib/tauri";
 
 export type UpdaterStatus =
   | "idle" // no check run yet this session
@@ -81,6 +86,10 @@ export const useUpdaterStore = create<UpdaterStore>((set, get) => ({
     let downloaded = 0;
     let contentLength = 0;
     try {
+      // Kill the HardwareMonitor sidecar (+ PresentMon) and its supervisor
+      // first — a running sidecar holds its .exe open and the NSIS installer
+      // would fail to overwrite it ("Error opening file for writing").
+      await prepareForUpdate();
       await pendingUpdate.downloadAndInstall((event) => {
         switch (event.event) {
           case "Started":


### PR DESCRIPTION
## Summary

Fixes the in-app auto-updater failing to install with `Error opening file for writing: HardwareMonitor.exe`. The updater ran the installer while the `HardwareMonitor.exe` / `presentmon.exe` sidecars were still running, and the supervisor respawns the sidecar within ~1s of it dying, so the NSIS installer could never overwrite those files.

## Change

- New `prepare_for_update` command: stops the sidecar supervisor (so it cannot respawn) and kills `HardwareMonitor.exe` + `presentmon.exe`, with a brief wait for Windows to release the handles. Mirrors the Quit/exit teardown without exiting the app.
- `updater-store.ts` calls it via a `prepareForUpdate` wrapper immediately before `downloadAndInstall`.

## Testing

- `cargo check` and `tsc` clean; added lines lint-clean.
- Note: the fix runs in the *source* version performing the update, so end-to-end verification needs a fixed-version hop (install 2.2.7 -> publish 2.2.8 -> confirm clean in-app update).