### PR TITLE
fix(sidecar): keep running when the WinRing0 driver is blocked; bump LHM to 0.9.6

### DIFF
--- a/HardwareMonitor/HardwareMonitor/HardwareMonitor.csproj
+++ b/HardwareMonitor/HardwareMonitor/HardwareMonitor.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre392" />
+        <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.0"/>
         <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0"/>

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -40,8 +40,27 @@ public class MonitorPoller(
     {
         logger.LogInformation("Starting monitor");
 
-        _computer.Open();
-        _computer.Accept(new UpdateVisitor());
+        // The LibreHardwareMonitor kernel driver (WinRing0) can be quarantined
+        // or blocked — Windows Defender flags it as
+        // "VulnerableDriver:WinNT/Winring0", and HVCI / Smart App Control can
+        // refuse to load it. If Open() throws, swallow it so the sidecar keeps
+        // running: FPS (PresentMon) and any sensors that don't need ring0 stay
+        // alive instead of crashing the process into the supervisor's respawn
+        // loop. Only low-level readings (CPU temperature/power via MSRs) are
+        // lost. See SECURITY.md.
+        try
+        {
+            _computer.Open();
+            _computer.Accept(new UpdateVisitor());
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "LibreHardwareMonitor failed to initialize — the kernel driver may be " +
+                "blocked or quarantined (Windows Defender 'VulnerableDriver:WinNT/Winring0'). " +
+                "Continuing with FPS and any sensors that initialized; low-level CPU sensors " +
+                "may be unavailable.");
+        }
 
         // Log discovered hardware and sensor counts for diagnostics
         int hwCount = 0, sensorCount = 0;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,11 @@ Cleanmeter uses [LibreHardwareMonitor](https://github.com/LibreHardwareMonitor/L
 WinRing0 is **a known-vulnerable driver** ([CVE-2020-14979](https://nvd.nist.gov/vuln/detail/CVE-2020-14979)). Microsoft Defender therefore flags it under names like:
 
 - `VulnerableDriver:WinNT/Winring0`
+- `VulnerableDriver:WinNT/Winring0.G` (a newer, more aggressive variant that rolled out in 2025)
 - `HackTool:Win32/Winring0`
 - `Trojan:Win32/Vigorf.A`
+
+Because the detection ships in Defender's definitions, it can **re-appear after any Defender definition update** even if you previously allowed the file — so you may see it quarantined "again" on a machine where Cleanmeter was working fine the day before.
 
 **These detections are not false positives.** Microsoft has [explicitly stated](https://support.microsoft.com/en-us/windows/microsoft-defender-antivirus-alert-vulnerabledriver-winnt-winring0-eb057830-d77b-41a2-9a34-015a5d203c42) that the driver is vulnerable in a generic sense — not that Cleanmeter or LibreHardwareMonitor is malicious. The same flag affects MSI Afterburner, FanControl, OpenHardwareMonitor, HWiNFO, and many other hardware-monitoring tools that share this driver.
 
@@ -16,8 +19,9 @@ If you do not want this driver on your machine, **do not install Cleanmeter**. H
 
 ## What Cleanmeter does about it
 
-- Cleanmeter's CI has **Authenticode signing infrastructure wired up** for the installer, main executable (`cleanmeter.exe`), background sidecar (`HardwareMonitor.exe`), and bundled `presentmon.exe`. As of v2.1.3 the project does not yet have a code-signing certificate funded, so tagged release builds are currently shipped unsigned. Once a certificate is added to the repository's GitHub secrets, every subsequent tag will produce signed bundles automatically with no further code changes — the signing path is conditional on the secret being present.
+- Cleanmeter's CI has **Authenticode signing infrastructure wired up** for the installer, main executable (`cleanmeter.exe`), background sidecar (`HardwareMonitor.exe`), and bundled `presentmon.exe`. The project does not yet have a code-signing certificate funded, so tagged release builds are currently shipped unsigned. Once a certificate is added to the repository's GitHub secrets, every subsequent tag will produce signed bundles automatically with no further code changes — the signing path is conditional on the secret being present. (Note: signing the Cleanmeter binaries would clear the SmartScreen prompt below, but it would **not** clear the WinRing0 driver flag — that detection is on the driver's contents, independent of our signatures.)
 - Cleanmeter does not bundle a separately-signed kernel driver of its own. The WinRing0 driver lives inside `LibreHardwareMonitorLib`.
+- **Cleanmeter keeps running if the driver is blocked.** If Defender (or HVCI / Smart App Control) quarantines or refuses to load the driver, the app does not crash: the FPS counter (PresentMon) and every sensor that doesn't need kernel access keep working. Only low-level readings that require the driver — chiefly CPU temperature and package power via MSRs — drop out until the driver is restored/allowed.
 
 ## What you'll see today (unsigned releases)
 


### PR DESCRIPTION
## Summary

Addresses the Discord report *HardwareMonitor.sys blocked by Windows Defender again*. It does **not** make the Defender flag disappear (that isn't possible in code — see below); it makes the flag **non-fatal** and keeps the app working when the driver is blocked, bumps the sensor library, and updates the docs.

## Background — why the flag can't be code-fixed

`HardwareMonitor.sys` is LibreHardwareMonitor's **WinRing0** kernel driver (extracted at runtime to `%LOCALAPPDATA%\CleanMeter\`). It's a genuinely vulnerable driver (CVE-2020-14979), and Defender's detection is **content-based**, so it fires regardless of which app ships it or whether our binaries are signed. A more aggressive `.G` variant rolled out in 2025, which is why it recurs "every now and then" — each Defender definition update can re-quarantine the file. Latest LibreHardwareMonitor (0.9.6) still triggers it. The only true fix is shipping a mitigated, separately **EV-signed** driver, which needs a funded certificate — out of scope here.

## What this PR does

- **Sidecar no longer crash-loops when the driver is blocked.** `Computer.Open()` was unguarded; if Defender quarantined the driver (or HVCI / Smart App Control refused it), the exception propagated out of the background service, the sidecar exited, and the supervisor respawned it straight into the same failure. It's now wrapped so the process keeps running: **FPS (PresentMon) and every sensor that doesn't need ring0 keep working**; only low-level CPU temperature/power (MSR reads) drop out. The failure is logged with the Defender detection name.
- **Bumps `LibreHardwareMonitorLib` 0.9.5-pre392 → 0.9.6** (latest stable).
- **`SECURITY.md`**: documents the `.G` variant, that the detection recurs after Defender definition updates, and the new graceful-degradation behaviour.

## What this PR does NOT do

It does not remove the Defender quarantine prompt — see above. Users who want to keep low-level sensors still need to allow the file in Defender (documented in `SECURITY.md`).

## Windows test plan

> Verified on macOS for review only — Windows-only app, needs a real run. (No .NET on the authoring machine, so the C# change is review-only — please confirm it compiles.)

**Build & run** (see `.github/workflows/build.yml`):
1. `git fetch && git checkout fix/sidecar-survives-blocked-driver`
2. Build the sidecar: `cd HardwareMonitor/HardwareMonitor && dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true` — **confirm it restores `LibreHardwareMonitorLib 0.9.6` and compiles** (the MonitorPoller try/catch).
3. `cp presentmon/* HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/`
4. From `tauri-app/`: `npm install --legacy-peer-deps` then `npm run tauri:build` (or `tauri:dev`).

**Normal-operation regression check (the 0.9.6 bump):**
5. Launch and confirm CPU/GPU/RAM sensors still populate — i.e. the LHM version bump didn't change sensor names/identifiers in a way that breaks saved `customReadingId`s. Watch CPU temp, CPU/GPU usage, VRAM, RAM, net rates.

**Graceful-degradation check (the core fix):**
6. Block the driver the clean way: **Windows Security → Device security → Core isolation → turn ON Memory Integrity**, reboot. That stops WinRing0 from loading without uninstalling anything. (Alternatively, let Defender quarantine `HardwareMonitor.sys` and don't restore it.)
7. Launch Cleanmeter and confirm:
   - The app **does not** crash-loop (no flicker of the overlay appearing/disappearing; `HardwareMonitor.exe` stays up — check Task Manager).
   - **FPS still works** in a game, and GPU/RAM/network sensors still read.
   - CPU temperature / package power read 0 / are absent (expected — those need the driver).
   - The sidecar log `LogFiles/<date>/Log.txt` contains the line: *"LibreHardwareMonitor failed to initialize — the kernel driver may be blocked or quarantined…"*.
8. Turn Memory Integrity back OFF (reboot) and confirm full sensors return.

**Please report:** whether it compiles on 0.9.6, whether sensors are unchanged after the bump, and whether step 7 behaves as described (no crash-loop, FPS + non-driver sensors alive, log line present).
