### PR TITLE
chore: bump version to 2.2.13

### DIFF
--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleanmeter",
   "private": true,
-  "version": "2.2.12",
+  "version": "2.2.13",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "cleanmeter"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "byteorder",
  "dirs",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cleanmeter"
-version = "2.2.12"
+version = "2.2.13"
 description = "Gaming performance overlay"
 authors = ["Cleanmeter"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui/toolkits/refs/heads/main/tauri/schema.json",
   "productName": "Cleanmeter",
   "identifier": "com.cleanmeter.desktop",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump to 2.2.13 for the first release including the PawnIO driver migration (#35). No functional changes.