### PR TITLE
fix: gauge threshold colors and Discord invite link

### DIFF
--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -340,8 +340,9 @@ function FooterLinkButton({
   );
 }
 
-// TODO: replace with API data (canonical discord URL from product).
-const DISCORD_INVITE_URL = "https://discord.gg/CN2b7d4c9";
+// Canonical invite to the official Cleanmeter community server, set to never
+// expire (the invite this replaced had lapsed and returned Unknown Invite).
+const DISCORD_INVITE_URL = "https://discord.gg/SCgXtTMNvJ";
 
 // Triggers an in-app update check and reflects the updater status in its label.
 // The actual "download & install" happens from the floating UpdateBanner.

--- a/tauri-app/src/lib/utils.ts
+++ b/tauri-app/src/lib/utils.ts
@@ -31,8 +31,19 @@ export function getBoundaryColor(
   // The semantic `--color-{danger,warning,success}` tokens point at darker
   // shades (red700, yellow700) chosen for the settings UI — don't reuse
   // them in the overlay, the overlay palette is intentionally brighter.
-  if (value >= boundaries.high) return "var(--red500)";
-  if (value >= boundaries.medium) return "var(--yellow300)";
+  //
+  // Thresholds are the UPPER bound of each segment, matching what the settings
+  // control paints (TempRangeControl: Low 0→low, Medium low→medium, High
+  // medium→high) and the legacy app's Progress.kt:
+  //   value <= low             → green
+  //   low < value <= medium    → yellow
+  //   value > medium           → red
+  // `boundaries.high` is the top of the High segment for display only, never a
+  // threshold. Comparing against .high/.medium instead (the bug this replaced)
+  // shifted every color one segment late, so green ran past the whole Medium
+  // band and red only appeared at the very top of the scale.
+  if (value > boundaries.medium) return "var(--red500)";
+  if (value > boundaries.low) return "var(--yellow300)";
   return "var(--green500)";
 }
 


### PR DESCRIPTION
## Gauge threshold colors

`getBoundaryColor` compared the reading against `boundaries.high` and `boundaries.medium`, so `boundaries.low` was never read and every color fired one segment late.

The settings control (`TempRangeControl`) paints the segments as Low `0` to `low`, Medium `low` to `medium`, High `medium` to `high`, and the legacy implementation in `target/desktop` (`Progress.kt`) evaluates that same rule, using `high` only as the top of the High segment rather than as a threshold. The overlay now matches both:

- `value <= low` gives green
- `low < value <= medium` gives yellow
- `value > medium` gives red

With the stock 60/80/90 the gauge previously stayed green through the entire Medium band and only turned red at 90. It now turns yellow above 60 and red above 80, which is what the settings screen has always shown. Existing installs will see more color on the HUD than before.

The ring and bar gauges share the helper, so this covers CPU usage and temperature, GPU usage and temperature, VRAM and RAM.

### Verification

Compared against the settings segments and the legacy rule across 43 combinations spanning the stock 60/80/90, two custom threshold sets, and a 0 to 120 C temperature scale: 25 cases previously disagreed with both, 0 disagree now.

Confirmed in the running app against live sensors:

| gauge | reading | before | after |
| --- | --- | --- | --- |
| CPU usage | 53 % | green | green |
| CPU usage | 60 % | green | yellow |
| CPU usage | 85 %, 88 % | yellow | red |
| CPU temp | 64 C | green | yellow |
| CPU temp | 89 to 95 C | red | red |
| GPU 35 C, GPU 8 to 17 %, VRAM 22 %, RAM 58 % | | green | green |

## Discord invite

The invite behind the "Join the discord server!" button in Settings was a placeholder carried over from the redesign and no longer resolves; the Discord API returns Unknown Invite for it. It now points at the current permanent invite for the official Cleanmeter server, checked against the API before and after the change. It is the only Discord URL in the repo.
