### PR TITLE
fix: restore CPU readings and pin RAM to physical memory

### DIFF
--- a/HardwareMonitor/HardwareMonitor/HardwareMonitor.csproj
+++ b/HardwareMonitor/HardwareMonitor/HardwareMonitor.csproj
@@ -14,7 +14,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
+        <!-- 0.9.6 switched Ryzen MSR access to the PawnIO driver, which nothing
+             installs — CPU temperature/power silently read 0 for every user
+             (shipped broken in v2.2.9/v2.2.10). Stay on the last WinRing0-based
+             version until PawnIO installation ships with the app. -->
+        <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre392" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.0"/>
         <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0"/>

--- a/tauri-app/src/components/overlay/RamSection.tsx
+++ b/tauri-app/src/components/overlay/RamSection.tsx
@@ -37,14 +37,14 @@ export function RamSection({ isHorizontal }: RamSectionProps) {
   const ramSensor = sensors.find(
     (s) =>
       s.sensorType === SensorType.Load &&
-      s.name === "Memory" &&
+      s.name.toLowerCase() === "memory" &&
       !s.identifier.startsWith("/vram")
   );
   // Find RAM data sensor (used GB)
   const ramDataSensor = sensors.find(
     (s) =>
       s.sensorType === SensorType.Data &&
-      s.name === "Memory Used" &&
+      s.name.toLowerCase() === "memory used" &&
       !s.identifier.startsWith("/vram")
   );
 

--- a/tauri-app/src/components/overlay/RamSection.tsx
+++ b/tauri-app/src/components/overlay/RamSection.tsx
@@ -26,24 +26,26 @@ export function RamSection({ isHorizontal }: RamSectionProps) {
   const Progress = progressType === "bar" ? ProgressBar : ProgressRing;
   const showProgress = progressType !== "none";
 
-  // Find RAM load sensor. Both name-matches must exclude the virtual-memory
-  // sensors: "Virtual Memory"/"Virtual Memory Used" match the same substrings,
-  // and which of physical/virtual enumerates first is not stable across
-  // sidecar restarts — the first-match used to flip to committed memory
-  // (~total RAM) instead of physical used after a restart.
+  // Match the exact sensor names the previous builds (and the legacy app)
+  // relied on: on LHM <= 0.9.5 "Memory"/"Memory Used" are unique because the
+  // virtual sensors carry a "Virtual " name prefix. LHM 0.9.6 instead splits
+  // memory into Total (/ram) and Virtual (/vram) hardware nodes whose sensors
+  // share the SAME names, so additionally reject /vram identifiers — the
+  // match stays pinned to physical memory under either layout (first-match
+  // over the raw sensor array otherwise flips to committed memory, ~total
+  // RAM, depending on enumeration order).
   const ramSensor = sensors.find(
     (s) =>
       s.sensorType === SensorType.Load &&
-      s.name.toLowerCase().includes("memory") &&
-      !s.name.toLowerCase().includes("virtual")
+      s.name === "Memory" &&
+      !s.identifier.startsWith("/vram")
   );
   // Find RAM data sensor (used GB)
   const ramDataSensor = sensors.find(
     (s) =>
       s.sensorType === SensorType.Data &&
-      s.name.toLowerCase().includes("memory") &&
-      s.name.toLowerCase().includes("used") &&
-      !s.name.toLowerCase().includes("virtual")
+      s.name === "Memory Used" &&
+      !s.identifier.startsWith("/vram")
   );
 
   const ramPercent = ramSensor?.value ?? 0;


### PR DESCRIPTION
## Summary
v2.2.9/v2.2.10 ship with CPU temperature and power reading 0 for every user, and the RAM row can display committed memory (~total RAM) instead of physical used. Both trace to the LibreHardwareMonitor 0.9.6 bump that rode along with the sidecar resilience fix.

## Changes
- **Revert LibreHardwareMonitorLib to 0.9.5-pre392** — 0.9.6 moved Ryzen MSR access to the PawnIO driver, which nothing installs, so temperature/power sensors enumerate but read 0 (verified elevated and non-elevated on a Ryzen 5 7600X). The WinRing0-based 0.9.5-pre392 is what v2.2.8 shipped and reads correctly. PawnIO adoption (which would also resolve the Defender-flag saga properly) is tracked as follow-up work.
- **RAM sensor resolution** — match the exact sensor names previous builds relied on ("Memory" / "Memory Used") and reject `/vram` identifiers: 0.9.6 splits memory into Total and Virtual hardware nodes whose sensors share identical names, so the name-based virtual exclusion from #30 filtered nothing and the row could show committed memory depending on enumeration order. The combined predicate is correct under both memory layouts, so it survives a future library upgrade.

## Testing
- Sensor-level: enumerated both library versions on the affected machine — 0.9.6 reads Tctl/Tdie and Package power as 0 (elevated and not); 0.9.5-pre392 reads real values; both memory layouts dumped and matched against the new predicate.
- End-to-end: rebuilt and published the sidecar with the reverted library exactly as CI does, ran the app against it — CPU temperature/power and physical RAM all display correctly.
- Type-check and lint clean.