### PR TITLE
fix(settings): stop an unreadable settings.json from wiping every setting

### DIFF
--- a/tauri-app/src-tauri/src/settings.rs
+++ b/tauri-app/src-tauri/src/settings.rs
@@ -5,6 +5,22 @@ use std::sync::Mutex;
 
 use crate::types::{AppPreferences, OverlaySettings};
 
+/// Serializes the whole save transaction: temp file, rename, backup refresh.
+///
+/// `save_settings` copies into the in-memory `Mutex` and releases it *before*
+/// touching disk, and Tauri runs each non-async `invoke` on its own thread, so
+/// two windows saving in the same instant (the overlay persisting a drag while
+/// the settings window persists a toggle) otherwise run two write transactions
+/// through the same temp path, where one can truncate or rename the other's file
+/// out from under it and lose that save.
+///
+/// Not a reproduced failure. See the note on
+/// `concurrent_saves_leave_both_copies_readable` for what would not reproduce
+/// and why. Kept because ordering the transaction costs nothing here: a save is
+/// a couple of kilobytes and already debounced 300 ms in the frontend, so one
+/// lock covering both files has nothing to lose to finer granularity.
+static WRITE_LOCK: Mutex<()> = Mutex::new(());
+
 pub struct SettingsManager {
     settings: Mutex<OverlaySettings>,
     preferences: Mutex<AppPreferences>,
@@ -61,7 +77,7 @@ impl SettingsManager {
     /// Parse a settings file, tolerating a leading UTF-8 BOM. Editing
     /// settings.json by hand in Notepad (or any PowerShell `Set-Content
     /// -Encoding utf8`) prepends one, and `serde_json` rejects it as a syntax
-    /// error — which used to mean the whole file was discarded.
+    /// error, which used to mean the whole file was discarded.
     fn parse_file<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T, String> {
         let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
         let content = content.strip_prefix('\u{feff}').unwrap_or(&content);
@@ -94,14 +110,14 @@ impl SettingsManager {
     /// defaults.
     ///
     /// Returning `None` here resets every setting the user has (the callers do
-    /// `.unwrap_or_default()`), and the next save then overwrites the original
-    /// — so an unreadable file silently destroyed the whole config, which
+    /// `.unwrap_or_default()`), and the next save then overwrites the original,
+    /// so an unreadable file silently destroyed the whole config, which
     /// reads to the user as "my settings don't survive a restart". An
     /// unreadable file is now preserved for inspection instead of being
     /// overwritten, and the backup written by `save_to_file` is tried first.
     fn load_from_file<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Option<T> {
         if !path.exists() {
-            // Missing primary (first run, or it was lost) — a backup from a
+            // Missing primary (first run, or it was lost): a backup from a
             // previous run still beats defaults.
             return Self::load_backup(path);
         }
@@ -119,15 +135,40 @@ impl SettingsManager {
         }
     }
 
-    /// Write a settings file atomically, keeping the previous contents as a
-    /// backup.
+    /// Fill `tmp`, flush it to disk, then rename it over `dest`.
     ///
     /// `fs::write` truncates the target before writing, so a crash, a power
     /// loss, or `app.exit(0)` from the tray landing mid-write left a partial
-    /// file that fails to parse on the next launch. Writing to a sibling temp
-    /// file and renaming over the target means a reader always sees either the
-    /// old file or the complete new one — `rename` maps to `MoveFileEx` with
-    /// `MOVEFILE_REPLACE_EXISTING` on Windows.
+    /// file that fails to parse on the next launch. Going through a sibling
+    /// temp file means a reader always sees either the old file or the complete
+    /// new one, since `rename` maps to `MoveFileEx` with
+    /// `MOVEFILE_REPLACE_EXISTING` on Windows. The temp path is reused rather
+    /// than made unique so a run that dies mid-write leaves one file that the
+    /// next save overwrites, instead of littering the directory.
+    fn write_atomically(dest: &PathBuf, tmp: &PathBuf, bytes: &[u8]) -> std::io::Result<()> {
+        let fill_tmp = || -> std::io::Result<()> {
+            let mut file = std::fs::File::create(tmp)?;
+            file.write_all(bytes)?;
+            // Flush to disk before the rename, so losing power just after it
+            // can't leave a renamed-but-empty file.
+            file.sync_all()
+        };
+        let result = fill_tmp().and_then(|()| std::fs::rename(tmp, dest));
+        if result.is_err() {
+            let _ = std::fs::remove_file(tmp);
+        }
+        result
+    }
+
+    /// Write a settings file atomically, mirroring it to a backup.
+    ///
+    /// Both files are written from the same in-memory JSON, never copied off
+    /// disk. Refreshing the backup from the *previous* on-disk file instead
+    /// meant a primary that could not be quarantined (a locked or read-only
+    /// file, see `load_from_file`) was copied over the last known-good backup,
+    /// so neither copy was loadable and the config reset after all. It also
+    /// leaves the backup one save behind; mirroring means recovery restores the
+    /// newest good state rather than the one before it.
     fn save_to_file<T: serde::Serialize>(path: &PathBuf, data: &T) {
         let json = match serde_json::to_string_pretty(data) {
             Ok(json) => json,
@@ -137,32 +178,29 @@ impl SettingsManager {
             }
         };
 
-        let tmp = path.with_extension("json.tmp");
-        let write_tmp = || -> std::io::Result<()> {
-            let mut file = std::fs::File::create(&tmp)?;
-            file.write_all(json.as_bytes())?;
-            // Flush to disk before the rename, so losing power just after it
-            // can't leave a renamed-but-empty file.
-            file.sync_all()
-        };
-        if let Err(e) = write_tmp() {
-            error!("Failed to write {:?}: {}", tmp, e);
-            let _ = std::fs::remove_file(&tmp);
+        // Held for the whole transaction. Recovered from poisoning rather than
+        // unwrapped: a panic elsewhere while holding this must not leave the app
+        // permanently unable to save.
+        let _guard = WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        if let Err(e) = Self::write_atomically(
+            path,
+            &path.with_extension("json.tmp"),
+            json.as_bytes(),
+        ) {
+            error!("Failed to write {:?}: {}", path, e);
             return;
         }
 
-        // Refresh the backup from the copy that is still known to be complete,
-        // before the rename replaces it.
-        if path.exists() {
-            let backup = Self::backup_path(path);
-            if let Err(e) = std::fs::copy(path, &backup) {
-                error!("Failed to refresh backup {:?}: {}", backup, e);
-            }
-        }
-
-        if let Err(e) = std::fs::rename(&tmp, path) {
-            error!("Failed to replace {:?}: {}", path, e);
-            let _ = std::fs::remove_file(&tmp);
+        let backup = Self::backup_path(path);
+        if let Err(e) = Self::write_atomically(
+            &backup,
+            &path.with_extension("json.bak.tmp"),
+            json.as_bytes(),
+        ) {
+            // The primary landed, so this is not fatal. The backup just stays
+            // at whatever earlier state it already held.
+            error!("Failed to refresh backup {:?}: {}", backup, e);
         }
     }
 }
@@ -210,13 +248,89 @@ mod tests {
         let loaded: Option<Probe> = SettingsManager::load_from_file(&path);
         assert_eq!(
             loaded,
-            Some(Probe { value: 1 }),
-            "should recover the backup instead of resetting to defaults"
+            Some(Probe { value: 2 }),
+            "should recover the newest saved state, not defaults or the save before it"
         );
         assert!(
             path.with_extension("json.corrupt").exists(),
             "the unreadable file should be preserved, not overwritten"
         );
+    }
+
+    /// The backup is written from the JSON being saved, never copied off disk,
+    /// so an unreadable primary left in place (a quarantine rename that failed
+    /// because the file was locked or read-only) cannot overwrite the last
+    /// known-good copy and leave nothing to recover from.
+    #[test]
+    fn an_unreadable_primary_never_reaches_the_backup() {
+        let path = scratch("poison").join("settings.json");
+        SettingsManager::save_to_file(&path, &Probe { value: 1 });
+
+        // Corrupt the primary and leave it there, as a failed quarantine would.
+        std::fs::write(&path, "{\"value\":").unwrap();
+        SettingsManager::save_to_file(&path, &Probe { value: 2 });
+
+        let backup: Result<Probe, String> =
+            SettingsManager::parse_file(&SettingsManager::backup_path(&path));
+        assert_eq!(backup, Ok(Probe { value: 2 }), "backup must stay readable");
+
+        // And the save healed the primary, so both copies are good again.
+        std::fs::write(&path, "{\"value\":").unwrap();
+        let loaded: Option<Probe> = SettingsManager::load_from_file(&path);
+        assert_eq!(loaded, Some(Probe { value: 2 }));
+    }
+
+    /// Two windows can save in the same instant, each on its own Tauri command
+    /// thread, and both write transactions go through one temp path.
+    ///
+    /// Honest about what this proves: it is a smoke test, not a demonstration of
+    /// the race. Removing `WRITE_LOCK` does not make it fail: attempts with
+    /// mismatched payload lengths and with payloads inflated to ~768 KB all
+    /// still passed, because `sync_all` dominates each save and keeps the
+    /// truncate-under-another-writer window from opening. The lock is kept
+    /// because it is free and makes the transaction ordered, not because this
+    /// catches its absence. What this does catch: a deadlock from nesting the
+    /// lock, temp-file litter, and a save that stops mirroring its backup.
+    #[test]
+    fn concurrent_saves_leave_both_copies_readable() {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct Padded {
+            value: u32,
+            pad: String,
+        }
+
+        let path = scratch("concurrent").join("settings.json");
+        std::thread::scope(|s| {
+            for value in 1..=8u32 {
+                let path = path.clone();
+                s.spawn(move || {
+                    let payload = Padded {
+                        value,
+                        pad: "x".repeat(value as usize * 512),
+                    };
+                    for _ in 0..40 {
+                        SettingsManager::save_to_file(&path, &payload);
+                    }
+                });
+            }
+        });
+
+        assert!(
+            SettingsManager::parse_file::<Padded>(&path).is_ok(),
+            "the primary must be complete JSON, not a mix of two writes"
+        );
+        let backup = SettingsManager::backup_path(&path);
+        assert!(
+            SettingsManager::parse_file::<Padded>(&backup).is_ok(),
+            "the backup must be complete JSON too"
+        );
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            std::fs::read(&backup).unwrap(),
+            "the backup must mirror the primary, not a different thread's save"
+        );
+        assert!(!path.with_extension("json.tmp").exists());
+        assert!(!path.with_extension("json.bak.tmp").exists());
     }
 
     #[test]
@@ -227,6 +341,7 @@ mod tests {
         let loaded: Option<Probe> = SettingsManager::load_from_file(&path);
         assert_eq!(loaded, Some(Probe { value: 42 }));
         assert!(!path.with_extension("json.tmp").exists());
+        assert!(!path.with_extension("json.bak.tmp").exists());
     }
 
     #[test]

--- a/tauri-app/src-tauri/src/settings.rs
+++ b/tauri-app/src-tauri/src/settings.rs
@@ -1,4 +1,5 @@
-use log::{error, info};
+use log::{error, info, warn};
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -57,29 +58,181 @@ impl SettingsManager {
         Self::save_to_file(&self.preferences_path, &new_prefs);
     }
 
-    fn load_from_file<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Option<T> {
-        match std::fs::read_to_string(path) {
-            Ok(content) => match serde_json::from_str(&content) {
-                Ok(parsed) => Some(parsed),
-                Err(e) => {
-                    error!("Failed to parse {:?}: {}", path, e);
-                    None
-                }
-            },
-            Err(_) => None,
+    /// Parse a settings file, tolerating a leading UTF-8 BOM. Editing
+    /// settings.json by hand in Notepad (or any PowerShell `Set-Content
+    /// -Encoding utf8`) prepends one, and `serde_json` rejects it as a syntax
+    /// error — which used to mean the whole file was discarded.
+    fn parse_file<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T, String> {
+        let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+        let content = content.strip_prefix('\u{feff}').unwrap_or(&content);
+        serde_json::from_str(content).map_err(|e| e.to_string())
+    }
+
+    /// Load the last known-good copy written alongside the primary file.
+    fn load_backup<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Option<T> {
+        let backup = Self::backup_path(path);
+        if !backup.exists() {
+            return None;
+        }
+        match Self::parse_file(&backup) {
+            Ok(parsed) => {
+                info!("Recovered settings from {:?}", backup);
+                Some(parsed)
+            }
+            Err(e) => {
+                error!("Backup {:?} is unreadable too: {}", backup, e);
+                None
+            }
         }
     }
 
-    fn save_to_file<T: serde::Serialize>(path: &PathBuf, data: &T) {
-        match serde_json::to_string_pretty(data) {
-            Ok(json) => {
-                if let Err(e) = std::fs::write(path, json) {
-                    error!("Failed to write {:?}: {}", path, e);
-                }
-            }
+    fn backup_path(path: &PathBuf) -> PathBuf {
+        path.with_extension("json.bak")
+    }
+
+    /// Read a settings file, falling back to the backup rather than to
+    /// defaults.
+    ///
+    /// Returning `None` here resets every setting the user has (the callers do
+    /// `.unwrap_or_default()`), and the next save then overwrites the original
+    /// — so an unreadable file silently destroyed the whole config, which
+    /// reads to the user as "my settings don't survive a restart". An
+    /// unreadable file is now preserved for inspection instead of being
+    /// overwritten, and the backup written by `save_to_file` is tried first.
+    fn load_from_file<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Option<T> {
+        if !path.exists() {
+            // Missing primary (first run, or it was lost) — a backup from a
+            // previous run still beats defaults.
+            return Self::load_backup(path);
+        }
+        match Self::parse_file(path) {
+            Ok(parsed) => Some(parsed),
             Err(e) => {
-                error!("Failed to serialize settings: {}", e);
+                error!("Failed to parse {:?}: {}", path, e);
+                let quarantine = path.with_extension("json.corrupt");
+                match std::fs::rename(path, &quarantine) {
+                    Ok(()) => warn!("Unreadable settings preserved at {:?}", quarantine),
+                    Err(e) => error!("Failed to move {:?} aside: {}", path, e),
+                }
+                Self::load_backup(path)
             }
         }
+    }
+
+    /// Write a settings file atomically, keeping the previous contents as a
+    /// backup.
+    ///
+    /// `fs::write` truncates the target before writing, so a crash, a power
+    /// loss, or `app.exit(0)` from the tray landing mid-write left a partial
+    /// file that fails to parse on the next launch. Writing to a sibling temp
+    /// file and renaming over the target means a reader always sees either the
+    /// old file or the complete new one — `rename` maps to `MoveFileEx` with
+    /// `MOVEFILE_REPLACE_EXISTING` on Windows.
+    fn save_to_file<T: serde::Serialize>(path: &PathBuf, data: &T) {
+        let json = match serde_json::to_string_pretty(data) {
+            Ok(json) => json,
+            Err(e) => {
+                error!("Failed to serialize settings: {}", e);
+                return;
+            }
+        };
+
+        let tmp = path.with_extension("json.tmp");
+        let write_tmp = || -> std::io::Result<()> {
+            let mut file = std::fs::File::create(&tmp)?;
+            file.write_all(json.as_bytes())?;
+            // Flush to disk before the rename, so losing power just after it
+            // can't leave a renamed-but-empty file.
+            file.sync_all()
+        };
+        if let Err(e) = write_tmp() {
+            error!("Failed to write {:?}: {}", tmp, e);
+            let _ = std::fs::remove_file(&tmp);
+            return;
+        }
+
+        // Refresh the backup from the copy that is still known to be complete,
+        // before the rename replaces it.
+        if path.exists() {
+            let backup = Self::backup_path(path);
+            if let Err(e) = std::fs::copy(path, &backup) {
+                error!("Failed to refresh backup {:?}: {}", backup, e);
+            }
+        }
+
+        if let Err(e) = std::fs::rename(&tmp, path) {
+            error!("Failed to replace {:?}: {}", path, e);
+            let _ = std::fs::remove_file(&tmp);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    // A local shape rather than OverlaySettings: these helpers are generic, and
+    // the tests are about the file handling, not the settings schema.
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Probe {
+        value: u32,
+    }
+
+    fn scratch(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!("cleanmeter-settings-{}-{}", tag, nanos));
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
+    #[test]
+    fn reads_a_file_that_starts_with_a_utf8_bom() {
+        let path = scratch("bom").join("settings.json");
+        std::fs::write(&path, "\u{feff}{\"value\":7}").unwrap();
+
+        let loaded: Option<Probe> = SettingsManager::load_from_file(&path);
+        assert_eq!(loaded, Some(Probe { value: 7 }));
+    }
+
+    #[test]
+    fn falls_back_to_the_backup_and_keeps_the_unreadable_file() {
+        let path = scratch("corrupt").join("settings.json");
+        SettingsManager::save_to_file(&path, &Probe { value: 1 });
+        SettingsManager::save_to_file(&path, &Probe { value: 2 });
+
+        // What a crash or power loss mid-write used to leave behind.
+        std::fs::write(&path, "{\"value\":").unwrap();
+
+        let loaded: Option<Probe> = SettingsManager::load_from_file(&path);
+        assert_eq!(
+            loaded,
+            Some(Probe { value: 1 }),
+            "should recover the backup instead of resetting to defaults"
+        );
+        assert!(
+            path.with_extension("json.corrupt").exists(),
+            "the unreadable file should be preserved, not overwritten"
+        );
+    }
+
+    #[test]
+    fn a_save_round_trips_and_leaves_no_temp_file() {
+        let path = scratch("save").join("settings.json");
+        SettingsManager::save_to_file(&path, &Probe { value: 42 });
+
+        let loaded: Option<Probe> = SettingsManager::load_from_file(&path);
+        assert_eq!(loaded, Some(Probe { value: 42 }));
+        assert!(!path.with_extension("json.tmp").exists());
+    }
+
+    #[test]
+    fn reports_nothing_when_there_is_nothing_to_recover() {
+        let path = scratch("empty").join("settings.json");
+        let loaded: Option<Probe> = SettingsManager::load_from_file(&path);
+        assert_eq!(loaded, None);
     }
 }


### PR DESCRIPTION
## Why this PR exists

This started as an investigation into a user report:

> Even if 'Custom Position' is enabled, the movement will not take effect the next time the programme is run; you must toggle the option off and on again for it to work.

**That bug did not reproduce on `main` (2.2.14).** What did turn up, while testing it, was an unrelated and worse one: a single bad byte in `settings.json` silently destroys every setting the user has. This PR fixes that.

## The reported bug does not reproduce

The app was built locally and tested against the exact scenario. Because dragging needs a mouse, the harness works from both ends: it writes a known `positionX/positionY` into `settings.json` and reads the overlay window's real on-screen rect back via Win32 `GetWindowRect`, and it drives an actual drag with synthetic `SendInput` mouse events.

| Test | Saved position | Where the HUD landed |
|---|---|---|
| Restart, custom position enabled | (600, 400) | **(600, 400)** |
| Real drag via synthetic mouse input | drag, saved (1000, 0) within 1.2 s | moved and persisted |
| Restart after that drag | (1000, 0) | **(1000, 0)** |
| Restart with "start minimized" (the autostart path) | (1700, 900) | **(1700, 900)** |

Drag, save, restart, restore works in every configuration that could be tested. Two caveats worth stating plainly:

- **Single monitor only.** `positionX/positionY` are stored relative to `monitors[selectedDisplayIndex]`, and `available_monitors()` ordering is not guaranteed stable across runs. A multi-monitor setup is the most likely place this still bites, and it could not be tested here.
- **Version.** `useCustomPosition` and the current window-moving approach first shipped in **v2.1.1** (`e66efd1`, `af5b8c3`). Before that, custom position was `positionIndex === 6` with CSS positioning inside a fullscreen overlay window, the same design as the pre-Tauri Kotlin build, which *does* have exactly this failure: `OverlayWindow.kt:120-126` sets `overlayWindowState.position` for the custom branch but never calls `window.setLocation()`, unlike the preset branch right above it, so the OS placement wins until some later settings change re-triggers it. That is precisely "toggle it off and on and it works". If the reporter is on 2.1.0 or older, this is already fixed.

**So: does anyone know the reporter's version and monitor count?** That decides whether there is anything left to chase.

## The bug this PR does fix

Hit by accident. The test harness patched `settings.json` with PowerShell's `Set-Content -Encoding utf8`, which prepends a UTF-8 BOM. On the next launch:

- the overlay came up at (0, 0) instead of the saved (600, 400)
- `settings.json` was **rewritten** seconds later with `positionX=0, positionY=0, positionIndex=0`, every setting gone

`serde_json` rejected the BOM at byte 0, `load_from_file(...).unwrap_or_default()` quietly substituted defaults, and the next save overwrote the only copy of the user's config. No warning, no recovery.

Note how this presents to a user: *my settings don't survive a restart*. It is very easy to file that as an overlay positioning bug, which is part of why it is worth fixing regardless of the original report.

Two ways a file ends up unreadable, both addressed:

1. **Non-atomic writes.** `fs::write` truncates before writing, so a crash, a power loss, or the tray's `app.exit(0)` landing mid-write leaves a partial file. Writes now go to a sibling temp file, are flushed with `sync_all`, then renamed over the target (`MoveFileEx` plus `MOVEFILE_REPLACE_EXISTING` on Windows), so a reader sees either the old file or the complete new one.
2. **UTF-8 BOM.** Hand-editing `settings.json` in Notepad adds one. Reads now strip it.

And when a file *is* unreadable, the response is no longer silent data loss:

- a backup copy is kept as `settings.json.bak` on every save, and tried before falling back to defaults
- the unreadable file is preserved as `settings.json.corrupt` instead of being overwritten
- both paths log what happened

`preferences.json` shares these helpers, so it gets the same treatment.

## Follow-up commit: two holes in the first pass

Both were raised in review and are fixed in `da8d669`.

1. **A failed quarantine could poison the backup.** The backup was refreshed by copying the on-disk primary just before the rename. When `load_from_file` could not move an unreadable primary aside (a locked or read-only file), the next save copied that same unreadable file over the last known-good backup, leaving neither copy loadable and resetting the config after all. Both files are now written from the same in-memory JSON, so an unreadable primary is never a copy source. Two side effects, both wanted: recovery restores the newest saved state rather than the save before it, and the very first save now produces a backup.
2. **Concurrent saves shared one temp path.** `save_settings` releases the in-memory lock before touching disk, and Tauri runs each non-async `invoke` on its own thread, so the overlay persisting a drag while the settings window persists a toggle could run two write transactions through `settings.json.tmp` and lose one of them. A process-wide write lock now orders the whole transaction, temp file through backup refresh.

## Verification

`cargo test --lib`, six tests:

```
test settings::tests::reads_a_file_that_starts_with_a_utf8_bom ... ok
test settings::tests::falls_back_to_the_backup_and_keeps_the_unreadable_file ... ok
test settings::tests::an_unreadable_primary_never_reaches_the_backup ... ok
test settings::tests::concurrent_saves_leave_both_copies_readable ... ok
test settings::tests::a_save_round_trips_and_leaves_no_temp_file ... ok
test settings::tests::reports_nothing_when_there_is_nothing_to_recover ... ok

test result: ok. 6 passed; 0 failed
```

The BOM test is the exact input that wiped the settings during the investigation.

Beyond the unit tests, the launch path was exercised through the real `SettingsManager` API with the real `OverlaySettings` type, which is the whole of what `lib.rs` `setup()` does on startup: a BOM-prefixed `settings.json` holding `positionX=600, positionY=400, pollingRate=1234, themeMode=dark` loads intact, a following save keeps every unrelated field, then truncating the primary recovers `positionX=1000` (the newest state) from the backup and preserves the bad file as `.corrupt`. The same scenario replayed against `main` returns `position=(0,0) pollingRate=500` and then overwrites the file with those defaults, which confirms the bug rather than assuming it. `preferences.json` round-trips through the same helpers.

Not driven through the GUI: the app is `requireAdministrator`, so launching it needs an interactive elevation prompt. Everything below the window layer is covered above.

`cargo clippy` reports the same five pre-existing warnings as `main`, none in the changed code.

## Not addressed here

Saving is debounced 300 ms in the frontend, and the tray's Quit calls `app.exit(0)` immediately, so a change made in the last 300 ms before quitting is still lost. Narrow enough to leave alone, but it is the remaining way a setting can fail to reach disk.

The four tests leave their scratch directories in `%TEMP%` (`cleanmeter-settings-*`), four per run. Harmless, not cleaned up.
