### PR TITLE
Startup splash: sequenced exit animation + dark-mode flash fix

### DIFF
--- a/tauri-app/index.html
+++ b/tauri-app/index.html
@@ -5,6 +5,20 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cleanmeter</title>
+    <script>
+      // Apply the persisted theme before first paint so the startup splash and
+      // settings window never flash the default (light) theme while the real
+      // setting loads async from the backend. The app mirrors the resolved
+      // theme into localStorage (see App.tsx); unknown/first run falls back to
+      // light, matching DEFAULT_SETTINGS.
+      try {
+        var cmTheme =
+          localStorage.getItem("cm-theme") === "dark" ? "dark" : "light";
+        document.documentElement.setAttribute("data-theme", cmTheme);
+      } catch (e) {
+        /* localStorage unavailable — leave the CSS default (light) */
+      }
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -115,11 +115,17 @@ export default function App() {
     };
   }, []);
 
+  // Keep <html data-theme> in sync and mirror the resolved theme into
+  // localStorage so the pre-hydration script in index.html can paint the
+  // correct theme on the next launch before settings load — no startup flash.
   useEffect(() => {
-    document.documentElement.setAttribute(
-      "data-theme",
-      settings.isDarkTheme ? "dark" : "light",
-    );
+    const theme = settings.isDarkTheme ? "dark" : "light";
+    document.documentElement.setAttribute("data-theme", theme);
+    try {
+      localStorage.setItem("cm-theme", theme);
+    } catch {
+      /* localStorage unavailable — theme still applies for this session */
+    }
   }, [settings.isDarkTheme]);
 
   return (

--- a/tauri-app/src/components/SplashScreen.tsx
+++ b/tauri-app/src/components/SplashScreen.tsx
@@ -4,31 +4,47 @@ import "./splash-screen.css";
 // Startup splash: the animated CleanMeter logo (authored as a standalone
 // CSS-only HTML snippet, ported verbatim — see splash-screen.css) shown once
 // per launch over the settings window. Timeline: entrance + ring sweep
-// complete at ~1.93s into the 3480ms cycle; hold to 2.4s; fade the shell
-// 280ms; then onDone unmounts it before the authored loop seam (3.32s) can
-// show. Reduced motion renders the finished logo statically for the same
-// beat (the CSS handles it), so nobody gets a flashing startup.
+// complete at ~1.93s into the 3480ms cycle; hold to 2.4s; then a two-beat
+// exit — the rings/logo fade out (320ms) while the background still covers
+// the app, then the background eases out (560ms ease-in-out) so the app
+// screen fades in cleanly. onDone unmounts at ~3.28s; the logo is already
+// hidden by the first beat, so the authored loop seam (3.32s) never shows.
+// Reduced motion renders the finished logo statically for the same beat (the
+// CSS handles it), so nobody gets a flashing startup.
 const HOLD_MS = 2400;
-const FADE_MS = 280;
+const RINGS_FADE_MS = 320;
+const SCREEN_FADE_MS = 560;
 
 interface SplashScreenProps {
   onDone: () => void;
 }
 
 export function SplashScreen({ onDone }: SplashScreenProps) {
-  const [fading, setFading] = useState(false);
+  // Two-stage exit: rings fade out first, then the background clears.
+  const [ringsOut, setRingsOut] = useState(false);
+  const [screenIn, setScreenIn] = useState(false);
 
   useEffect(() => {
-    const fadeTimer = setTimeout(() => setFading(true), HOLD_MS);
-    const doneTimer = setTimeout(onDone, HOLD_MS + FADE_MS);
+    const ringsTimer = setTimeout(() => setRingsOut(true), HOLD_MS);
+    const screenTimer = setTimeout(() => setScreenIn(true), HOLD_MS + RINGS_FADE_MS);
+    const doneTimer = setTimeout(onDone, HOLD_MS + RINGS_FADE_MS + SCREEN_FADE_MS);
     return () => {
-      clearTimeout(fadeTimer);
+      clearTimeout(ringsTimer);
+      clearTimeout(screenTimer);
       clearTimeout(doneTimer);
     };
   }, [onDone]);
 
+  const className = [
+    "cm-splash",
+    ringsOut && "cm-splash--rings-out",
+    screenIn && "cm-splash--screen-in",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div className={fading ? "cm-splash cm-splash--fading" : "cm-splash"}>
+    <div className={className}>
       <div className="cm-logo" role="img" aria-label="CleanMeter">
         <div className="cm-logo__slide">
           <svg viewBox="0 0 172 66" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/tauri-app/src/components/splash-screen.css
+++ b/tauri-app/src/components/splash-screen.css
@@ -47,20 +47,25 @@
   95.5%    { stroke-dashoffset:0;   } 100%  { stroke-dashoffset:100; } /* re-close before loop seam */
 }
 
-/* accessibility: reduced motion = show the finished logo instantly */
+/* accessibility: reduced motion = show the finished logo instantly, and the
+   exit stays a plain opacity fade (no entrance slide, no leftward exit slide). */
 @media (prefers-reduced-motion: reduce) {
   .cm-logo__slide { animation:none; transform:none; }
   .cm-logo .cm-track { animation:none; opacity:0; }
   .cm-logo .cm-fill  { animation:none; opacity:1; }
   .cm-logo .cm-trim  { animation:none; stroke-dashoffset:0; }
+  .cm-splash .cm-logo { transition-property: opacity; }
+  .cm-splash--rings-out .cm-logo { transform: none; }
 }
 
 /* ============ Splash shell (startup overlay around the logo) ============
    Covers the settings window from first paint until the sweep completes:
    entrance + sweep finish at ~55.5% of the 3480ms cycle (~1.93s); hold to
-   2.4s, then fade the whole shell out (280ms) and unmount. bg-background
-   keeps it theme-aware and hides the light→dark flash while the saved
-   theme loads. */
+   2.4s, then a two-beat exit — first the rings/logo fade out (320ms) while
+   this shell still covers the app, then the shell itself eases out (560ms
+   ease-in-out) so the app screen fades in cleanly, and unmount. bg-background
+   keeps it theme-aware and hides the light→dark flash while the saved theme
+   loads. */
 .cm-splash {
   position: absolute;
   inset: 0;
@@ -70,6 +75,19 @@
   justify-content: center;
   background: var(--background);
   opacity: 1;
-  transition: opacity 280ms ease-out;
+  transition: opacity 560ms ease-in-out;
 }
-.cm-splash--fading { opacity: 0; }
+
+/* beat 1 — rings/logo fade out on their own, background stays opaque.
+   The logo slides further left as it fades, continuing the entrance's
+   right→left motion into one pass; the exit ease is the time-reverse of the
+   entrance's cubic-bezier(0.16,1,0.3,1), so it accelerates out as the
+   entrance decelerated in. */
+.cm-splash .cm-logo {
+  transition: opacity 320ms ease-out,
+              transform 320ms cubic-bezier(0.7, 0, 0.84, 0);
+}
+.cm-splash--rings-out .cm-logo { opacity: 0; transform: translateX(-30px); }
+
+/* beat 2 — shell clears (logo already gone) so the app screen fades in */
+.cm-splash--screen-in { opacity: 0; }

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -195,8 +195,16 @@ interface SettingsStore {
   loadAppVersion: () => Promise<void>;
 }
 
+// Seed isDarkTheme from the <html data-theme> the pre-hydration script in
+// index.html set from the persisted localStorage mirror. This makes the first
+// React render (and App's data-theme effect) match what the splash already
+// painted, so the theme doesn't flip when the async loadSettings() resolves.
+const prehydratedDark =
+  typeof document !== "undefined" &&
+  document.documentElement.getAttribute("data-theme") === "dark";
+
 export const useSettingsStore = create<SettingsStore>((set, get) => ({
-  settings: DEFAULT_SETTINGS,
+  settings: { ...DEFAULT_SETTINGS, isDarkTheme: prehydratedDark },
   preferences: { adminConsent: false, startMinimized: false },
   sensorData: null,
   presentMonApps: [],


### PR DESCRIPTION
## Summary

Two improvements to the startup splash from #28:

1. **Sequenced exit animation** — replaces the single 280ms shell fade with a two-beat exit: the logo rings fade out while sliding left (continuing the entrance''s right-to-left motion), then the background eases out over 560ms so the app screen fades in cleanly instead of snapping in.
2. **Dark-mode startup flash fix** — the splash background is theme-driven, but `data-theme` was only applied after the async settings load, so dark-mode launches briefly painted the light default before snapping to dark.

## Changes

- `SplashScreen.tsx` / `splash-screen.css`: two-stage exit — rings fade + slide left (320ms, exit ease is the time-reverse of the entrance ease), then background fade-out (560ms ease-in-out). Reduced motion keeps opacity-only fades with no slide.
- `index.html`: a pre-hydration script applies the persisted theme from a `localStorage` mirror before first paint.
- `settings-store.ts`: seed the initial `isDarkTheme` from that attribute so the mount effect does not reset it to the light default before settings load.
- `App.tsx`: mirror the resolved theme to `localStorage` on every change.

## Notes

- The first launch after this change writes the theme mirror once; subsequent launches paint the correct theme immediately. Fresh installs default to light.
- The animation timing is identical in light and dark mode; only the background color differs.

## Testing

- `tsc --noEmit`, `eslint`, and `vite build` pass.
- Verified the exit sequence by launching a local production build.