### PR TITLE
fix(overlay): pin RAM readings to physical memory sensors

### DIFF
--- a/tauri-app/src/components/overlay/RamSection.tsx
+++ b/tauri-app/src/components/overlay/RamSection.tsx
@@ -26,18 +26,24 @@ export function RamSection({ isHorizontal }: RamSectionProps) {
   const Progress = progressType === "bar" ? ProgressBar : ProgressRing;
   const showProgress = progressType !== "none";
 
-  // Find RAM load sensor
+  // Find RAM load sensor. Both name-matches must exclude the virtual-memory
+  // sensors: "Virtual Memory"/"Virtual Memory Used" match the same substrings,
+  // and which of physical/virtual enumerates first is not stable across
+  // sidecar restarts — the first-match used to flip to committed memory
+  // (~total RAM) instead of physical used after a restart.
   const ramSensor = sensors.find(
     (s) =>
       s.sensorType === SensorType.Load &&
-      s.name.toLowerCase().includes("memory")
+      s.name.toLowerCase().includes("memory") &&
+      !s.name.toLowerCase().includes("virtual")
   );
   // Find RAM data sensor (used GB)
   const ramDataSensor = sensors.find(
     (s) =>
       s.sensorType === SensorType.Data &&
       s.name.toLowerCase().includes("memory") &&
-      s.name.toLowerCase().includes("used")
+      s.name.toLowerCase().includes("used") &&
+      !s.name.toLowerCase().includes("virtual")
   );
 
   const ramPercent = ramSensor?.value ?? 0;


### PR DESCRIPTION
## Summary
The RAM row resolves its sensors by name substring and took the first match — 'Virtual Memory' / 'Virtual Memory Used' match the same substrings as the physical sensors, and sensor enumeration order changes across sidecar restarts. After a restart the row could silently show committed memory (~total RAM, e.g. 31.5 GB on a 32 GB machine) instead of physical used (~16.8 GB).

## Changes
- Exclude 'virtual' from both the load-sensor match (gauge fill) and the data-sensor match (GB reading) in the overlay RAM section, making the resolution deterministic regardless of enumeration order.

## Testing
- Reproduced the wrong reading live (overlay showed 31.5 GB while Windows reported 16.8 GB used of 31.6); verified the affected first-match logic is unchanged since v2.2.8, so this is latent in all prior releases.
- Type-check and lint clean.