### PR TITLE
fix: disable default WebView2 right-click context menu

### DIFF
--- a/tauri-app/src/disable-context-menu.ts
+++ b/tauri-app/src/disable-context-menu.ts
@@ -1,0 +1,11 @@
+// Suppress WebView2's default browser context menu (Back / Refresh / Save as /
+// Print / More tools / Send tab to your devices) so right-click does nothing in
+// the app. Nothing in the UI relies on a right-click menu; the native one just
+// leaked Edge chrome into the overlay and settings windows.
+//
+// Capture phase so no component-level handler can bypass it.
+window.addEventListener(
+  "contextmenu",
+  (e) => e.preventDefault(),
+  { capture: true },
+);

--- a/tauri-app/src/main.tsx
+++ b/tauri-app/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import "./disable-context-menu";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/tauri-app/src/overlay.tsx
+++ b/tauri-app/src/overlay.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import OverlayApp from "./OverlayApp";
 import "./index.css";
+import "./disable-context-menu";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
## What

Right-clicking the overlay or the settings window surfaced WebView2's default browser context menu (Back / Refresh / Save as / Print / More tools / Send tab to your devices), which users were reporting.

## Change

Adds a small `disable-context-menu.ts` module that registers a global capture-phase `contextmenu` handler calling `preventDefault()`, imported by both entry points (`main.tsx` for settings, `overlay.tsx` for the overlay). This is the standard way to suppress the native WebView2 menu; keyboard shortcuts (e.g. Ctrl+V) are unaffected. Disabled in all builds, dev included.

## Test

- `npm run build` passes; the module is bundled into both the settings and overlay entries.
- Verify at runtime: right-click anywhere on the overlay or settings window and no menu appears.