### PR TITLE
feat(overlay): add bar graph option

### DIFF
--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -137,10 +137,21 @@ export default function App() {
       <div className="flex min-h-0 flex-1 flex-col gap-5 px-6 pb-6 pt-6">
         <TabNav activeTab={activeTab} onTabChange={setActiveTab} />
         <div className="min-h-0 flex-1 overflow-y-auto">
-          {activeTab === "stats" && <StatsTab />}
-          {activeTab === "style" && <StyleTab />}
-          {activeTab === "settings" && <SettingsTab />}
-          {activeTab === "help" && <HelpTab />}
+          {/* Tabs stay mounted and hide via CSS so local UI state (expanded
+              collapsibles, dropdowns, scroll targets) survives tab switches —
+              conditional rendering reset it all on every switch. */}
+          <div className={activeTab === "stats" ? "h-full" : "hidden"}>
+            <StatsTab />
+          </div>
+          <div className={activeTab === "style" ? "h-full" : "hidden"}>
+            <StyleTab />
+          </div>
+          <div className={activeTab === "settings" ? "h-full" : "hidden"}>
+            <SettingsTab />
+          </div>
+          <div className={activeTab === "help" ? "h-full" : "hidden"}>
+            <HelpTab />
+          </div>
         </div>
       </div>
     </div>

--- a/tauri-app/src/app/globals.css
+++ b/tauri-app/src/app/globals.css
@@ -213,3 +213,46 @@ body {
   color: var(--foreground);
   font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
 }
+
+/* ============================================================
+   Collapsible open/close — Radix measures the panel into
+   --radix-collapsible-content-height so height can tween between
+   two known values. ease-out both ways (user-initiated reveal),
+   exit faster than enter.
+   ============================================================ */
+@keyframes collapsible-down {
+  from {
+    height: 0;
+    opacity: 0;
+  }
+  to {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+  }
+}
+@keyframes collapsible-up {
+  from {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+  }
+  to {
+    height: 0;
+    opacity: 0;
+  }
+}
+/* Tailwind v4 tree-shakes animation utilities declared outside
+   @layer utilities. */
+@layer utilities {
+  .animate-collapsible-down {
+    animation: collapsible-down 200ms cubic-bezier(0.165, 0.84, 0.44, 1);
+  }
+  .animate-collapsible-up {
+    animation: collapsible-up 150ms cubic-bezier(0.165, 0.84, 0.44, 1);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .animate-collapsible-down,
+    .animate-collapsible-up {
+      animation: none;
+    }
+  }
+}

--- a/tauri-app/src/components/overlay/FpsSection.tsx
+++ b/tauri-app/src/components/overlay/FpsSection.tsx
@@ -41,38 +41,63 @@ export function FpsSection({ isHorizontal }: FpsSectionProps) {
 
   const fpsValue = Math.round(fpsSensor?.value ?? 0);
   const lastFrametime = frametimeHistory.length > 0 ? frametimeHistory[frametimeHistory.length - 1] : 0;
+  const showFrametime = frametime.isEnabled && frametimeHistory.length > 2;
 
-  return (
-    <Pill title="FPS" isHorizontal={isHorizontal}>
-      {framerate.isEnabled && (
-        <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
-          {formatValue(fpsValue)}
-        </span>
-      )}
-      {frametime.isEnabled && frametimeHistory.length > 2 && (
+  const valueText = framerate.isEnabled && (
+    <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
+      {formatValue(fpsValue)}
+    </span>
+  );
+
+  // Figma 2202:3261/3176/3173: "6.2 ms" is ONE text node at 12px / weight 500
+  // / letterSpacing +4% / opacity 0.7 at EVERY value-font step — the whole
+  // frametime reading (number included) tracks the LABEL font settings, not
+  // the Stats font, and both parts are muted.
+  const frametimeText = showFrametime && (
+    <span className="tabular-nums" style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "0.04em" }}>
+      {formatValue(lastFrametime, 1)} ms
+    </span>
+  );
+
+  if (isHorizontal) {
+    // Figma 2202:2664 (Frame 73): value, graph, and ms form ONE cluster with
+    // 6px gaps on both sides of the graph — tighter than the pill-level 12px
+    // cluster gap. The 100×7 band sits at y=9 of the 29-high row — 2px above
+    // flex-center (y=11) — so nudge the centered canvas up by that constant
+    // (the sweep only specifies font 24; the -2 is kept fixed across fonts).
+    return (
+      <Pill title="FPS" isHorizontal>
         <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-          {/* Figma 2202:2313 Frame 66 wraps a 100x7 vector — fixed dimensions
-              regardless of HUD size, vertically centered by the parent flex. */}
-          <FrametimeGraph
-            history={frametimeHistory}
-            width={isHorizontal ? 100 : 80}
-            height={isHorizontal ? 7 : 24}
-          />
-          {/* Figma 2202:2313 paints "6.2 ms" as one text node, so the value
-              and unit sit closer together than the graph↔value gap (6px).
-              Wrap in a sub-flex with gap-1 (4px) to match value↔unit spacing
-              used everywhere else (Figma value-unit Frame, gap=4). */}
-          {/* Figma 2202:2313 renders "6.2 ms" as ONE text node with node-opacity
-              0.7 — both the value and the unit are muted (unlike every other
-              value+unit pair in the HUD, where only the label is muted). */}
-          <div className="flex items-center gap-1">
-            <span className="tabular-nums" style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "-0.02em" }}>
-              {formatValue(lastFrametime, 1)}
-            </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "0.04em" }}>ms</span>
-          </div>
+          {valueText}
+          {showFrametime && (
+            <div style={{ position: "relative", top: -2 }}>
+              <FrametimeGraph history={frametimeHistory} width={100} />
+            </div>
+          )}
+          {frametimeText}
         </div>
-      )}
+      </Pill>
+    );
+  }
+
+  // Figma 2202:3255 (Frame 80 + 81): the value row holds "120" and "6.2 ms"
+  // at the pill's regular 12px gap, and the graph gets its own full-width
+  // 24px row below (band offset 6 from the row top, per the 134×24 frame
+  // wrapping a 134×7 vector).
+  return (
+    <Pill
+      title="FPS"
+      isHorizontal={false}
+      graphRow={
+        showFrametime && (
+          <div style={{ height: 24, paddingTop: 6 }}>
+            <FrametimeGraph history={frametimeHistory} width="fill" />
+          </div>
+        )
+      }
+    >
+      {valueText}
+      {frametimeText}
     </Pill>
   );
 }

--- a/tauri-app/src/components/overlay/FrametimeGraph.tsx
+++ b/tauri-app/src/components/overlay/FrametimeGraph.tsx
@@ -114,6 +114,7 @@ export function FrametimeGraph({ history, width }: FrametimeGraphProps) {
       <div ref={wrapperRef} style={{ position: "relative", height: BAND_HEIGHT }}>
         <canvas
           ref={canvasRef}
+          aria-hidden="true"
           style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
         />
       </div>
@@ -123,6 +124,7 @@ export function FrametimeGraph({ history, width }: FrametimeGraphProps) {
   return (
     <canvas
       ref={canvasRef}
+      aria-hidden="true"
       style={{ width, height: BAND_HEIGHT, display: "block" }}
     />
   );

--- a/tauri-app/src/components/overlay/FrametimeGraph.tsx
+++ b/tauri-app/src/components/overlay/FrametimeGraph.tsx
@@ -1,25 +1,55 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState } from "react";
+
+// Figma 2202:3533 (horizontal) / 2218:3721 (vertical): the wave is a 7px-tall
+// band in both layouts — the line rests on the bottom of the band and rises in
+// smooth spikes, it never fills the row height.
+const BAND_HEIGHT = 7;
+const STROKE_WIDTH = 1;
+// Deviations below the range floor render near-flat. Without a floor,
+// normalizing against the buffer's own min/max stretches sensor jitter across
+// the whole band and the line reads as random noise. The floor scales with
+// the baseline (RATIO × the rolling minimum, but at least FLOOR_MS) because
+// frame-to-frame jitter is proportional to the frametime itself: ±2ms is a
+// visible stutter at 7ms (144fps) but ordinary variance at 30ms (33fps).
+// Real stutters exceed the floor and still spike to the top of the band.
+const RANGE_FLOOR_MS = 2;
+const RANGE_FLOOR_RATIO = 0.3;
 
 interface FrametimeGraphProps {
   history: number[];
-  width: number;
-  height: number;
+  /** CSS pixel width, or "fill" to track the parent's width (vertical layout). */
+  width: number | "fill";
 }
 
-export function FrametimeGraph({ history, width, height }: FrametimeGraphProps) {
+export function FrametimeGraph({ history, width }: FrametimeGraphProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const sizeRef = useRef({ w: 0, h: 0 });
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+
+  useEffect(() => {
+    if (width !== "fill") return;
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    const observer = new ResizeObserver((entries) => {
+      setMeasuredWidth(entries[0].contentRect.width);
+    });
+    observer.observe(wrapper);
+    return () => observer.disconnect();
+  }, [width]);
+
+  const drawWidth = width === "fill" ? measuredWidth : width;
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas || history.length < 2) return;
+    if (!canvas || history.length < 2 || drawWidth < 2) return;
 
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
     const dpr = window.devicePixelRatio || 1;
-    const targetW = width * dpr;
-    const targetH = height * dpr;
+    const targetW = drawWidth * dpr;
+    const targetH = BAND_HEIGHT * dpr;
 
     if (sizeRef.current.w !== targetW || sizeRef.current.h !== targetH) {
       canvas.width = targetW;
@@ -28,34 +58,72 @@ export function FrametimeGraph({ history, width, height }: FrametimeGraphProps) 
     }
 
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    ctx.clearRect(0, 0, width, height);
-
-    const maxVal = Math.max(...history, 1);
-    const stepX = width / (history.length - 1);
+    ctx.clearRect(0, 0, drawWidth, BAND_HEIGHT);
 
     // Figma 2202:3552: stroke is a horizontal linear gradient — white fading
     // in 0→23%, opaque 23→79%, fading out 79→100%. Stops apply to the canvas's
     // CSS pixel width so the fade tracks the visible graph, not the DPR-scaled
     // backing store.
-    const grad = ctx.createLinearGradient(0, 0, width, 0);
+    const grad = ctx.createLinearGradient(0, 0, drawWidth, 0);
     grad.addColorStop(0, "rgba(255,255,255,0)");
     grad.addColorStop(0.23, "rgba(255,255,255,1)");
     grad.addColorStop(0.79, "rgba(255,255,255,1)");
     grad.addColorStop(1, "rgba(255,255,255,0)");
     ctx.strokeStyle = grad;
-    ctx.lineWidth = 1;
-    ctx.lineJoin = "round";
+    ctx.lineWidth = STROKE_WIDTH;
+    // Figma vector: strokeCap ROUND (the two line ends) but default MITER
+    // joins — miter extends each spike vertex into a sharp needle tip, while
+    // a round join would cap it with an arc and visibly blunt the peak.
+    ctx.lineJoin = "miter";
     ctx.lineCap = "round";
 
+    // Figma anchors sit at y≈6.9 of the 7px band (baseline) with spike peaks
+    // at y≈0.3–0.5: the rolling minimum maps to the bottom of the band and
+    // deviations above it rise toward the top. Stroke centers stay half a
+    // stroke inside the band, so the flat baseline lands on a half-pixel
+    // (6.5) and renders as a crisp 1px line at 100% scale.
+    const min = Math.min(...history);
+    const floor = Math.max(RANGE_FLOOR_MS, min * RANGE_FLOOR_RATIO);
+    const range = Math.max(Math.max(...history) - min, floor);
+    const stepX = drawWidth / (history.length - 1);
+    const baselineY = BAND_HEIGHT - STROKE_WIDTH / 2;
+
+    // Straight segments, no curve smoothing: the Figma vector is a polyline —
+    // stutters read as crisp triangular spikes off the flat baseline (the
+    // bezier commands in its exported path are only the round join/cap
+    // outlines). Round joins take the 1px-scale edge off the vertices,
+    // exactly like the reference.
     ctx.beginPath();
     history.forEach((val, i) => {
       const x = i * stepX;
-      const y = height - (val / maxVal) * (height - 4) - 2;
+      const y = baselineY - ((val - min) / range) * (BAND_HEIGHT - STROKE_WIDTH);
       if (i === 0) ctx.moveTo(x, y);
       else ctx.lineTo(x, y);
     });
     ctx.stroke();
-  }, [history, width, height]);
+  }, [history, drawWidth]);
 
-  return <canvas ref={canvasRef} style={{ width, height }} />;
+  if (width === "fill") {
+    // A canvas's intrinsic width (its backing-store attribute — 300 by
+    // default before the first draw) participates in the pill's
+    // shrink-to-fit sizing, so an in-flow canvas at width:100% inflates the
+    // pill far past the value row. Absolutely positioning it removes it from
+    // intrinsic sizing; the wrapper stretches to the column width set by the
+    // value row and the ResizeObserver tracks that.
+    return (
+      <div ref={wrapperRef} style={{ position: "relative", height: BAND_HEIGHT }}>
+        <canvas
+          ref={canvasRef}
+          style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ width, height: BAND_HEIGHT, display: "block" }}
+    />
+  );
 }

--- a/tauri-app/src/components/overlay/NetSection.tsx
+++ b/tauri-app/src/components/overlay/NetSection.tsx
@@ -44,6 +44,22 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
     fontFamily: "Inter",
     letterSpacing: "0.04em",
   };
+  // The ↓/↑ arrows are a fixed 12×15 glyph box (Figma node — TEXT "↓"/"↑"
+  // [12×15] @ size 12). They never scale with the Label/Stats font; the arrow
+  // is centered in the box so the NET row stays stable across font sizes.
+  const arrowStyle: React.CSSProperties = {
+    width: 12,
+    height: 15,
+    flexShrink: 0,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: 12,
+    fontWeight: labelFontWeight,
+    color: "var(--overlay-text)",
+    fontFamily: "Inter",
+    letterSpacing: "0.04em",
+  };
 
   return (
     <Pill title="NET" isHorizontal={isHorizontal}>
@@ -54,14 +70,14 @@ export function NetSection({ isHorizontal }: NetSectionProps) {
         <div className="flex items-center gap-1">
           <span style={valueStyle} className="tabular-nums">{down.value}</span>
           <span style={labelStyle}>{down.unit}</span>
-          <span style={labelStyle}>↓</span>
+          <span style={arrowStyle}>↓</span>
         </div>
       )}
       {upRate.isEnabled && (
         <div className="flex items-center gap-1">
           <span style={valueStyle} className="tabular-nums">{up.value}</span>
           <span style={labelStyle}>{up.unit}</span>
-          <span style={labelStyle}>↑</span>
+          <span style={arrowStyle}>↑</span>
         </div>
       )}
       {showNetGraph && (

--- a/tauri-app/src/components/overlay/OverlayHud.tsx
+++ b/tauri-app/src/components/overlay/OverlayHud.tsx
@@ -30,7 +30,9 @@ export function OverlayHud() {
         lineHeight: 1.2,
         "--overlay-text": dark ? "#fff" : "#000",
         "--overlay-text-muted": dark ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.5)",
-        "--overlay-track": dark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.1)",
+        // Track (ring + bar) is 10% per Figma — 2106:2313 Ellipse 2 and the
+        // 2527:10167 bar swatches both carry node opacity 0.1.
+        "--overlay-track": dark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)",
         "--overlay-arrow-down": dark ? "#22d3ee" : "#0891b2",
         "--overlay-arrow-up": dark ? "#a78bfa" : "#6d28d9",
         ...(isHorizontal

--- a/tauri-app/src/components/overlay/Pill.tsx
+++ b/tauri-app/src/components/overlay/Pill.tsx
@@ -1,4 +1,5 @@
 import { useSettingsStore } from "@/stores/settings-store";
+import { gaugeSize } from "./gauge-metrics";
 
 interface PillProps {
   title: string;
@@ -22,11 +23,12 @@ export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
   // renders identically. Values, units, and arrows stay full white.
   const labelColor = "var(--overlay-text-muted)";
   // Figma's auto-layout produces uniform sub-pill heights even when one pill
-  // has no ring (FPS, NET). Force a floor of ring + vertical-pad so ring-less
-  // pills don't sit shorter than ring-bearing ones, matching the Figma sweep
-  // (24/37 horizontal, 32/45 vertical).
-  const ringSize = valueFontSize <= 14 ? 16 : 20;
-  const minHeight = ringSize + (isHorizontal ? 8 : 16);
+  // has no gauge (FPS, NET). Force a floor of gauge + vertical-pad so
+  // gauge-less pills don't sit shorter than gauge-bearing ones, matching the
+  // Figma sweep (24/37 horizontal, 32/45 vertical). Shares the ring/bar size
+  // step via gaugeSize; text taller than the floor still grows the pill
+  // naturally (minHeight, not height).
+  const minHeight = gaugeSize(valueFontSize) + (isHorizontal ? 8 : 16);
   // Figma vertical (2169:286) pins every 3-char label to a uniform width so
   // values align across stacked sub-pills. Figma reports 28px @ fontSizeLabel
   // 12, but in CSS Inter "RAM" renders at 28.2px (rounding to 29) — wider
@@ -51,9 +53,10 @@ export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
   if (isHorizontal) {
     // Figma 2106:2313 sub-pill spec: r=100, bg rgba(0,0,0,0.24), pad 4/12/4/12,
     // gap 12 uniform between label AND between every metric cluster (e.g. GPU
-    // has temp/load/vram clusters all spaced at 12). minHeight removed so the
-    // pill hugs its tallest child — height grows with fontSizeValue exactly
-    // as the 7-size Figma sweep illustrates (24→37 inner row height).
+    // has temp/load/vram clusters all spaced at 12). Height hugs the tallest
+    // child — it grows with the fonts exactly as the 7-size Figma sweep
+    // illustrates (24→37 inner row height) — while minHeight only floors the
+    // gauge-less pills (FPS, NET) at gauge + pad so they match their siblings.
     return (
       <div
         title={tooltip}

--- a/tauri-app/src/components/overlay/Pill.tsx
+++ b/tauri-app/src/components/overlay/Pill.tsx
@@ -6,9 +6,14 @@ interface PillProps {
   isHorizontal: boolean;
   children: React.ReactNode;
   tooltip?: string;
+  /** Full-width row rendered under the label/value row — vertical layout only
+   *  (Figma 2202:3255 Frame 81: the FPS graph spans the pill content width on
+   *  its own row, 8px below the value row). Ignored in horizontal layout,
+   *  where the graph sits inline (Figma 2202:2664). */
+  graphRow?: React.ReactNode;
 }
 
-export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
+export function Pill({ title, isHorizontal, children, tooltip, graphRow }: PillProps) {
   // The Opacity slider drives the PILL background alpha only (max = solid
   // black/white pills); the outer HUD background and text are unaffected.
   const pillAlpha = useSettingsStore((s) => s.settings.opacity ?? 0.3);
@@ -30,13 +35,14 @@ export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
   // naturally (minHeight, not height).
   const minHeight = gaugeSize(valueFontSize) + (isHorizontal ? 8 : 16);
   // Figma vertical (2169:286) pins every 3-char label to a uniform width so
-  // values align across stacked sub-pills. Figma reports 28px @ fontSizeLabel
-  // 12, but in CSS Inter "RAM" renders at 28.2px (rounding to 29) — wider
-  // than FPS/GPU/CPU/NET. Use a fixed width slightly larger than RAM's
-  // natural so every label slot is identical and value clusters start at
-  // the exact same x. Horizontal lets labels hug their text since pills
-  // sit side-by-side.
-  const labelWidth = isHorizontal ? undefined : Math.ceil(labelSize * 2.5);
+  // values align across stacked sub-pills: exactly 28px @ fontSizeLabel 12
+  // (2202:3255 annotates label→value as a 12px gap measured from that slot
+  // edge). Scale the same 28:12 ratio with the label font. In CSS Inter
+  // "RAM" renders ~28.2px — a hair over the slot — which just grazes into
+  // the gap; padding the slot instead (the old 30px) widened label→value
+  // past the Figma 12 on every pill. Horizontal lets labels hug their text
+  // since pills sit side-by-side.
+  const labelWidth = isHorizontal ? undefined : Math.ceil(labelSize * (28 / 12));
   // Figma TEXT nodes have letterSpacing +4% on labels/units/arrows, -2% on
   // values. Applied here for labels.
   const labelStyle: React.CSSProperties = {
@@ -81,14 +87,17 @@ export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
   // Figma 2169:286 vertical sub-pill: r=8, bg rgba(0,0,0,0.24), pad 8/12/8/12,
   // gap 12 between label and value-cluster. Internally HORIZONTAL — same row
   // structure as the horizontal HUD, just rounder vertical padding so stacked
-  // pills sit comfortably one above the other.
+  // pills sit comfortably one above the other. The column wrapper only matters
+  // when a graphRow is present (Figma 2202:3255: content row, 8px gap, graph
+  // row); without one it renders a single centered row exactly as before.
   return (
     <div
       title={tooltip}
       style={{
         display: "flex",
-        alignItems: "center",
-        gap: 12,
+        flexDirection: "column",
+        justifyContent: "center",
+        gap: 8,
         background: pillBg,
         borderRadius: 8,
         padding: "8px 12px",
@@ -97,8 +106,11 @@ export function Pill({ title, isHorizontal, children, tooltip }: PillProps) {
         minHeight,
       }}
     >
-      <span style={labelStyle}>{title}</span>
-      <div style={{ display: "flex", alignItems: "center", gap: 12, flexShrink: 0 }}>{children}</div>
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <span style={labelStyle}>{title}</span>
+        <div style={{ display: "flex", alignItems: "center", gap: 12, flexShrink: 0 }}>{children}</div>
+      </div>
+      {graphRow}
     </div>
   );
 }

--- a/tauri-app/src/components/overlay/ProgressBar.tsx
+++ b/tauri-app/src/components/overlay/ProgressBar.tsx
@@ -1,6 +1,7 @@
 import { getBoundaryColor } from "@/lib/utils";
 import type { Boundaries } from "@/lib/types";
 import { useSettingsStore } from "@/stores/settings-store";
+import { gaugeSize } from "./gauge-metrics";
 
 interface ProgressBarProps {
   value: number;
@@ -21,25 +22,37 @@ export function ProgressBar({
   const labelFontSize = useSettingsStore((s) => s.settings.fontSizeLabel ?? 12);
   const valueFontWeight = useSettingsStore((s) => s.settings.fontWeight ?? 500);
   const labelFontWeight = useSettingsStore((s) => s.settings.labelFontWeight ?? 500);
-  // Bar geometry verbatim from Figma (2526:9002 / 2526:8590): every bar is 2px
-  // tall and fully rounded (cornerRadius 110), stacked with a fixed 1.5px gap —
-  // never scaled. The column (and so each bar) is 16px wide at value font ≤14,
-  // 20px at ≥16, sitting 6px (16) / 8px (20) from the text. Always 6 bars; the
-  // value fills them bottom-up (active = boundary color, the rest muted track).
-  const barWidth = valueFontSize <= 14 ? 16 : 20;
-  const barToTextGap = barWidth === 16 ? 6 : 8;
-  // Figma (node 2527:9744): the gauge is a fixed ~20px block — 6 bars, each 2px
-  // tall, 1.5px apart — vertically centered with the text beside it (the row
-  // below is align-items:center), like the ring. Bar height is fixed 2px in
-  // every combination, never scaling with the font.
-  // 1.5px is sub-pixel below 2× scaling, where it renders with uneven gaps. Snap
-  // it to the running display's device-pixel grid so every gap is a whole number
-  // of device pixels — even and crisp at any Windows scale (and exactly 1.5px at
-  // 200%, where 1.5 already lands on 3 device pixels).
-  const barCount = 6;
+  // Bar gauge geometry verbatim from Figma — horizontal sizes (2526:9002),
+  // vertical sizes (2526:8590), state swatches (2527:10167). The gauge is a
+  // FIXED square box the same size as the ring (16 at value font ≤14, 20 at
+  // ≥16) so both gauge types occupy identical space and the pill height never
+  // shifts when switching ring↔bar:
+  //   16 box → 5 bars 16w×2h, gap 1.5 (5·2 + 4·1.5 = 16, fills the box)
+  //   20 box → 6 bars 20w×2h, gap 1.5 (6·2 + 5·1.5 = 19.5, centered in the box)
+  // Bars are always 2px tall, fully rounded (cornerRadius 110), nominal gap
+  // 1.5. The value fills bottom-up (active = boundary color, the rest muted
+  // track).
+  const size = gaugeSize(valueFontSize);
+  const barWidth = size;
+  const barToTextGap = size === 16 ? 6 : 8;
+  const barCount = size === 16 ? 5 : 6;
   const barHeight = 2;
+  const barGap = 1.5;
+  // A flex `gap: 1.5` lands bars on half-pixels at 100% Windows scale, and the
+  // antialiasing renders ragged, uneven gaps (measured 1/2/1 in real captures).
+  // Instead, place each bar absolutely and snap its offset to the device-pixel
+  // grid: at 200% scale every gap is exactly Figma's 1.5; at 100% the rounding
+  // degrades to a crisp, symmetric 2,1,2,1(,2) — while the box stays exactly
+  // 16/20 and the first/last bars stay flush with its edges.
   const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
-  const barGap = Math.round(1.5 * dpr) / dpr;
+  const snap = (v: number) => Math.round(v * dpr) / dpr;
+  const stackHeight = barCount * barHeight + (barCount - 1) * barGap;
+  const stackOffset = (size - stackHeight) / 2; // 0 in the 16 box, 0.25 in the 20 box
+  // Clamp keeps the last bar inside the box at fractional scales (e.g. 125%,
+  // where cumulative rounding can push it 0.4px past the bottom edge).
+  const barTops = Array.from({ length: barCount }, (_, i) =>
+    Math.min(snap(stackOffset + i * (barHeight + barGap)), size - barHeight)
+  );
   const percentage = Math.min(value / max, 1);
   const filledBars = Math.round(percentage * barCount);
   const color = boundaries
@@ -50,9 +63,9 @@ export function ProgressBar({
     <div style={{ display: "flex", alignItems: "center", gap: barToTextGap }}>
       <div
         className="shrink-0"
-        style={{ display: "flex", flexDirection: "column", gap: barGap, width: barWidth }}
+        style={{ position: "relative", width: barWidth, height: size }}
       >
-        {Array.from({ length: barCount }, (_, i) => {
+        {barTops.map((top, i) => {
           // Bottom-up fill: i=0 is the top bar (highest index).
           const barIndex = barCount - 1 - i;
           return (
@@ -60,10 +73,13 @@ export function ProgressBar({
               key={i}
               className="rounded-full"
               style={{
+                position: "absolute",
+                top,
+                left: 0,
                 height: barHeight,
                 width: "100%",
                 backgroundColor:
-                  barIndex < filledBars ? color : "var(--overlay-track, rgba(255,255,255,0.15))",
+                  barIndex < filledBars ? color : "var(--overlay-track, rgba(255,255,255,0.1))",
               }}
             />
           );

--- a/tauri-app/src/components/overlay/ProgressBar.tsx
+++ b/tauri-app/src/components/overlay/ProgressBar.tsx
@@ -22,38 +22,44 @@ export function ProgressBar({
   const labelFontSize = useSettingsStore((s) => s.settings.fontSizeLabel ?? 12);
   const valueFontWeight = useSettingsStore((s) => s.settings.fontWeight ?? 500);
   const labelFontWeight = useSettingsStore((s) => s.settings.labelFontWeight ?? 500);
-  // Bar gauge geometry verbatim from Figma — horizontal sizes (2526:9002),
-  // vertical sizes (2526:8590), state swatches (2527:10167). The gauge is a
-  // FIXED square box the same size as the ring (16 at value font ≤14, 20 at
-  // ≥16) so both gauge types occupy identical space and the pill height never
-  // shifts when switching ring↔bar:
-  //   16 box → 5 bars 16w×2h, gap 1.5 (5·2 + 4·1.5 = 16, fills the box)
-  //   20 box → 6 bars 20w×2h, gap 1.5 (6·2 + 5·1.5 = 19.5, centered in the box)
-  // Bars are always 2px tall, fully rounded (cornerRadius 110), nominal gap
-  // 1.5. The value fills bottom-up (active = boundary color, the rest muted
-  // track).
+  // Bar gauge geometry from Figma — horizontal (2526:9002), vertical
+  // (2526:8590), state swatches (2527:10167) — with ONE deliberate deviation:
+  // the gap is 1px, not Figma's 1.5px (1.5 can't land on a whole pixel at 100%
+  // display scale and blurs the bars; 1px renders crisp). Everything that
+  // derives from the gap therefore differs from Figma's 1.5-based numbers, and
+  // that is intentional — do NOT "correct" these back to Figma:
+  //   Figma (1.5 gap): 16 box, 5 bars → stack 5·2 + 4·1.5 = 16 (fills box)
+  //                     20 box, 6 bars → stack 6·2 + 5·1.5 = 19.5 (≈ box)
+  //   Ours  (1px gap):  16 box, 5 bars → stack 5·2 + 4·1 = 14 (centered in 16)
+  //                     20 box, 6 bars → stack 6·2 + 5·1 = 17 (centered in 20)
+  // What still matches Figma exactly: bar size 16w/20w × 2h, box = ring size
+  // (16/20) so the pill height never shifts on ring↔bar, cornerRadius 110
+  // (fully rounded), bottom-up fill (active = boundary color, rest = track).
   const size = gaugeSize(valueFontSize);
   const barWidth = size;
   const barToTextGap = size === 16 ? 6 : 8;
   const barCount = size === 16 ? 5 : 6;
-  const barHeight = 2;
-  const barGap = 1.5;
-  // A flex `gap: 1.5` lands bars on half-pixels at 100% Windows scale, and the
-  // antialiasing renders ragged, uneven gaps (measured 1/2/1 in real captures).
-  // Instead, place each bar absolutely and snap its offset to the device-pixel
-  // grid: at 200% scale every gap is exactly Figma's 1.5; at 100% the rounding
-  // degrades to a crisp, symmetric 2,1,2,1(,2) — while the box stays exactly
-  // 16/20 and the first/last bars stay flush with its edges.
+  const barHeight = 2; // Figma bar thickness (CSS px)
+  // Gap LOCKED at 1px (Figma spec is 1.5; see the deviation note above).
+  const barGap = 1;
+  // Snap the whole stack to the DEVICE-pixel grid so every layer is an
+  // identical, fully-solid block (no half-pixel blur). The box stays the Figma
+  // gauge size (16/20 — same as the ring) so the bar gauge keeps Figma's exact
+  // top/bottom breathing room and matches the ring footprint; the shorter 1px
+  // stack is centered inside it with an integer offset so it stays crisp.
   const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
-  const snap = (v: number) => Math.round(v * dpr) / dpr;
-  const stackHeight = barCount * barHeight + (barCount - 1) * barGap;
-  const stackOffset = (size - stackHeight) / 2; // 0 in the 16 box, 0.25 in the 20 box
-  // Clamp keeps the last bar inside the box at fractional scales (e.g. 125%,
-  // where cumulative rounding can push it 0.4px past the bottom edge).
-  const barTops = Array.from({ length: barCount }, (_, i) =>
-    Math.min(snap(stackOffset + i * (barHeight + barGap)), size - barHeight)
+  const sizeDev = Math.round(size * dpr);
+  const barWDev = Math.round(barWidth * dpr);
+  const barHDev = Math.max(1, Math.round(barHeight * dpr));
+  const gapDev = Math.max(1, Math.round(barGap * dpr));
+  const stackDev = barCount * barHDev + (barCount - 1) * gapDev;
+  const offsetDev = Math.round((sizeDev - stackDev) / 2); // integer → stays crisp
+  const barTopsDev = Array.from({ length: barCount }, (_, i) =>
+    offsetDev + i * (barHDev + gapDev)
   );
+  const boxCss = size;
   const percentage = Math.min(value / max, 1);
+  // Whole bars only — each layer is entirely filled or entirely empty track.
   const filledBars = Math.round(percentage * barCount);
   const color = boundaries
     ? getBoundaryColor(value, boundaries)
@@ -61,30 +67,36 @@ export function ProgressBar({
 
   return (
     <div style={{ display: "flex", alignItems: "center", gap: barToTextGap }}>
-      <div
+      {/* viewBox is DEVICE px (barWDev×sizeDev) while the SVG lays out at CSS
+          size (barWidth×boxCss), so integer bar coords map 1:1 to physical
+          pixels and render crisp. */}
+      <svg
+        width={barWidth}
+        height={boxCss}
+        viewBox={`0 0 ${barWDev} ${sizeDev}`}
         className="shrink-0"
-        style={{ position: "relative", width: barWidth, height: size }}
       >
-        {barTops.map((top, i) => {
+        {barTopsDev.map((top, i) => {
           // Bottom-up fill: i=0 is the top bar (highest index).
           const barIndex = barCount - 1 - i;
           return (
-            <div
+            <rect
               key={i}
-              className="rounded-full"
-              style={{
-                position: "absolute",
-                top,
-                left: 0,
-                height: barHeight,
-                width: "100%",
-                backgroundColor:
-                  barIndex < filledBars ? color : "var(--overlay-track, rgba(255,255,255,0.1))",
-              }}
+              x={0}
+              y={top}
+              width={barWDev}
+              height={barHDev}
+              // Figma cornerRadius 110 clamps to half the bar height.
+              rx={barHDev / 2}
+              fill={
+                barIndex < filledBars
+                  ? color
+                  : "var(--overlay-track, rgba(255,255,255,0.1))"
+              }
             />
           );
         })}
-      </div>
+      </svg>
       {/* number→unit stays gap-1 (Figma 4); unit holds at labelFontSize like
           the ring. tabular-nums avoids same-digit jitter. */}
       <div className="flex items-center gap-1" style={{ fontSize: valueFontSize }}>

--- a/tauri-app/src/components/overlay/ProgressBar.tsx
+++ b/tauri-app/src/components/overlay/ProgressBar.tsx
@@ -21,22 +21,47 @@ export function ProgressBar({
   const labelFontSize = useSettingsStore((s) => s.settings.fontSizeLabel ?? 12);
   const valueFontWeight = useSettingsStore((s) => s.settings.fontWeight ?? 500);
   const labelFontWeight = useSettingsStore((s) => s.settings.labelFontWeight ?? 500);
+  // Bar geometry verbatim from Figma (2526:9002 / 2526:8590): every bar is 2px
+  // tall and fully rounded (cornerRadius 110), stacked with a fixed 1.5px gap —
+  // never scaled. The column (and so each bar) is 16px wide at value font ≤14,
+  // 20px at ≥16, sitting 6px (16) / 8px (20) from the text. Always 6 bars; the
+  // value fills them bottom-up (active = boundary color, the rest muted track).
+  const barWidth = valueFontSize <= 14 ? 16 : 20;
+  const barToTextGap = barWidth === 16 ? 6 : 8;
+  // Figma (node 2527:9744): the gauge is a fixed ~20px block — 6 bars, each 2px
+  // tall, 1.5px apart — vertically centered with the text beside it (the row
+  // below is align-items:center), like the ring. Bar height is fixed 2px in
+  // every combination, never scaling with the font.
+  // 1.5px is sub-pixel below 2× scaling, where it renders with uneven gaps. Snap
+  // it to the running display's device-pixel grid so every gap is a whole number
+  // of device pixels — even and crisp at any Windows scale (and exactly 1.5px at
+  // 200%, where 1.5 already lands on 3 device pixels).
+  const barCount = 6;
+  const barHeight = 2;
+  const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+  const barGap = Math.round(1.5 * dpr) / dpr;
   const percentage = Math.min(value / max, 1);
-  const filledBars = Math.round(percentage * 10);
+  const filledBars = Math.round(percentage * barCount);
   const color = boundaries
     ? getBoundaryColor(value, boundaries)
     : "var(--green-500)";
 
   return (
-    <div className="flex items-center gap-1.5">
-      <div className="flex flex-col gap-[1px] w-6">
-        {Array.from({ length: 10 }, (_, i) => {
-          const barIndex = 9 - i;
+    <div style={{ display: "flex", alignItems: "center", gap: barToTextGap }}>
+      <div
+        className="shrink-0"
+        style={{ display: "flex", flexDirection: "column", gap: barGap, width: barWidth }}
+      >
+        {Array.from({ length: barCount }, (_, i) => {
+          // Bottom-up fill: i=0 is the top bar (highest index).
+          const barIndex = barCount - 1 - i;
           return (
             <div
               key={i}
-              className="h-[2px] w-full rounded-sm"
+              className="rounded-full"
               style={{
+                height: barHeight,
+                width: "100%",
                 backgroundColor:
                   barIndex < filledBars ? color : "var(--overlay-track, rgba(255,255,255,0.15))",
               }}
@@ -44,8 +69,8 @@ export function ProgressBar({
           );
         })}
       </div>
-      {/* Cluster hugs content: cluster→cluster gap reads as Figma 12px;
-          number→unit stays gap-1 (4px). tabular-nums avoids same-digit jitter. */}
+      {/* number→unit stays gap-1 (Figma 4); unit holds at labelFontSize like
+          the ring. tabular-nums avoids same-digit jitter. */}
       <div className="flex items-center gap-1" style={{ fontSize: valueFontSize }}>
         <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
           {label}

--- a/tauri-app/src/components/overlay/ProgressRing.tsx
+++ b/tauri-app/src/components/overlay/ProgressRing.tsx
@@ -1,6 +1,7 @@
 import { getBoundaryColor } from "@/lib/utils";
 import type { Boundaries } from "@/lib/types";
 import { useSettingsStore } from "@/stores/settings-store";
+import { gaugeSize } from "./gauge-metrics";
 
 interface ProgressRingProps {
   value: number;
@@ -22,11 +23,15 @@ export function ProgressRing({
   const valueFontWeight = useSettingsStore((s) => s.settings.fontWeight ?? 500);
   const labelFontWeight = useSettingsStore((s) => s.settings.labelFontWeight ?? 500);
   // Figma 2106:2313 ring sizing is a step function on fontSizeValue:
-  // 16px ring when value font ≤14, 20px ring when ≥16.
-  const ringSize = valueFontSize <= 14 ? 16 : 20;
-  // Ring→value gap is a flat 8 at every size per Figma (node 2106:2313 redline).
-  const ringToTextGap = 8;
-  const strokeWidth = 3;
+  // 16px ring when value font ≤14, 20px ring when ≥16 (shared with the bar
+  // gauge and the Pill minHeight floor via gaugeSize).
+  const ringSize = gaugeSize(valueFontSize);
+  // Ring→value gap steps with the ring per the Figma sweeps (2106:2313
+  // clusters): 6 at the 16 ring, 8 at the 20 ring — same as the bar gauge.
+  const ringToTextGap = ringSize === 16 ? 6 : 8;
+  // Figma draws the ring as an arc with innerRadius 0.7 — a band 15% of the
+  // diameter thick: 2.4 at 16, 3 at 20. A flat 3 made the small ring too heavy.
+  const strokeWidth = ringSize * 0.15;
   const radius = (ringSize - strokeWidth) / 2;
   const center = ringSize / 2;
   const percentage = Math.min(value / max, 1);
@@ -44,13 +49,15 @@ export function ProgressRing({
         viewBox={`0 0 ${ringSize} ${ringSize}`}
         className="shrink-0"
       >
+        {/* Track at 10% per Figma (2106:2313 Ellipse 2, node opacity 0.1) —
+            sourced from the same var as the bar track so both gauges and both
+            meter themes stay in lockstep. */}
         <circle
           cx={center}
           cy={center}
           r={radius}
           fill="none"
-          stroke="var(--overlay-text)"
-          strokeOpacity="0.15"
+          stroke="var(--overlay-track, rgba(255,255,255,0.1))"
           strokeWidth={strokeWidth}
         />
         <circle

--- a/tauri-app/src/components/overlay/gauge-metrics.ts
+++ b/tauri-app/src/components/overlay/gauge-metrics.ts
@@ -1,0 +1,10 @@
+// Single source of truth for the overlay gauge size step. Figma sizes sweeps
+// (2106:2313, 2526:9002 horizontal; 2169:286, 2526:8590 vertical) show both
+// gauges (ring and bar) stepping once with the Stats/value font — never
+// continuously: 16px square at value font ≤14, 20px at ≥16. Pill minHeight
+// derives from the same step so gauge-less pills (FPS/NET) stay as tall as
+// gauge-bearing ones. Keep all three consumers (ProgressRing, ProgressBar,
+// Pill) on this helper so the step can't drift between them again.
+export function gaugeSize(valueFontSize: number): 16 | 20 {
+  return valueFontSize <= 14 ? 16 : 20;
+}

--- a/tauri-app/src/components/settings/help/HelpTab.tsx
+++ b/tauri-app/src/components/settings/help/HelpTab.tsx
@@ -1,9 +1,38 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
 import { FaqSection } from "./FaqSection";
+import { FeedbackDialog } from "../settings/FeedbackDialog";
+
+function FeedbackPrompt() {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <section className="flex w-full items-center justify-between gap-3 rounded-[12px] bg-[var(--bgSurfaceRaised)] p-5">
+      <div className="flex flex-col gap-[6px]">
+        <span className="text-body-sm-medium text-[var(--textHeading)]">
+          Have an issue or suggestions? We want to hear!
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={cn(
+          "shrink-0 rounded-[var(--cornerRound)] border border-[var(--borderBolder)]/50 bg-[var(--bgSurfaceRaised)] px-5 py-3",
+          "text-body-sm-medium text-[var(--textHeading)] transition-colors",
+          "hover:border-[var(--borderBolder)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+        )}
+      >
+        Give feedback
+      </button>
+      <FeedbackDialog open={open} onOpenChange={setOpen} />
+    </section>
+  );
+}
 
 export function HelpTab() {
   return (
     <div className="flex h-full w-full flex-col gap-4">
       <FaqSection />
+      <FeedbackPrompt />
     </div>
   );
 }

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -96,7 +96,10 @@ function GeneralSection() {
         <div className="h-px w-full bg-[var(--borderSubtle)]" />
         <div className="flex items-center gap-3">
           <div className="flex size-10 shrink-0 items-center justify-center rounded-[var(--cornerRound)] border border-[var(--borderBold)] bg-[var(--bgSurfaceRaised)]">
-            <ComputerIcon className="size-5 text-[var(--textParagraph1)]" />
+            {/* The glyph is geometrically centered but top-heavy (solid
+                monitor body over thin legs), which reads as sitting high in
+                the circle — nudge down 1px for optical center. */}
+            <ComputerIcon className="size-5 translate-y-[1px] text-[var(--textParagraph1)]" />
           </div>
           <div className="flex min-w-0 flex-1 flex-col gap-[6px]">
             <span className="text-[14px] font-medium text-[var(--textHeading)]">

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -26,7 +26,6 @@ import {
   ThemePreviewLight,
   ThemePreviewSystem,
 } from "./icons";
-import { FeedbackDialog } from "./FeedbackDialog";
 
 function SectionCard({
   title,
@@ -376,31 +375,6 @@ function UpdatesButton() {
   );
 }
 
-function FeedbackPrompt() {
-  const [open, setOpen] = React.useState(false);
-  return (
-    <section className="flex w-full items-center justify-between gap-3 rounded-[12px] bg-[var(--bgSurfaceRaised)] p-5">
-      <div className="flex flex-col gap-[6px]">
-        <span className="text-body-sm-medium text-[var(--textHeading)]">
-          Have an issue or suggestions? We want to hear!
-        </span>
-      </div>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className={cn(
-          "shrink-0 rounded-[var(--cornerRound)] border border-[var(--borderBolder)]/50 bg-[var(--bgSurfaceRaised)] px-5 py-3",
-          "text-body-sm-medium text-[var(--textHeading)] transition-colors",
-          "hover:border-[var(--borderBolder)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
-        )}
-      >
-        Give feedback
-      </button>
-      <FeedbackDialog open={open} onOpenChange={setOpen} />
-    </section>
-  );
-}
-
 export function SettingsTab() {
   const appVersion = useSettingsStore((s) => s.appVersion);
 
@@ -413,7 +387,6 @@ export function SettingsTab() {
         <AppearanceSection />
       </div>
       <div className="flex w-full flex-col gap-6">
-        <FeedbackPrompt />
         <div className="flex gap-3">
           <UpdatesButton />
           <FooterLinkButton

--- a/tauri-app/src/components/settings/stats/CpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/CpuSection.tsx
@@ -98,7 +98,7 @@ export function CpuSection({ sensors, hardwares }: Props) {
             <TempRangeControl
               boundaries={cpuTemp.boundaries}
               onChange={(b) => updateBoundary("cpuTemp", b)}
-              unit="°"
+              isTemperature
               max={120}
             />
           </div>

--- a/tauri-app/src/components/settings/stats/GpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/GpuSection.tsx
@@ -123,7 +123,7 @@ export function GpuSection({ sensors, hardwares }: Props) {
             <TempRangeControl
               boundaries={gpuTemp.boundaries}
               onChange={(b) => updateBoundary("gpuTemp", b)}
-              unit="°"
+              isTemperature
               max={120}
             />
           </div>

--- a/tauri-app/src/components/settings/stats/SectionCard.tsx
+++ b/tauri-app/src/components/settings/stats/SectionCard.tsx
@@ -105,9 +105,11 @@ export function SubCollapsible({
         />
         <span className="text-[14px] font-medium text-foreground">{label}</span>
         <CollapsibleTrigger asChild>
+          {/* Chevron pairs with the panel animation: same ease-out-quart,
+              same 200ms (paired elements move as a unit). */}
           <button
             type="button"
-            className="ml-auto flex size-5 items-center justify-center text-muted-foreground transition-transform data-[state=open]:rotate-180"
+            className="ml-auto flex size-5 items-center justify-center text-muted-foreground transition-transform duration-200 ease-[cubic-bezier(0.165,0.84,0.44,1)] motion-reduce:transition-none data-[state=open]:rotate-180"
             aria-label={open ? "Collapse" : "Expand"}
           >
             <ChevronDown className="size-[18px]" strokeWidth={2} />
@@ -115,7 +117,7 @@ export function SubCollapsible({
         </CollapsibleTrigger>
       </div>
       {children && (
-        <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-none">
+        <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
           <div className="flex gap-5 pl-3">
             <div className="w-[2px] shrink-0 rounded-full bg-divider" />
             <div className="flex-1 rounded-[8px] bg-sub-card p-4">

--- a/tauri-app/src/components/settings/stats/TempRangeControl.tsx
+++ b/tauri-app/src/components/settings/stats/TempRangeControl.tsx
@@ -6,7 +6,7 @@ const CLAMP = (v: number, min: number, max: number) =>
 
 /**
  * 3-segment range control from Figma. Defaults to a 0-100% scale (GPU/CPU
- * usage); pass `unit` + `max` to reuse for °C temperatures, watts, etc.
+ * usage); pass `isTemperature` + `max` (in °C) to reuse for temperatures.
  * Boundaries.low / .medium are the upper bounds of the Low / Medium segments.
  * Boundaries.high is the absolute max.
  */
@@ -15,42 +15,59 @@ export function TempRangeControl({
   onChange,
   unit = "%",
   max = 100,
+  isTemperature = false,
 }: {
   boundaries: Boundaries;
   onChange: (b: Boundaries) => void;
   unit?: string;
   max?: number;
+  /** Temperature thresholds: label °C/°F per the selected unit and, in
+   *  Fahrenheit mode, display + accept °F while storing °C. */
+  isTemperature?: boolean;
 }) {
   const graphEnabled = useSettingsStore(
     (s) => s.settings.progressType !== "none",
   );
+  const temperatureUnit = useSettingsStore((s) => s.settings.temperatureUnit);
   if (!graphEnabled) return null;
 
-  const lowMin = 0;
-  const lowMax = boundaries.low;
-  const medMin = boundaries.low;
-  const medMax = boundaries.medium;
-  const highMin = boundaries.medium;
-  const highMax = boundaries.high || max;
+  // Boundaries are always STORED and compared in °C (the overlay evaluates
+  // raw sensor °C against them). In Fahrenheit mode the inputs display and
+  // accept °F and convert per edit — since storage is whole °C, a typed °F
+  // value can settle ±1°F away after the round-trip.
+  const useF = isTemperature && temperatureUnit === "F";
+  const toDisplay = (c: number) => (useF ? Math.round((c * 9) / 5 + 32) : c);
+  const fromDisplay = (v: number) => (useF ? Math.round(((v - 32) * 5) / 9) : v);
+  const displayUnit = isTemperature ? (useF ? "°F" : "°C") : unit;
+  const displayInputMax = toDisplay(max);
 
+  const lowMin = toDisplay(0);
+  const lowMax = toDisplay(boundaries.low);
+  const medMin = toDisplay(boundaries.low);
+  const medMax = toDisplay(boundaries.medium);
+  const highMin = toDisplay(boundaries.medium);
+  const highMax = toDisplay(boundaries.high || max);
+
+  // Inputs hand over display-scale values; convert to °C first so the ±1
+  // segment-gap invariants keep holding in the stored scale.
   const setLowMax = (v: number) => {
-    const lv = CLAMP(v, 0, boundaries.medium - 1);
+    const lv = CLAMP(fromDisplay(v), 0, boundaries.medium - 1);
     onChange({ ...boundaries, low: lv });
   };
   const setMedMax = (v: number) => {
-    const mv = CLAMP(v, boundaries.low + 1, highMax - 1);
+    const mv = CLAMP(fromDisplay(v), boundaries.low + 1, (boundaries.high || max) - 1);
     onChange({ ...boundaries, medium: mv });
   };
   const setHighMax = (v: number) => {
-    const hv = CLAMP(v, boundaries.medium + 1, max);
+    const hv = CLAMP(fromDisplay(v), boundaries.medium + 1, max);
     onChange({ ...boundaries, high: hv });
   };
 
   return (
     <div className="flex gap-4">
-      <RangeSegment color="#17B26A" label="Low" min={lowMin} max={lowMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setLowMax} />
-      <RangeSegment color="#FEC84B" label="Medium" min={medMin} max={medMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setMedMax} />
-      <RangeSegment color="#F04438" label="High" min={highMin} max={highMax} unit={unit} inputMax={max} readOnlyMin onMaxChange={setHighMax} />
+      <RangeSegment color="#17B26A" label="Low" min={lowMin} max={lowMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin onMaxChange={setLowMax} />
+      <RangeSegment color="#FEC84B" label="Medium" min={medMin} max={medMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin onMaxChange={setMedMax} />
+      <RangeSegment color="#F04438" label="High" min={highMin} max={highMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin onMaxChange={setHighMax} />
     </div>
   );
 }

--- a/tauri-app/src/components/settings/style/FontCard.tsx
+++ b/tauri-app/src/components/settings/style/FontCard.tsx
@@ -14,7 +14,10 @@ import { useSettingsStore } from "@/stores/settings-store";
 //   [Stats]  [size ▾]   [weight ▾]
 // All three columns share equal flex-1 width; gap-3 horizontally & vertically.
 
-const SIZE_OPTIONS = [8, 10, 12, 14, 16, 18, 20, 24, 28, 32] as const;
+// Stats (value) tops out at 24px, Label at 18px — larger sizes read cluttered
+// in the overlay, so they're not offered.
+const STATS_SIZE_OPTIONS = [8, 10, 12, 14, 16, 18, 20, 24] as const;
+const LABEL_SIZE_OPTIONS = [8, 10, 12, 14, 16, 18] as const;
 
 const WEIGHT_OPTIONS: { value: number; label: string }[] = [
   { value: 400, label: "Regular" },
@@ -36,30 +39,44 @@ const triggerClasses = cn(
 function FontRow({
   label,
   size,
+  sizeOptions,
   onSizeChange,
   weight,
   onWeightChange,
 }: {
   label: string;
   size: number;
+  sizeOptions: readonly number[];
   onSizeChange: (v: number) => void;
   weight: number;
   onWeightChange: (v: number) => void;
 }) {
+  // Never show an out-of-range saved value as a blank trigger — clamp the
+  // displayed selection to the largest offered size.
+  const maxSize = sizeOptions[sizeOptions.length - 1];
+  const selectedSize = Math.min(size, maxSize);
   return (
     <div className="flex w-full items-center gap-3">
       <span className="flex-1 text-[14px] font-medium leading-none text-foreground">
         {label}
       </span>
       <Select
-        value={String(size)}
+        value={String(selectedSize)}
         onValueChange={(v) => onSizeChange(parseInt(v, 10))}
       >
         <SelectTrigger className={triggerClasses}>
           <SelectValue placeholder="Size" />
         </SelectTrigger>
-        <SelectContent>
-          {SIZE_OPTIONS.map((s) => (
+        {/* Force the list downward — this card sits mid-panel and Radix
+            otherwise flips the tall size list upward. Cap to the space below
+            and scroll so it never runs off the window. */}
+        <SelectContent
+          side="bottom"
+          sideOffset={4}
+          avoidCollisions={false}
+          className="max-h-[var(--radix-select-content-available-height)] overflow-y-auto"
+        >
+          {sizeOptions.map((s) => (
             <SelectItem key={s} value={String(s)}>
               {s}px
             </SelectItem>
@@ -73,7 +90,12 @@ function FontRow({
         <SelectTrigger className={triggerClasses}>
           <SelectValue placeholder="Weight">{weightLabel(weight)}</SelectValue>
         </SelectTrigger>
-        <SelectContent>
+        <SelectContent
+          side="bottom"
+          sideOffset={4}
+          avoidCollisions={false}
+          className="max-h-[var(--radix-select-content-available-height)] overflow-y-auto"
+        >
           {WEIGHT_OPTIONS.map((w) => (
             <SelectItem key={w.value} value={String(w.value)}>
               {w.label}
@@ -95,6 +117,7 @@ export function FontCard() {
         <FontRow
           label="Label"
           size={settings.fontSizeLabel}
+          sizeOptions={LABEL_SIZE_OPTIONS}
           onSizeChange={(v) => updateSettings({ fontSizeLabel: v })}
           weight={settings.labelFontWeight}
           onWeightChange={(v) => updateSettings({ labelFontWeight: v })}
@@ -102,6 +125,7 @@ export function FontCard() {
         <FontRow
           label="Stats"
           size={settings.fontSizeValue}
+          sizeOptions={STATS_SIZE_OPTIONS}
           onSizeChange={(v) => updateSettings({ fontSizeValue: v })}
           weight={settings.fontWeight}
           onWeightChange={(v) => updateSettings({ fontWeight: v })}

--- a/tauri-app/src/components/settings/style/GraphTypePicker.tsx
+++ b/tauri-app/src/components/settings/style/GraphTypePicker.tsx
@@ -27,27 +27,27 @@ function RingPreview() {
   );
 }
 
-// TODO: Bar graph disabled until designed in Figma (2075:7833). Re-enable
-// BarPreview + the Bar tile + the "bar" branches in handleToggle/setType and
-// the loadSettings heal once the bar visual is finalized.
-// function BarPreview() {
-//   return (
-//     <div className="flex flex-col gap-[2px]">
-//       {Array.from({ length: 9 }, (_, i) => {
-//         const filled = i >= 4;
-//         return (
-//           <div
-//             key={i}
-//             className={cn(
-//               "h-[2px] w-[26px] rounded-full",
-//               filled ? "bg-success" : "bg-foreground/10",
-//             )}
-//           />
-//         );
-//       })}
-//     </div>
-//   );
-// }
+// Figma 2091:2570: 9 bars, 26×2, fully rounded, 2px stack gap. Top 4 are the
+// muted track (foreground @10%), bottom 5 filled success — a static preview of
+// a partially-filled bar gauge.
+function BarPreview() {
+  return (
+    <div className="flex flex-col gap-[2px]">
+      {Array.from({ length: 9 }, (_, i) => {
+        const filled = i >= 4;
+        return (
+          <div
+            key={i}
+            className={cn(
+              "h-[2px] w-[26px] rounded-full",
+              filled ? "bg-success" : "bg-foreground/10",
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}
 
 function GraphTile({
   selected,
@@ -91,18 +91,20 @@ export function GraphTypePicker() {
 
   const handleToggle = (enabled: boolean) => {
     if (enabled) {
-      // Bar graph disabled (pending Figma 2075:7833) — always enable as ring.
-      updateSettings({ progressType: "circular", graphType: "ring" });
+      // Re-enabling restores the last picked type: graphType remembers the
+      // choice while the graph is off, progressType is the live render state.
+      updateSettings({
+        progressType: settings.graphType === "bar" ? "bar" : "circular",
+      });
     } else {
       updateSettings({ progressType: "none" });
     }
   };
 
   const setType = (type: GraphType) => {
-    // Bar disabled (2075:7833): coerce any selection to the circular ring.
     updateSettings({
-      graphType: type === "bar" ? "ring" : type,
-      progressType: "circular",
+      graphType: type,
+      progressType: type === "bar" ? "bar" : "circular",
     });
   };
 
@@ -124,13 +126,12 @@ export function GraphTypePicker() {
             icon={<RingPreview />}
             label="Ring graph"
           />
-          {/* TODO: Bar graph option disabled until designed in Figma (2075:7833).
           <GraphTile
             selected={currentType === "bar"}
             onClick={() => setType("bar")}
             icon={<BarPreview />}
             label="Bar graph"
-          /> */}
+          />
         </div>
       )}
     </CollapsibleCard>

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -256,16 +256,6 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       if (settings.pillOpacity === 0.24) {
         settings.pillOpacity = 0.3;
       }
-      // Bar graph is temporarily disabled (pending Figma 2075:7833). Heal any
-      // saved "bar" selection back to the circular ring so existing installs
-      // never render the unfinished bar progress. "none" (graph off) is left
-      // untouched.
-      if (settings.progressType === "bar") {
-        settings.progressType = "circular";
-      }
-      if (settings.graphType === "bar") {
-        settings.graphType = "ring";
-      }
       set({ settings });
       tauri.setOverlayClickThrough(!settings.useCustomPosition && settings.isPositionLocked);
       // Push the persisted target-app to the C# poller so it starts in sync.

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -289,6 +289,11 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       if (settings.pillOpacity === 0.24) {
         settings.pillOpacity = 0.3;
       }
+      // Font sizes are now capped (Stats ≤24, Label ≤18); clamp any larger
+      // value saved by an older build so the overlay never renders an
+      // unsupported size the picker can no longer represent.
+      if (settings.fontSizeValue > 24) settings.fontSizeValue = 24;
+      if (settings.fontSizeLabel > 18) settings.fontSizeLabel = 18;
       set({ settings });
       tauri.setOverlayClickThrough(!settings.useCustomPosition && settings.isPositionLocked);
       // Push the persisted target-app to the C# poller so it starts in sync.


### PR DESCRIPTION
## Summary
Adds the **Bar graph** option to the overlay's *Show graph* picker with the bar gauge built to match Figma, rebuilds gauge sizing around a shared size step, matches the FPS frametime graph to the design, and ships a batch of settings improvements (Fahrenheit threshold editing, persistent tabs, animated collapsible sections, feedback section on Help).

## Changes
- **Enable the bar graph option** — the Bar tile is selectable again; picking it applies `progressType: "bar"` (previously coerced to ring), toggling *Show graph* restores the last-picked type, and a saved bar choice persists (removed the `loadSettings` heal that reset it on launch).
- **Bar gauge matches Figma** — a fixed 16/20px block (stepping with the Stats font) of 2px bars with 1px gaps rendered as device-snapped SVG layers, so every bar is crisp and uniform at 100% display scale; the value fills bars bottom-up in the threshold color; 6/8px gap to the text.
- **Shared gauge size step** — new `gauge-metrics` helper: ring, bar, and pill min-height all step 16→20px at Stats font 16 per the design size sweeps, so switching gauge types never shifts pill height.
- **FPS frametime graph matches the design** — the rolling minimum anchors a flat baseline at the bottom of a 7px band and a proportional noise floor keeps steady frametimes flat at any framerate, while stutters draw as crisp triangular spikes (straight segments, miter tips) with edge fade gradients. Horizontal keeps value / graph / frametime as one 6px-gap cluster; vertical gives the graph its own full-width 24px row. The frametime reading renders at the label font size.
- **Temperature thresholds edit in the selected unit** — threshold inputs display and accept °F when Fahrenheit is selected, converting on edit; values stay stored and compared in °C so overlay colors are unchanged. Inputs are now labeled with their unit.
- **Settings UX** — the feedback section moved to the Help tab under the FAQs; tab UI state (expanded sections) persists across tab switches; collapsible sections animate open/close (200ms/150ms ease-out, disabled under reduced motion); Stats/Label font sizes are capped at 24/18 with oversized saved values clamped on load; the Pixel Shift icon is optically centered.
- **NET arrows** — pinned the down/up arrows to a fixed 12x15px box so they no longer scale with the font, in both ring and bar modes.

## Testing
- Bar geometry, spacing, centering, and pill padding verified across all 100 Label x Stats font combinations in both orientations.
- Ring and bar sizing verified against the design size sweeps across every font step; FPS graph shape verified against the design vectors and with live sensor data at 100% display scale.
- Celsius/Fahrenheit threshold editing round-trips verified; type-check and lint clean.
- Built and installed locally; confirmed the bar graph renders with live sensor data, threshold colors, and fixed-size NET arrows.
