### PR TITLE
fix(overlay): make the VRAM ring reflect true VRAM usage

### DIFF
--- a/tauri-app/src/components/overlay/GpuSection.tsx
+++ b/tauri-app/src/components/overlay/GpuSection.tsx
@@ -3,6 +3,7 @@ import { ProgressRing } from "./ProgressRing";
 import { ProgressBar } from "./ProgressBar";
 import { useSettingsStore } from "@/stores/settings-store";
 import { SensorType } from "@/lib/types";
+import type { Sensor } from "@/lib/types";
 import { findSensorById, formatValue, formatTemperature } from "@/lib/utils";
 
 interface GpuSectionProps {
@@ -36,15 +37,38 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
 
   const gpuTempVal = findSensorById(sensors, gpuTemp.customReadingId)?.value ?? 0;
   const gpuUsageVal = findSensorById(sensors, gpuUsage.customReadingId)?.value ?? 0;
-  const vramUsageVal = findSensorById(sensors, vramUsage.customReadingId)?.value ?? 0;
-  const vramUsedSensor = findSensorById(sensors, totalVramUsed.customReadingId);
-  // LibreHardwareMonitor's "GPU Memory Used" is SmallData (MB). Pass through
-  // when the user picked a Data-typed sensor that's already in GB.
-  const vramUsedVal =
-    vramUsedSensor?.sensorType === SensorType.SmallData
-      ? (vramUsedSensor.value ?? 0) / 1024
-      : vramUsedSensor?.value ?? 0;
   const gpuPowerVal = findSensorById(sensors, gpuConsumption.customReadingId)?.value ?? 0;
+
+  // LibreHardwareMonitor's "GPU Memory *" readings are SmallData (MB); a
+  // Data-typed sensor the user picked manually is already in GB.
+  const toGigabytes = (s: Sensor | undefined): number =>
+    s == null ? 0 : s.sensorType === SensorType.SmallData ? (s.value ?? 0) / 1024 : s.value ?? 0;
+
+  // Anchor VRAM lookups to the GPU of the configured "GPU Memory Used" sensor.
+  const vramUsedConfigured = findSensorById(sensors, totalVramUsed.customReadingId);
+  const gpuHwId = vramUsedConfigured?.hardwareIdentifier;
+  const onGpu = (re: RegExp): Sensor | undefined =>
+    gpuHwId ? sensors.find((s) => s.hardwareIdentifier === gpuHwId && re.test(s.name)) : undefined;
+
+  // Prefer LHM's D3D "Dedicated Memory Used" counter — it matches Task Manager
+  // and nvidia-smi. The NVAPI "GPU Memory Used" reading it would otherwise use
+  // runs a few hundred MB high (e.g. 15.0 GB vs a true 14.7 GB), which both
+  // inflates the GB label and pushes the ring a couple points past reality.
+  const vramUsedSensor = onGpu(/dedicated memory used/i) ?? vramUsedConfigured;
+  const vramUsedVal = toGigabytes(vramUsedSensor);
+
+  // Ring fill = allocated fraction = used / total dedicated memory. We
+  // deliberately do NOT trust the "GPU Memory" Load sensor
+  // (vramUsage.customReadingId): on NVIDIA/LibreHardwareMonitor it reports
+  // memory-*controller* utilization (bandwidth), not allocation — a nearly-full
+  // 15.5/16 GB card reads ~10% there. Fall back to that Load sensor only when no
+  // total reading is exposed (some AMD/Intel setups).
+  const vramLoadVal = findSensorById(sensors, vramUsage.customReadingId)?.value ?? 0;
+  const vramTotalVal = toGigabytes(onGpu(/memory total/i));
+  const vramUsageVal =
+    vramTotalVal > 0
+      ? Math.min((vramUsedVal / vramTotalVal) * 100, 100)
+      : vramLoadVal;
 
   const temp = formatTemperature(gpuTempVal, settings.temperatureUnit);
 

--- a/tauri-app/vite.config.ts
+++ b/tauri-app/vite.config.ts
@@ -26,7 +26,11 @@ export default defineConfig({
   clearScreen: false,
   server: {
     port: 1420,
-    strictPort: true
+    strictPort: true,
+    // Don't let the dev-server file watcher descend into the Rust build output —
+    // watching target/ races with cargo relinking (`EBUSY` on freshly written
+    // .dll/.exe) and crashes `tauri dev`.
+    watch: { ignored: ['**/src-tauri/**'] }
   },
   envPrefix: ['VITE_', 'TAURI_'],
   build: {


### PR DESCRIPTION
## Summary

The GPU **VRAM circular gauge doesn't reflect actual VRAM usage**. On an NVIDIA card it can show ~10% filled while the card is actually at ~92% (e.g. 15.5/16 GB). This PR makes the ring track true allocation and makes the GB label match Task Manager / `nvidia-smi`.

## Root cause

The ring's fill was driven by LibreHardwareMonitor's **`GPU Memory` _Load_ sensor** (`sensors.vramUsage`). On NVIDIA that sensor is **memory-controller utilization** (bandwidth activity), *not* the fraction of VRAM allocated. When VRAM is full but idle, controller activity is low, so the ring collapses toward ~10%.

Verified on an RTX 5080 (LHM `0.9.5-pre392`) with a D3D11 allocation stress test — the load sensor is erratic while real allocation climbs smoothly:

| Real allocation | `GPU Memory Used`/`Total` | **`GPU Memory` load sensor (old ring)** |
|---|---|---|
| 19.7% | 19.7% | **39.0%** |
| 32.4% | 32.4% | **17.0%** |
| 57.5% | 57.5% | **10.0%** |
| 76.4% | 76.4% | **70.0%** |
| ~92%  | ~92%  | **10.0%** |

## Fix

Derive the ring fill from **used / total dedicated memory** instead of the load sensor:

- **Used**: prefer the D3D **`Dedicated Memory Used`** counter (matches Task Manager / `nvidia-smi`). The NVAPI `GPU Memory Used` reading runs a few hundred MB high (15.0 vs a true 14.7 GB), which inflates both the GB label and the ring by ~2 points.
- **Total**: `GPU Memory Total` on the same GPU.
- **Fallback**: the previous Load sensor, only when no total-memory reading is exposed (some AMD/Intel setups) — so no regression where it currently works.

## Testing

Built and ran the app locally against live sensors, driving VRAM with a D3D11 allocator. At **15009 / 16303 MiB (92%)** measured by `nvidia-smi`:

| | Ring | GB label |
|---|---|---|
| Before (`GPU Memory` load) | **10%** | — |
| After (this PR) | **~92%, red** (crosses the 90% danger threshold) | **14.7 GB** ✓ matches `nvidia-smi` |

Also captured the overlay before/after at ~14.6 GB: the old build shows a nearly-empty ~10% ring next to a "14.6 GB" label; the fixed build shows a ~92% red ring. (Screenshots can be added to this description.)

`tsc --noEmit` and `eslint` pass clean.

## Commits

1. `fix(overlay): make the VRAM ring track true allocation` — the fix above (`GpuSection.tsx`).
2. `fix(dev): exclude src-tauri from the Vite file watcher` — unrelated dev-env fix: `tauri dev`'s Vite watcher descends into `src-tauri/target` and crashes with `EBUSY` on Rust artifacts cargo is relinking. Scoping `server.watch` away from `src-tauri` fixes it. (Happy to split into its own PR if you'd prefer.)
