### PR TITLE
fix(overlay): show presented FPS so the counter works on all GPUs

### DIFF
--- a/tauri-app/src/components/overlay/FpsSection.tsx
+++ b/tauri-app/src/components/overlay/FpsSection.tsx
@@ -22,12 +22,22 @@ export function FpsSection({ isHorizontal }: FpsSectionProps) {
   const { framerate, frametime } = settings.sensors;
   if (!framerate.isEnabled && !frametime.isEnabled) return null;
 
-  // Find FPS sensor
-  const fpsSensor = framerate.customReadingId
-    ? findSensorById(sensors, framerate.customReadingId)
-    : sensors.find(
-        (s) => s.name.toLowerCase().includes("fps") || s.name.toLowerCase().includes("framerate")
-      );
+  // Resolve the FPS sensor: the configured reading first, then fall back to the
+  // PresentMon "presented" sensor (frametime-derived — populated on every GPU,
+  // including APUs/iGPUs). The old name-only fallback searched for "fps"/
+  // "framerate", but the PresentMon sensors are named "Presented Frames"/
+  // "Displayed Frames", so it never matched and unconfigured installs silently
+  // read 0.
+  const fpsSensor =
+    findSensorById(sensors, framerate.customReadingId) ??
+    sensors.find((s) => s.identifier === "/presentmon/presented") ??
+    sensors.find(
+      (s) =>
+        s.identifier.toLowerCase().includes("presented") ||
+        s.name.toLowerCase().includes("presented") ||
+        s.name.toLowerCase().includes("fps") ||
+        s.name.toLowerCase().includes("framerate")
+    );
 
   const fpsValue = Math.round(fpsSensor?.value ?? 0);
   const lastFrametime = frametimeHistory.length > 0 ? frametimeHistory[frametimeHistory.length - 1] : 0;

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -270,6 +270,10 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
             customReadingId: "/presentmon/presented",
           },
         };
+        // Persist immediately so a fully-configured install (where
+        // autoSelectSensors produces no patch) doesn't re-run this heal
+        // on every subsequent startup.
+        tauri.saveSettings(settings);
       }
       // pillOpacity has no UI control, so a saved 0.24 can only be PR#8's
       // (now reverted) default leaking in from a prior run. Heal it back to

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -47,10 +47,9 @@ function autoSelectSensors(
 
   const cpuHw = [HardwareType.Cpu];
   const gpuHw = [HardwareType.GpuNvidia, HardwareType.GpuAmd, HardwareType.GpuIntel];
-  const netHw = [HardwareType.Network];
 
-  const tryFill = (
-    key: SensorKey,
+  const tryFill = <K extends SensorKey>(
+    key: K,
     hwTypes: HardwareType[],
     sType: SensorType,
     prefer: string[]
@@ -59,7 +58,7 @@ function autoSelectSensors(
     if (!current.customReadingId) {
       const id = findBest(sensors, hardwares, hwTypes, sType, prefer);
       if (id) {
-        patch[key] = { ...current, customReadingId: id } as any;
+        patch[key] = { ...current, customReadingId: id } as OverlaySettings["sensors"][K];
         changed = true;
       }
     }
@@ -119,21 +118,28 @@ function autoSelectSensors(
     changed = true;
   }
 
-  // Framerate
-  const framerateSensor = sensors.find(
-    (s) =>
-      !settings.sensors.framerate.customReadingId &&
-      (s.name.toLowerCase().includes("display") ||
-        s.name.toLowerCase().includes("fps") ||
-        s.identifier.toLowerCase().includes("displayed") ||
-        s.identifier.toLowerCase().includes("framerate"))
-  );
-  if (framerateSensor) {
-    patch["framerate"] = {
-      ...settings.sensors.framerate,
-      customReadingId: framerateSensor.identifier,
-    };
-    changed = true;
+  // Framerate — prefer the PresentMon "presented" sensor. It's derived from
+  // present-to-present frametime, which PresentMon reports on every config
+  // (including AMD APUs / iGPUs). The "displayed" sensor needs display-timing
+  // telemetry that some GPUs don't expose, so it reads 0 there (and older
+  // builds surfaced -1) — see the displayed→presented heal in loadSettings.
+  if (!settings.sensors.framerate.customReadingId) {
+    const framerateSensor =
+      sensors.find((s) => s.identifier.toLowerCase().includes("presented")) ??
+      sensors.find(
+        (s) =>
+          s.name.toLowerCase().includes("fps") ||
+          s.name.toLowerCase().includes("framerate") ||
+          s.identifier.toLowerCase().includes("displayed") ||
+          s.identifier.toLowerCase().includes("framerate")
+      );
+    if (framerateSensor) {
+      patch["framerate"] = {
+        ...settings.sensors.framerate,
+        customReadingId: framerateSensor.identifier,
+      };
+      changed = true;
+    }
   }
 
   return changed ? patch : null;
@@ -247,6 +253,21 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
             ...fr,
             targetAppName: fr.targetAppName || fr.customReadingId,
             customReadingId: "",
+          },
+        };
+      }
+      // FPS source heal: older builds auto-selected the PresentMon "displayed"
+      // sensor, which reads 0 on GPUs that don't expose display-timing telemetry
+      // (the same machines where the old reader surfaced -1). The "presented"
+      // sensor is frametime-derived and populates everywhere, so repoint
+      // existing installs at it. Only the auto-managed presentmon identifier is
+      // rewritten — a user's own custom pick is left untouched.
+      if (settings.sensors.framerate.customReadingId === "/presentmon/displayed") {
+        settings.sensors = {
+          ...settings.sensors,
+          framerate: {
+            ...settings.sensors.framerate,
+            customReadingId: "/presentmon/presented",
           },
         };
       }


### PR DESCRIPTION
## Summary

Fixes the recurring "FPS stuck on **-1** / **0**" reports (Discord *FPS BUG STUCK ON -1 FPS*). The counter never showed a real framerate on certain machines — notably AMD APUs / integrated GPUs (one reporter is on a Ryzen 3 4350G).

## Root cause

FPS was read from the PresentMon **"displayed"** sensor, which is computed from display-timing telemetry (the display-to-display interval). Some GPUs — integrated graphics in particular — don't expose that telemetry:

- **Older builds** passed PresentMon's raw column straight through, and PresentMon emits `-1` for an unavailable metric → the overlay printed **-1**.
- **Current builds** clamp empty/invalid to 0 → the same machines now read **0**.

Either way the metric was permanently unavailable on that hardware, which is why it was "stuck since install" and survived reinstalls — it's a telemetry gap, not corrupted state.

The **"presented"** sensor is computed from present-to-present **frametime** (a CPU/DXGI-side measurement) and is reported on every configuration, including APUs/iGPUs. It's also the figure other overlays label "Framerate" (RTSS / MSI Afterburner).

A corroborating detail: the original report shows the value as a *parsed* `-1` (not a blank), which means PresentMon was capturing and attributing the user's frames — only the chosen column was unavailable. Reading the frametime-derived "presented" value uses data those same rows already carry.

## Changes (frontend only — no sidecar/Rust changes)

- **`settings-store.ts` › `autoSelectSensors`** — fresh installs auto-select the presented sensor.
- **`settings-store.ts` › `loadSettings`** — one-time heal repoints existing saves from `/presentmon/displayed` → `/presentmon/presented`. Only the auto-managed PresentMon id is rewritten; a user's manual pick is left untouched.
- **`overlay/FpsSection.tsx`** — resilient resolution (configured id → presented → name match) and fixes a dead fallback: the PresentMon sensors are named *"Presented Frames" / "Displayed Frames"*, so the previous `fps`/`framerate` name search never matched and unconfigured installs silently read 0.

Type-check (`tsc --noEmit`) and the production build pass locally; the two touched files are lint-clean. (Unrelated repo-wide ESLint debt in other files is intentionally left for a separate cleanup PR.)

## Windows test plan

> Verified on macOS for type-check/build only — this is the Windows-only app (PresentMon + .NET sidecar), so it needs a real Windows run to confirm. Steps are written to be followed directly.

**Build & run** (mirrors `.github/workflows/build.yml`):
1. `git fetch && git checkout fix/fps-presented-sensor`
2. `cd tauri-app && npm install --legacy-peer-deps`
3. Build the sidecar:
   - `cd HardwareMonitor/HardwareMonitor && dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true`
   - Stage PresentMon next to it: `cp presentmon/* HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/`
4. From `tauri-app/`: `npm run tauri:build` (bundles the sidecar) — or `npm run tauri:dev` for fast iteration. The app self-elevates for the ETW session.

**Expected result:**
5. Open any game or 3D app (fullscreen or borderless). The overlay **FPS** should show a **live, non-zero** number that tracks the framerate — not `-1`, not `0`.
6. **If an AMD APU / integrated-GPU machine is available, test there** — that's the reported repro hardware (Ryzen 3 4350G and similar).
7. **Existing-install check:** on a box that previously ran a release build, confirm FPS works after updating to this branch (the displayed→presented heal fires on first load).

**If FPS is still `0` in-game** (that would point at frame *attribution*, which is a separate fix, not the sensor choice):
8. Enable verbose logging: in `HardwareMonitor/HardwareMonitor/Program.cs`, add `.MinimumLevel.Debug()` to the Serilog config and rebuild (the FPS attribution lines log at Debug level).
9. Reproduce in-game ~30s, then grab the newest `LogFiles/<date>/Log.txt` (sits next to `HardwareMonitor.exe` — the install dir, or the `publish` dir in a dev build).
10. Report the `[FPS-DEBUG] fg=… sel=… fps=… rows=… counted=[…] dropped=[…]` lines:
    - `rows=0` → PresentMon isn't capturing (admin/ETW path).
    - `counted` empty + `dropped` populated → the foreground-app match is failing.
    - `counted` populated but overlay still 0 → sensor wiring downstream.

**Please report back:** GPU model, whether FPS now shows in-game, and (if not) the log lines above.
