### PR TITLE
chore(lint): clear pre-existing ESLint errors across the frontend

### DIFF
--- a/tauri-app/eslint.config.js
+++ b/tauri-app/eslint.config.js
@@ -20,4 +20,14 @@ export default defineConfig([globalIgnores(['dist']), {
     ecmaVersion: 2020,
     globals: globals.browser,
   },
+}, {
+  // Design-system primitives in app/components/ intentionally co-locate their
+  // cva variant maps (buttonVariants, cardVariants, …) next to the component,
+  // per the shadcn/ui convention. That trips react-refresh's "only export
+  // components" rule — a dev-only fast-refresh concern, not worth scattering the
+  // variants into sidecar files. Scope the rule off for this directory only.
+  files: ['src/app/components/**/*.{ts,tsx}'],
+  rules: {
+    'react-refresh/only-export-components': 'off',
+  },
 }, ...storybook.configs["flat/recommended"]])

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -30,11 +30,10 @@ function MonitoringBanner() {
     return () => clearTimeout(timer);
   }, []);
 
-  useEffect(() => {
-    if (sensorData) setShowBanner(false);
-  }, [sensorData]);
-
-  if (!showBanner) return null;
+  // Hide the banner as soon as data arrives — derived from sensorData rather
+  // than mirrored into state via an effect (which would cascade an extra
+  // render). showBanner still gates the 8s "no data yet" delay above.
+  if (!showBanner || sensorData) return null;
 
   return (
     <div className="border-b border-yellow-400 bg-yellow-50 px-4 py-2.5 text-[13px] leading-snug text-yellow-900 dark:border-yellow-700 dark:bg-yellow-950 dark:text-yellow-200">

--- a/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
+++ b/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
@@ -92,8 +92,10 @@ export function SensorPickerModal({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  // Reset the search field whenever the modal closes.
+  // Reset the search field whenever the modal closes. Prop-sync effect, not a
+  // render cascade — the setState only fires on the open→closed transition.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!open) setQuery("");
   }, [open]);
 
@@ -107,12 +109,14 @@ export function SensorPickerModal({
   useEffect(() => {
     if (!open) return;
     const idx = options.findIndex((s) => s.identifier === value);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveIndex(idx >= 0 ? idx : 0);
   }, [open, value, options]);
 
   // Every keystroke re-narrows the list. Snap to the top match so Enter
   // selects what the user is reading at the top.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveIndex(0);
   }, [query]);
 

--- a/tauri-app/src/hooks/useSensorData.ts
+++ b/tauri-app/src/hooks/useSensorData.ts
@@ -39,6 +39,12 @@ export function useFrametimeHistory(maxPoints = 30) {
   const prevData = useRef<HardwareMonitorData | null>(null);
   const [history, setHistory] = useState<number[]>([]);
 
+  // Accumulate a rolling buffer by comparing the incoming store value against a
+  // ref and updating state during render — React's documented "adjust state
+  // when an input changes" pattern, which avoids the extra paint a useEffect
+  // would cost. react-hooks/refs flags the render-phase ref reads; they're
+  // intentional and safe here (single overlay instance, polled ~every 500ms).
+  /* eslint-disable react-hooks/refs */
   if (sensorData && sensorData !== prevData.current) {
     prevData.current = sensorData;
 
@@ -52,6 +58,7 @@ export function useFrametimeHistory(maxPoints = 30) {
       setHistory([...buf]);
     }
   }
+  /* eslint-enable react-hooks/refs */
 
   return history;
 }
@@ -64,6 +71,9 @@ export function useNetworkHistory(maxPoints = 30) {
   const prevData = useRef<HardwareMonitorData | null>(null);
   const [histories, setHistories] = useState<{ downHistory: number[]; upHistory: number[] }>({ downHistory: [], upHistory: [] });
 
+  // Same render-phase rolling-buffer pattern as useFrametimeHistory above —
+  // see that hook for why the react-hooks/refs reads are intentional.
+  /* eslint-disable react-hooks/refs */
   if (sensorData && sensorData !== prevData.current) {
     prevData.current = sensorData;
 
@@ -89,6 +99,7 @@ export function useNetworkHistory(maxPoints = 30) {
       setHistories({ downHistory: [...downRef.current], upHistory: [...upRef.current] });
     }
   }
+  /* eslint-enable react-hooks/refs */
 
   return histories;
 }

--- a/tauri-app/src/lib/tauri.ts
+++ b/tauri-app/src/lib/tauri.ts
@@ -11,13 +11,10 @@ import type {
 // When running via `npm run dev` in a browser (no Tauri runtime),
 // all invoke/listen calls are no-ops so the UI can be previewed.
 
-export const isBrowser = !(window as any).__TAURI_INTERNALS__;
-
-const noop = () => Promise.resolve(undefined as any);
-const noopListen = (): Promise<UnlistenFn> => Promise.resolve(() => {});
+export const isBrowser = !("__TAURI_INTERNALS__" in window);
 
 async function safeInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
-  if (isBrowser) return undefined as any;
+  if (isBrowser) return undefined as T;
   const { invoke } = await import("@tauri-apps/api/core");
   return invoke<T>(cmd, args);
 }


### PR DESCRIPTION
## Summary

Clears the pre-existing ESLint errors across the frontend (44 across 12 files). Separate from the FPS fix (#25) and sidecar fix (#26) — disjoint files, no overlap with Saad's bar-graph PR (#24). **No behaviour changes intended**; `tsc` and the production build pass.

## Approach (real fixes where safe; justified suppressions where the rule fights an intentional pattern)

- **`tauri.ts`** (3) — real fixes: drop two unused no-op helpers, replace `(window as any)` with an `in` check, and `undefined as any` with the generic return type `T`.
- **`App.tsx`** (1, `set-state-in-effect`) — real fix: derive the monitoring banner's visibility from `sensorData` in render instead of mirroring it into state via an effect. Same behaviour, one fewer render.
- **`SensorPickerModal.tsx`** (3, `set-state-in-effect`) — the open / close / query effects are legitimate prop-sync (reset search on close, seed highlight on open, snap to top on keystroke). Annotated with reasons rather than restructuring modal keyboard handling, which would add risk the rule doesn't justify.
- **`useSensorData.ts`** (26, `react-hooks/refs`) — the two overlay history hooks (`useFrametimeHistory`, `useNetworkHistory`) use React's documented ["adjust state during render"](https://react.dev/reference/react/useState#storing-information-from-previous-renders) pattern, which avoids the extra paint a `useEffect` would cost on every ~500 ms poll. Documented why the render-phase ref reads are intentional and scoped the rule off for those two blocks. **The hooks are unchanged — zero behaviour difference to the live overlay graphs.**
- **`eslint.config.js`** (9, `react-refresh/only-export-components`) — the design-system primitives in `app/components/` co-locate their `cva` variant maps (`buttonVariants`, `cardVariants`, …) next to the component per the shadcn/ui convention. Scoped the rule off for that directory (a dev-only fast-refresh concern) rather than scattering 9 variant files.

## Note on the 2 remaining errors

`eslint src` on this branch still reports 2 errors in `src/stores/settings-store.ts` (an unused `netHw` and an `as any`). Those are **already fixed in PR #25** — I left that file untouched here so the two PRs don't conflict. After both merge, `eslint src` is clean.

## Testing

No behaviour changes are intended, so this is mostly a read-through. The two things worth a 30-second smoke check on a Windows build (saadah7):
1. **Overlay graphs still animate** — the frametime graph and the network up/down graph (the `useSensorData` hooks were only annotated, not restructured, so this should be identical).
2. **Sensor-picker modal** in Settings still opens, filters as you type, and arrow-key navigation works.

`tsc --noEmit` clean, `npm run build` succeeds, `eslint src` = 0 (with #25).
