### PR TITLE
docs(ci): correct stale WinRing0 reference to PawnIO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           # Windows-only release. The HardwareMonitor sidecar depends on
           # PresentMon (ETW, Windows-only) and LibreHardwareMonitor's
-          # WinRing0 driver (Windows-only) for FPS + sensor data, so the
+          # PawnIO driver (Windows-only) for FPS + sensor data, so the
           # macOS/Linux bundles ship a non-functional service. Keep the
           # matrix structure for future re-introduction.
           - platform: windows-latest


### PR DESCRIPTION
Comment-only fix. The build.yml matrix comment still described the sidecar as using LibreHardwareMonitor's WinRing0 driver; it now uses PawnIO (see #35). No workflow behavior change.