### PR TITLE
feat(app): show animated logo splash on startup

### DIFF
--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { TopBar } from "@/components/settings/TopBar";
 import { TabNav, type SettingsTab as TabKey } from "@/components/settings/TabNav";
 import { StatsTab } from "@/components/settings/stats/StatsTab";
@@ -11,6 +11,7 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { useUpdaterStore } from "@/stores/updater-store";
 import { UpdateBanner } from "@/components/settings/UpdateBanner";
 import { checkDotnetRuntime, onSettingsChanged } from "@/lib/tauri";
+import { SplashScreen } from "@/components/SplashScreen";
 
 function MonitoringBanner() {
   const sensorData = useSettingsStore((s) => s.sensorData);
@@ -63,6 +64,13 @@ function MonitoringBanner() {
 
 export default function App() {
   const [activeTab, setActiveTab] = useState<TabKey>("stats");
+  // Startup splash: shown on every launch from first paint, covering the UI
+  // (and the light→dark theme flash while saved settings load) until the
+  // logo's ring sweep completes, then fades out and unmounts. Stable callback
+  // so App re-renders (settings load ~200ms in) don't re-run the splash's
+  // timer effect and stretch the hold.
+  const [showSplash, setShowSplash] = useState(true);
+  const handleSplashDone = useCallback(() => setShowSplash(false), []);
   const settings = useSettingsStore((s) => s.settings);
   const loadSettings = useSettingsStore((s) => s.loadSettings);
   const loadPreferences = useSettingsStore((s) => s.loadPreferences);
@@ -115,7 +123,8 @@ export default function App() {
   }, [settings.isDarkTheme]);
 
   return (
-    <div className="mx-auto flex h-screen w-full max-w-[651px] flex-col overflow-hidden rounded-[12px] border border-foreground/10 bg-background text-foreground shadow-sm">
+    <div className="relative mx-auto flex h-screen w-full max-w-[651px] flex-col overflow-hidden rounded-[12px] border border-foreground/10 bg-background text-foreground shadow-sm">
+      {showSplash && <SplashScreen onDone={handleSplashDone} />}
       <TopBar />
       <MonitoringBanner />
       <UpdateBanner />

--- a/tauri-app/src/components/SplashScreen.tsx
+++ b/tauri-app/src/components/SplashScreen.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import "./splash-screen.css";
+
+// Startup splash: the animated CleanMeter logo (authored as a standalone
+// CSS-only HTML snippet, ported verbatim — see splash-screen.css) shown once
+// per launch over the settings window. Timeline: entrance + ring sweep
+// complete at ~1.93s into the 3480ms cycle; hold to 2.4s; fade the shell
+// 280ms; then onDone unmounts it before the authored loop seam (3.32s) can
+// show. Reduced motion renders the finished logo statically for the same
+// beat (the CSS handles it), so nobody gets a flashing startup.
+const HOLD_MS = 2400;
+const FADE_MS = 280;
+
+interface SplashScreenProps {
+  onDone: () => void;
+}
+
+export function SplashScreen({ onDone }: SplashScreenProps) {
+  const [fading, setFading] = useState(false);
+
+  useEffect(() => {
+    const fadeTimer = setTimeout(() => setFading(true), HOLD_MS);
+    const doneTimer = setTimeout(onDone, HOLD_MS + FADE_MS);
+    return () => {
+      clearTimeout(fadeTimer);
+      clearTimeout(doneTimer);
+    };
+  }, [onDone]);
+
+  return (
+    <div className={fading ? "cm-splash cm-splash--fading" : "cm-splash"}>
+      <div className="cm-logo" role="img" aria-label="CleanMeter">
+        <div className="cm-logo__slide">
+          <svg viewBox="0 0 172 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              {/* each mask stroke traces a ring centerline; rotate(-90) starts
+                  the sweep at 12 o'clock, dashoffset 100→0 fills clockwise */}
+              <mask id="cm-reveal-green" maskUnits="userSpaceOnUse" x="0" y="0" width="172" height="66">
+                <circle className="cm-trim" cx="32.6267" cy="32.6267" r="28.1" pathLength="100" transform="rotate(-90 32.6267 32.6267)" />
+              </mask>
+              <mask id="cm-reveal-yellow" maskUnits="userSpaceOnUse" x="0" y="0" width="172" height="66">
+                <circle className="cm-trim" cx="85.8568" cy="32.6267" r="28.1" pathLength="100" transform="rotate(-90 85.8568 32.6267)" />
+              </mask>
+              <mask id="cm-reveal-red" maskUnits="userSpaceOnUse" x="0" y="0" width="172" height="66">
+                <circle className="cm-trim" cx="139.075" cy="32.6267" r="28.1" pathLength="100" transform="rotate(-90 139.075 32.6267)" />
+              </mask>
+            </defs>
+
+            {/* gray "track" layer (same path data, recolored) */}
+            <g>
+              <path className="cm-track cm-track--g" d="M65.2534 32.6267C65.2534 50.6459 50.6459 65.2534 32.6267 65.2534C14.6075 65.2534 0 50.6459 0 32.6267C0 14.6075 14.6075 0 32.6267 0C50.6459 0 65.2534 14.6075 65.2534 32.6267ZM9.04279 32.6267C9.04279 45.6517 19.6017 56.2106 32.6267 56.2106C45.6517 56.2106 56.2106 45.6517 56.2106 32.6267C56.2106 19.6017 45.6517 9.04279 32.6267 9.04279C19.6017 9.04279 9.04279 19.6017 9.04279 32.6267Z" />
+              <path className="cm-track cm-track--y" d="M66.2845 19.4646C70.5207 13.1778 77.7058 9.04279 85.8568 9.04279C98.8818 9.04279 109.441 19.6017 109.441 32.6267C109.441 45.6517 98.8818 56.2106 85.8568 56.2106C77.7519 56.2106 70.602 52.1222 66.3567 45.8953C65.1694 48.9308 63.5824 51.7659 61.6604 54.336C61.6361 54.3684 61.6118 54.4008 61.5875 54.4331C67.56 61.0759 76.2205 65.2534 85.8568 65.2534C103.876 65.2534 118.483 50.6459 118.483 32.6267C118.483 14.6075 103.876 0 85.8568 0C76.1565 0 67.445 4.23321 61.4688 10.953C61.4733 10.959 61.4778 10.965 61.4824 10.9709C63.2901 13.3475 64.8095 15.9553 65.9883 18.7422C66.0896 18.9817 66.1883 19.2225 66.2845 19.4646Z" />
+              <path className="cm-track cm-track--r" d="M119.49 19.484C123.724 13.1863 130.916 9.04279 139.075 9.04279C152.1 9.04279 162.659 19.6017 162.659 32.6267C162.659 45.6517 152.1 56.2106 139.075 56.2106C130.962 56.2106 123.805 52.1137 119.562 45.8758C118.374 48.9186 116.784 51.7604 114.858 54.336C114.837 54.3642 114.816 54.3923 114.794 54.4205C120.767 61.0706 129.433 65.2534 139.075 65.2534C157.094 65.2534 171.702 50.6459 171.702 32.6267C171.702 14.6075 157.094 0 139.075 0C129.369 0 120.652 4.23852 114.676 10.9657C116.638 13.5447 118.261 16.3962 119.478 19.4535C119.482 19.4637 119.486 19.4739 119.49 19.484Z" />
+            </g>
+
+            {/* colored logo (exact Figma paths + fills), revealed by the masks */}
+            <g>
+              <path className="cm-fill" mask="url(#cm-reveal-green)" d="M65.2534 32.6267C65.2534 50.6459 50.6459 65.2534 32.6267 65.2534C14.6075 65.2534 0 50.6459 0 32.6267C0 14.6075 14.6075 0 32.6267 0C50.6459 0 65.2534 14.6075 65.2534 32.6267ZM9.04279 32.6267C9.04279 45.6517 19.6017 56.2106 32.6267 56.2106C45.6517 56.2106 56.2106 45.6517 56.2106 32.6267C56.2106 19.6017 45.6517 9.04279 32.6267 9.04279C19.6017 9.04279 9.04279 19.6017 9.04279 32.6267Z" fill="#17B26A" />
+              <path className="cm-fill" mask="url(#cm-reveal-red)" d="M119.49 19.484C123.724 13.1863 130.916 9.04279 139.075 9.04279C152.1 9.04279 162.659 19.6017 162.659 32.6267C162.659 45.6517 152.1 56.2106 139.075 56.2106C130.962 56.2106 123.805 52.1137 119.562 45.8758C118.374 48.9186 116.784 51.7604 114.858 54.336C114.837 54.3642 114.816 54.3923 114.794 54.4205C120.767 61.0706 129.433 65.2534 139.075 65.2534C157.094 65.2534 171.702 50.6459 171.702 32.6267C171.702 14.6075 157.094 0 139.075 0C129.369 0 120.652 4.23852 114.676 10.9657C116.638 13.5447 118.261 16.3962 119.478 19.4535C119.482 19.4637 119.486 19.4739 119.49 19.484Z" fill="#F04438" />
+              <path className="cm-fill" mask="url(#cm-reveal-yellow)" d="M66.2845 19.4646C70.5207 13.1778 77.7058 9.04279 85.8568 9.04279C98.8818 9.04279 109.441 19.6017 109.441 32.6267C109.441 45.6517 98.8818 56.2106 85.8568 56.2106C77.7519 56.2106 70.602 52.1222 66.3567 45.8953C65.1694 48.9308 63.5824 51.7659 61.6604 54.336C61.6361 54.3684 61.6118 54.4008 61.5875 54.4331C67.56 61.0759 76.2205 65.2534 85.8568 65.2534C103.876 65.2534 118.483 50.6459 118.483 32.6267C118.483 14.6075 103.876 0 85.8568 0C76.1565 0 67.445 4.23321 61.4688 10.953C61.4733 10.959 61.4778 10.965 61.4824 10.9709C63.2901 13.3475 64.8095 15.9553 65.9883 18.7422C66.0896 18.9817 66.1883 19.2225 66.2845 19.4646Z" fill="#FEC84B" />
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tauri-app/src/components/splash-screen.css
+++ b/tauri-app/src/components/splash-screen.css
@@ -1,0 +1,75 @@
+/* ============ CleanMeter animated logo (scoped to .cm-logo) ============
+   Ported verbatim from the authored standalone HTML (self-contained, no JS).
+   The keyframes are designed as an infinite loop with a fade-out seam at
+   95.5–100%; the splash unmounts during its own container fade (~2.7s),
+   well before the seam, so a single pass is all that's ever visible. */
+.cm-logo { --cm-loop: 3480ms; --cm-track: #E3E5E4;
+           display: inline-block; width: 220px; line-height: 0; }
+.cm-logo svg { width: 100%; height: auto; display: block; overflow: visible; }
+
+/* entrance: slide in from the RIGHT (ease-out, 30px over ~1363ms), then hold.
+   Opacity fade-in stays short (tracks below), so the logo keeps gently
+   drifting into place after it's already fully opaque. */
+.cm-logo__slide { animation: cm-slide var(--cm-loop) cubic-bezier(0.16,1,0.3,1) infinite; }
+@keyframes cm-slide { 0% { transform: translateX(30px); } 39.2%,100% { transform: translateX(0); } }
+
+/* gray tracks fade in — green (left) leads, then yellow, then red */
+.cm-logo .cm-track { fill: var(--cm-track); opacity: 0; }
+.cm-logo .cm-track--g { animation: cm-trackG var(--cm-loop) ease-out infinite; }
+.cm-logo .cm-track--y { animation: cm-trackY var(--cm-loop) ease-out infinite; }
+.cm-logo .cm-track--r { animation: cm-trackR var(--cm-loop) ease-out infinite; }
+@keyframes cm-trackG { 0%,1%   { opacity:0; } 5%   { opacity:1; } 72% { opacity:1; } 95.5%,100% { opacity:0; } }
+@keyframes cm-trackY { 0%,2.5% { opacity:0; } 6.5% { opacity:1; } 72% { opacity:1; } 95.5%,100% { opacity:0; } }
+@keyframes cm-trackR { 0%,4%   { opacity:0; } 8%   { opacity:1; } 72% { opacity:1; } 95.5%,100% { opacity:0; } }
+
+/* colored fills: held empty through the fade-in, revealed only by the sweep */
+.cm-logo .cm-fill { animation: cm-fill var(--cm-loop) ease infinite; }
+@keyframes cm-fill {
+  0%, 17.2%   { opacity: 0; }   /* no colored fill during the fade-in     */
+  17.4%, 72%  { opacity: 1; }   /* on, in time for the sweep at 17.2%      */
+  95.5%, 100% { opacity: 0; }   /* fade out                               */
+}
+
+/* clockwise sweep — ease sampled frame-by-frame from the reference video.
+   dash 100 / gap 200 keeps the whole path inside the gap when closed, so
+   no round-cap poke leaks the fill. */
+.cm-logo .cm-trim {
+  stroke:#fff; fill:none; stroke-width:12; stroke-linecap:round;
+  stroke-dasharray:100 200; stroke-dashoffset:100;
+  animation: cm-trim var(--cm-loop) linear infinite;
+}
+@keyframes cm-trim {
+  0%,17.2% { stroke-dashoffset:100; } 21.5% { stroke-dashoffset:93; }
+  25.8%    { stroke-dashoffset:85;  } 30.1% { stroke-dashoffset:62; }
+  34.4%    { stroke-dashoffset:33;  } 38.8% { stroke-dashoffset:15; }
+  43.1%    { stroke-dashoffset:9;   } 47.4% { stroke-dashoffset:5;  }
+  51.7%    { stroke-dashoffset:2;   } 55.5% { stroke-dashoffset:0;  }
+  95.5%    { stroke-dashoffset:0;   } 100%  { stroke-dashoffset:100; } /* re-close before loop seam */
+}
+
+/* accessibility: reduced motion = show the finished logo instantly */
+@media (prefers-reduced-motion: reduce) {
+  .cm-logo__slide { animation:none; transform:none; }
+  .cm-logo .cm-track { animation:none; opacity:0; }
+  .cm-logo .cm-fill  { animation:none; opacity:1; }
+  .cm-logo .cm-trim  { animation:none; stroke-dashoffset:0; }
+}
+
+/* ============ Splash shell (startup overlay around the logo) ============
+   Covers the settings window from first paint until the sweep completes:
+   entrance + sweep finish at ~55.5% of the 3480ms cycle (~1.93s); hold to
+   2.4s, then fade the whole shell out (280ms) and unmount. bg-background
+   keeps it theme-aware and hides the light→dark flash while the saved
+   theme loads. */
+.cm-splash {
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--background);
+  opacity: 1;
+  transition: opacity 280ms ease-out;
+}
+.cm-splash--fading { opacity: 0; }


### PR DESCRIPTION
## Summary

Shows the animated CleanMeter logo over the settings window on every launch: the logo slides in with staggered gray-track fades, a clockwise sweep reveals the three colored rings, and after one pass (~2.4s) the splash fades out (280ms) into the UI.

## Behavior

- Renders from the window's first paint, so startup opens on the brand mark instead of a blank/half-loaded UI — it also masks the light→dark theme flash while saved settings load.
- One-shot per launch; unmounts before the animation's loop seam so only a single clean pass is visible.
- Background uses the app shell token (`--background`), so the splash is theme-aware.
- `prefers-reduced-motion` shows the finished static logo for the same beat.
- Settings window only — the overlay HUD is unaffected.

## Files

- `components/splash-screen.css` — the authored logo animation (SVG mask ring-sweep, CSS-only) plus the splash shell (overlay + fade-out)
- `components/SplashScreen.tsx` — SVG markup and the hold/fade/unmount orchestration
- `App.tsx` — mounts the splash from first paint with a stable dismiss callback

## Testing

- Type-check, lint, and production build pass.
- Verified on a local Windows install: splash plays from first paint on every launch and hands off cleanly to the settings UI.