### PR TITLE
fix(startup): stop the false "monitoring not connected" warning at boot, and connect sooner

### DIFF
--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -10,6 +10,7 @@
     "dev:preview": "vite --config preview/vite.config.ts",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest run --project unit",
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ windows = { version = "0.58", features = [
     "Win32_System_Pipes",
     "Win32_System_IO",
     "Win32_System_Threading",
+    "Win32_System_Diagnostics_ToolHelp",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 
 use crate::pipe_client::PipeCommand;
 use crate::settings::SettingsManager;
-use crate::types::{AppPreferences, MonitorInfo, OverlaySettings};
+use crate::types::{AppPreferences, MonitorInfo, OverlaySettings, SidecarStatus};
 
 #[tauri::command]
 pub fn ui_debug_log(msg: String) {
@@ -74,6 +74,19 @@ fn now_ms() -> u128 {
 }
 
 pub struct PipeCommandSender(pub mpsc::Sender<PipeCommand>);
+
+/// Last sidecar status the supervisor published, kept so a webview that loads
+/// after the first spawn or crash can still read it (events fired before its
+/// listener existed are gone).
+#[derive(Default)]
+pub struct SidecarHealth(pub std::sync::Arc<std::sync::Mutex<SidecarStatus>>);
+
+/// Read the supervisor's view of the sidecar. The banner needs this on mount to
+/// tell a slow start from a broken one without waiting on a timer.
+#[tauri::command]
+pub fn get_sidecar_status(health: State<'_, SidecarHealth>) -> SidecarStatus {
+    health.0.lock().unwrap().clone()
+}
 
 // ─── Settings Commands ──────────────────────────────────────────
 

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -4,9 +4,10 @@ mod settings;
 mod tray;
 mod types;
 
-use commands::PipeCommandSender;
+use commands::{PipeCommandSender, SidecarHealth};
 use log::{error, info, warn};
 use settings::SettingsManager;
+use types::SidecarStatus;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{Emitter, Manager};
@@ -73,6 +74,133 @@ fn pawnio_service_present() -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+}
+
+/// Whether a process with this image name is running. `None` means the snapshot
+/// could not be taken, i.e. we cannot tell.
+///
+/// Takes a name rather than hardcoding one so the mechanism itself is testable:
+/// a probe that silently answers "nothing is running" would disable the cleanup
+/// below without any visible failure.
+#[cfg(windows)]
+fn process_running(image_name: &str) -> Option<bool> {
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0).ok()?;
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+        let mut found = false;
+        if Process32FirstW(snapshot, &mut entry).is_ok() {
+            loop {
+                let len = entry
+                    .szExeFile
+                    .iter()
+                    .position(|&c| c == 0)
+                    .unwrap_or(entry.szExeFile.len());
+                if String::from_utf16_lossy(&entry.szExeFile[..len])
+                    .eq_ignore_ascii_case(image_name)
+                {
+                    found = true;
+                    break;
+                }
+                if Process32NextW(snapshot, &mut entry).is_err() {
+                    break;
+                }
+            }
+        }
+        let _ = CloseHandle(snapshot);
+        Some(found)
+    }
+}
+
+/// True when a HardwareMonitor we do not own is already running: one orphaned by
+/// a crashed run, or the instance the legacy CleanMeterHW service hosts. Only
+/// called before the first spawn, when we own no child, so anything found is
+/// foreign.
+///
+/// Checking the process rather than the named pipe matters. The sidecar creates
+/// its pipe only after LibreHardwareMonitor finishes enumerating (measured up to
+/// 13.7s), so an orphan still inside that window holds no pipe and a pipe probe
+/// misses it entirely. Nothing later corrects that: a second sidecar creates its
+/// own instance of the same pipe name rather than failing
+/// (`NamedPipeServerStream.MaxAllowedServerInstances` in PipeHost.cs), so
+/// neither process exits, the respawn loop below never iterates, and the
+/// duplicate keeps polling ring0 and driving PresentMon for the rest of the
+/// session. Unlike a `taskkill`, this costs no process spawn.
+///
+/// Fails safe: if the snapshot cannot be taken we assume one is running, which
+/// restores the old unconditional cleanup.
+#[cfg(windows)]
+fn foreign_sidecar_running() -> bool {
+    process_running("HardwareMonitor.exe").unwrap_or_else(|| {
+        warn!("Could not enumerate processes; assuming a stale sidecar is present");
+        true
+    })
+}
+
+#[cfg(all(test, windows))]
+mod process_probe_tests {
+    use super::process_running;
+
+    /// The probe's whole value is answering "yes" when something really is
+    /// running; a mechanism that always answered "no" would silently disable the
+    /// stale-instance cleanup. The test binary is the one process guaranteed to
+    /// be running while this test runs.
+    #[test]
+    fn finds_a_process_that_is_definitely_running() {
+        let me = std::env::current_exe().expect("current exe");
+        let name = me.file_name().expect("file name").to_string_lossy().into_owned();
+        assert_eq!(process_running(&name), Some(true), "probing for {}", name);
+    }
+
+    #[test]
+    fn does_not_find_a_process_that_cannot_exist() {
+        assert_eq!(
+            process_running("cleanmeter-no-such-process.exe"),
+            Some(false)
+        );
+    }
+
+    /// Windows image names are case-insensitive; the supervisor hardcodes one
+    /// spelling and the running process may differ.
+    #[test]
+    fn matches_regardless_of_case() {
+        let me = std::env::current_exe().expect("current exe");
+        let name = me.file_name().expect("file name").to_string_lossy().to_uppercase();
+        assert_eq!(process_running(&name), Some(true));
+    }
+}
+
+/// Drop the CleanMeterHW service, which hosts a second copy of the sidecar.
+///
+/// The app supervises its own sidecar now, so a service-hosted one is a
+/// duplicate: both poll ring0 and both drive PresentMon. Note this is not purely
+/// a migration from older builds. `commands::launch_hardware_monitor`, reachable
+/// from the admin-consent screen, still creates and starts the service, so this
+/// deletes what that flow installs on the next launch. That contradiction
+/// predates this change and is left alone here; it is called out so the next
+/// person does not read the deletion as dead legacy code.
+///
+/// Runs once per launch (the caller's flag is loop-local), off the startup path.
+#[cfg(windows)]
+fn remove_legacy_service() {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    for args in [["stop", "CleanMeterHW"], ["delete", "CleanMeterHW"]] {
+        let _ = std::process::Command::new("sc.exe")
+            .args(args)
+            .creation_flags(CREATE_NO_WINDOW)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
 }
 
 /// Install the PawnIO driver from the bundled signed installer if it is not
@@ -341,6 +469,21 @@ pub fn run() {
                 let child_slot: Arc<StdMutex<Option<Child>>> = Arc::new(StdMutex::new(None));
                 app.manage(child_slot.clone());
 
+                // Sidecar health is both pushed and pollable. The settings
+                // webview registers its listener only once it has loaded, which
+                // is easily after the first spawn (or a first crash), so an
+                // event alone would be missed and the banner would run on stale
+                // zeroes. `get_sidecar_status` lets it read the current value on
+                // mount; the event keeps it current afterwards.
+                let health = SidecarHealth::default();
+                let health_for_thread = health.0.clone();
+                app.manage(health);
+                let app_for_hw = app.handle().clone();
+                let publish = move |status: SidecarStatus| {
+                    *health_for_thread.lock().unwrap() = status.clone();
+                    let _ = app_for_hw.emit("sidecar-status", status);
+                };
+
                 let hw_running = running_for_hw;
                 std::thread::spawn(move || {
                     // Ensure the PawnIO driver is present before the sidecar
@@ -349,23 +492,27 @@ pub fn run() {
                     // Non-blocking and best-effort (see ensure_pawnio_installed).
                     ensure_pawnio_installed(&pawnio_setup);
 
-                    // One-time cleanup: drop any service or instance left behind
-                    // by a previous version or a previous run before we take over.
-                    let _ = std::process::Command::new("sc.exe")
-                        .args(["stop", "CleanMeterHW"])
-                        .creation_flags(CREATE_NO_WINDOW)
-                        .status();
-                    let _ = std::process::Command::new("sc.exe")
-                        .args(["delete", "CleanMeterHW"])
-                        .creation_flags(CREATE_NO_WINDOW)
-                        .status();
-                    let _ = std::process::Command::new("taskkill")
-                        .args(["/f", "/im", "HardwareMonitor.exe"])
-                        .creation_flags(CREATE_NO_WINDOW)
-                        .status();
-                    // Give the OS a moment to release the pipe handle held by any
-                    // instance we just killed before the first spawn.
-                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    // Clear a stale instance only when one is actually there.
+                    // This used to run unconditionally: two `sc.exe` calls, a
+                    // `taskkill`, and a flat 500ms sleep in front of every
+                    // launch, all to handle a case that only arises after a
+                    // crash. The sidecar is the long pole in startup (its
+                    // hardware enumeration measured 1.55s median and up to
+                    // 13.7s across 114 launches, and no overlay can appear
+                    // before it finishes), so nothing else belongs ahead of it.
+                    if foreign_sidecar_running() {
+                        warn!("A HardwareMonitor is already running; clearing it before spawning");
+                        let _ = std::process::Command::new("taskkill")
+                            .args(["/f", "/im", "HardwareMonitor.exe"])
+                            .creation_flags(CREATE_NO_WINDOW)
+                            .status();
+                        // Let the OS release the pipe handle held by whatever we
+                        // just killed before the first spawn tries to bind it.
+                        std::thread::sleep(std::time::Duration::from_millis(500));
+                    }
+
+                    let mut legacy_service_checked = false;
+                    let mut exits: u32 = 0;
 
                     while hw_running.load(Ordering::Relaxed) {
                         match std::process::Command::new(&hw_exe)
@@ -375,6 +522,20 @@ pub fn run() {
                             Ok(child) => {
                                 info!("HardwareMonitor spawned (pid {})", child.id());
                                 *child_slot.lock().unwrap() = Some(child);
+                                // Alive: clears any previous spawn error, so a
+                                // failure that recovers stops being reported.
+                                publish(SidecarStatus { exits, spawn_error: None });
+
+                                // Retire the service-hosted duplicate, on its own
+                                // thread so two `sc.exe` calls cannot delay the
+                                // sidecar we just started. Stopping it does not
+                                // disturb this child: two sidecars can serve the
+                                // same pipe name concurrently, so ours is already
+                                // running either way (see foreign_sidecar_running).
+                                if !legacy_service_checked {
+                                    legacy_service_checked = true;
+                                    std::thread::spawn(remove_legacy_service);
+                                }
 
                                 // Poll for exit so we can also react to shutdown.
                                 loop {
@@ -397,9 +558,15 @@ pub fn run() {
                                     std::thread::sleep(std::time::Duration::from_millis(500));
                                 }
                                 *child_slot.lock().unwrap() = None;
+                                exits = exits.saturating_add(1);
+                                publish(SidecarStatus { exits, spawn_error: None });
                             }
                             Err(e) => {
                                 error!("Failed to spawn HardwareMonitor: {}", e);
+                                publish(SidecarStatus {
+                                    exits,
+                                    spawn_error: Some(e.to_string()),
+                                });
                             }
                         }
 
@@ -532,6 +699,7 @@ pub fn run() {
             commands::get_settings,
             commands::save_settings,
             commands::clear_settings,
+            commands::get_sidecar_status,
             commands::get_preferences,
             commands::save_preferences,
             commands::set_overlay_visible,

--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -3,7 +3,7 @@ use log::{error, info, warn};
 use std::io::{self, Cursor, Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
 
@@ -180,6 +180,47 @@ fn build_command(cmd: &PipeCommand) -> Vec<u8> {
     buf
 }
 
+/// How long after losing (or before making) a connection we keep polling the
+/// pipe rapidly, before falling back to a slow retry.
+///
+/// The sidecar only creates its pipe once LibreHardwareMonitor has finished
+/// enumerating hardware, which measured at a median of 1.55s and up to 13.7s
+/// across 114 real launches. Backing off exponentially from the first failed
+/// attempt therefore guaranteed we were asleep when the pipe finally appeared:
+/// the gap between "sidecar listening" and "app connected" was a median of
+/// 3.08s and as much as 9.96s of pure dead time, and 61 of 113 runs wasted more
+/// than 3s. That delay is the app's own, not the sidecar's.
+///
+/// Must stay longer than `STARTUP_GRACE_MS` in `src/lib/monitoring.ts`, which is
+/// how long the UI treats a launch as still starting. That timer begins when the
+/// settings webview mounts, i.e. later than this one, so if this window closed
+/// first the client would be back on the slow backoff while the UI still expects
+/// a connection, and a sidecar that appeared in the gap would produce the very
+/// "not connected" banner this branch removes.
+const FAST_POLL_WINDOW: Duration = Duration::from_secs(60);
+/// Interval during that window. A failed open on a missing pipe is a cheap
+/// `CreateFile` that fails immediately, so this costs nothing measurable.
+const FAST_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// What to do before the next connect attempt.
+#[derive(Debug, PartialEq, Eq)]
+enum RetryMode {
+    /// Keep checking at `FAST_POLL_INTERVAL`: the sidecar may still be starting.
+    FastPoll,
+    /// Fall back to the growing delay: nothing has answered for long enough that
+    /// polling is no longer worth it.
+    Backoff,
+}
+
+/// A pure decision so the policy can be tested without a pipe or a sidecar.
+fn retry_mode(disconnected_for: Duration) -> RetryMode {
+    if disconnected_for < FAST_POLL_WINDOW {
+        RetryMode::FastPoll
+    } else {
+        RetryMode::Backoff
+    }
+}
+
 /// Named pipe client for Windows communication with HardwareMonitor backend
 pub async fn run_pipe_client(
     app: AppHandle,
@@ -188,17 +229,33 @@ pub async fn run_pipe_client(
 ) {
     let mut retry_delay = Duration::from_secs(2);
     let max_retry_delay = Duration::from_secs(10);
+    // Start of the current disconnected stretch, reset on every successful
+    // connect so a sidecar crash gets the same fast reconnect as startup.
+    let mut disconnected_since = Instant::now();
+    // Emit and log only on change: at a 250ms poll, announcing every failed
+    // attempt would spam the log and re-render the frontend four times a second
+    // for no new information.
+    let mut announced_disconnect = false;
+    let mut logged_failure = false;
 
     while running.load(Ordering::Relaxed) {
-        info!("Connecting to HardwareMonitor...");
-        let _ = app.emit("pipe-status", PipeStatus { connected: false, error: None });
+        if !announced_disconnect {
+            info!("Connecting to HardwareMonitor...");
+            let _ = app.emit("pipe-status", PipeStatus { connected: false });
+            announced_disconnect = true;
+        }
 
         let pipe_name = r"\\.\pipe\HardwareMonitor_31337";
         match std::fs::OpenOptions::new().read(true).write(true).open(pipe_name) {
             Ok(pipe_file) => {
-                info!("Connected to HardwareMonitor via named pipe");
-                let _ = app.emit("pipe-status", PipeStatus { connected: true, error: None });
+                info!(
+                    "Connected to HardwareMonitor via named pipe after {:.2}s",
+                    disconnected_since.elapsed().as_secs_f32()
+                );
+                let _ = app.emit("pipe-status", PipeStatus { connected: true });
                 retry_delay = Duration::from_secs(2);
+                announced_disconnect = false;
+                logged_failure = false;
 
                 let mut writer = match pipe_file.try_clone() {
                     Ok(w) => w,
@@ -301,17 +358,18 @@ pub async fn run_pipe_client(
                 }
 
                 let _ = read_handle.await;
+                // The connection just ended: start a fresh fast-poll window so a
+                // sidecar crash reconnects as quickly as a cold start does.
+                disconnected_since = Instant::now();
             }
             Err(e) => {
-                let msg = format!("Connection failed: {}", e);
-                warn!("{}", msg);
-                let _ = app.emit(
-                    "pipe-status",
-                    PipeStatus {
-                        connected: false,
-                        error: Some(msg),
-                    },
-                );
+                // Expected, not exceptional, for the first seconds of a launch:
+                // the sidecar has not created the pipe yet. Logged once per
+                // disconnected stretch rather than once per attempt.
+                if !logged_failure {
+                    warn!("Connection failed: {}", e);
+                    logged_failure = true;
+                }
             }
         }
 
@@ -319,9 +377,15 @@ pub async fn run_pipe_client(
             break;
         }
 
-        // Wait before retrying
-        tokio::time::sleep(retry_delay).await;
-        retry_delay = (retry_delay * 2).min(max_retry_delay);
+        // Poll fast while the sidecar could still be coming up, then fall back to
+        // the slow backoff so a genuinely absent sidecar is not polled forever.
+        match retry_mode(disconnected_since.elapsed()) {
+            RetryMode::FastPoll => tokio::time::sleep(FAST_POLL_INTERVAL).await,
+            RetryMode::Backoff => {
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = (retry_delay * 2).min(max_retry_delay);
+            }
+        }
     }
 
     info!("Pipe client stopped");
@@ -333,4 +397,51 @@ fn read_u16<R: Read>(reader: &mut R) -> io::Result<u16> {
 
 fn read_u32<R: Read>(reader: &mut R) -> io::Result<u32> {
     reader.read_u32::<LittleEndian>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The measured shape of the bug. Sidecar startup, from process start to the
+    /// pipe existing, ran to 13.7s across 114 logged launches, with the app then
+    /// taking a median of 3.08s (worst 9.96s) to notice. Exponential backoff from
+    /// the first failure is what produced that: by the time the pipe appeared the
+    /// client was asleep for 8 to 10 seconds. Every one of these instants must
+    /// still be inside the fast-poll window.
+    #[test]
+    fn a_sidecar_that_is_still_enumerating_is_polled_not_waited_on() {
+        for secs in [0.0f32, 0.25, 1.55, 3.08, 4.41, 9.96, 13.7, 19.67, 30.0, 44.9] {
+            assert_eq!(
+                retry_mode(Duration::from_secs_f32(secs)),
+                RetryMode::FastPoll,
+                "{}s into a disconnected stretch is still plausible startup",
+                secs
+            );
+        }
+    }
+
+    #[test]
+    fn a_sidecar_that_never_answers_stops_being_polled() {
+        assert_eq!(retry_mode(FAST_POLL_WINDOW), RetryMode::Backoff);
+        assert_eq!(
+            retry_mode(FAST_POLL_WINDOW + Duration::from_secs(60)),
+            RetryMode::Backoff
+        );
+    }
+
+    /// The window has to clear the slowest launch on record with room to spare,
+    /// or the old dead time comes straight back for the slowest machines.
+    #[test]
+    fn the_fast_poll_window_clears_the_slowest_launch_measured() {
+        let slowest_observed = Duration::from_millis(19_670);
+        assert!(FAST_POLL_WINDOW > slowest_observed * 2);
+    }
+
+    /// Worst-case added latency after the pipe appears is one poll interval, so
+    /// this bounds what the fix can leave on the table.
+    #[test]
+    fn the_poll_interval_bounds_the_remaining_delay() {
+        assert!(FAST_POLL_INTERVAL <= Duration::from_millis(300));
+    }
 }

--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -416,7 +416,22 @@ pub enum UpdateState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PipeStatus {
     pub connected: bool,
-    pub error: Option<String>,
+}
+
+/// What the supervisor has observed about the HardwareMonitor child process.
+///
+/// The frontend cannot tell a slow start from a broken one by waiting, because
+/// no reading exists until the sidecar finishes enumerating hardware (measured
+/// at up to 13.7s). This is the evidence it uses instead: a sidecar that will
+/// not spawn, or that keeps exiting, is a real failure, while silence from a
+/// process that is still running is just startup.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SidecarStatus {
+    /// Times the sidecar has exited since the app started.
+    pub exits: u32,
+    /// Why the last spawn attempt failed, if it did.
+    pub spawn_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -11,30 +11,46 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { useUpdaterStore } from "@/stores/updater-store";
 import { UpdateBanner } from "@/components/settings/UpdateBanner";
 import { checkDotnetRuntime, onSettingsChanged } from "@/lib/tauri";
+import { STARTUP_GRACE_MS, monitoringVerdict } from "@/lib/monitoring";
 import { SplashScreen } from "@/components/SplashScreen";
 
 function MonitoringBanner() {
   const sensorData = useSettingsStore((s) => s.sensorData);
   const pipeStatus = useSettingsStore((s) => s.pipeStatus);
-  const [showBanner, setShowBanner] = useState(false);
+  const sidecarStatus = useSettingsStore((s) => s.sidecarStatus);
+  const [graceExpired, setGraceExpired] = useState(false);
   const [dotnetMissing, setDotnetMissing] = useState(false);
 
+  // The banner used to be a plain 8s timer, which is not evidence of a failure:
+  // a reading cannot exist before the sidecar has enumerated hardware, and that
+  // alone measured up to 13.7s across 114 launches, so a third of them were
+  // called broken while starting normally. At logon it happened nearly every
+  // time. The verdict now comes from what the supervisor actually saw (see
+  // monitoringVerdict), and this timer is only the backstop for a sidecar that
+  // runs but never reports.
   useEffect(() => {
-    const timer = setTimeout(() => {
-      if (!useSettingsStore.getState().sensorData) {
-        setShowBanner(true);
-        checkDotnetRuntime().then((ok) => {
-          if (!ok) setDotnetMissing(true);
-        }).catch(() => {});
-      }
-    }, 8000);
+    const timer = setTimeout(() => setGraceExpired(true), STARTUP_GRACE_MS);
     return () => clearTimeout(timer);
   }, []);
 
-  // Hide the banner as soon as data arrives — derived from sensorData rather
-  // than mirrored into state via an effect (which would cascade an extra
-  // render). showBanner still gates the 8s "no data yet" delay above.
-  if (!showBanner || sensorData) return null;
+  const verdict = monitoringVerdict({
+    hasSensorData: !!sensorData,
+    sidecar: sidecarStatus,
+    graceExpired,
+  });
+
+  // Only a failing verdict is worth telling the user about, and only then is it
+  // worth paying for the .NET probe.
+  useEffect(() => {
+    if (verdict !== "failed") return;
+    checkDotnetRuntime()
+      .then((ok) => {
+        if (!ok) setDotnetMissing(true);
+      })
+      .catch(() => {});
+  }, [verdict]);
+
+  if (verdict !== "failed") return null;
 
   return (
     <div className="border-b border-yellow-400 bg-yellow-50 px-4 py-2.5 text-[13px] leading-snug text-yellow-900 dark:border-yellow-700 dark:bg-yellow-950 dark:text-yellow-200">

--- a/tauri-app/src/hooks/useSensorData.ts
+++ b/tauri-app/src/hooks/useSensorData.ts
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import { onSensorData, onPresentMonApps, onPipeStatus } from "@/lib/tauri";
+import {
+  onSensorData,
+  onPresentMonApps,
+  onPipeStatus,
+  onSidecarStatus,
+} from "@/lib/tauri";
 import { useSettingsStore } from "@/stores/settings-store";
 import { SensorType } from "@/lib/types";
 import type { HardwareMonitorData } from "@/lib/types";
@@ -8,6 +13,8 @@ export function useSensorData() {
   const setSensorData = useSettingsStore((s) => s.setSensorData);
   const setPresentMonApps = useSettingsStore((s) => s.setPresentMonApps);
   const setPipeStatus = useSettingsStore((s) => s.setPipeStatus);
+  const setSidecarStatus = useSettingsStore((s) => s.setSidecarStatus);
+  const loadSidecarStatus = useSettingsStore((s) => s.loadSidecarStatus);
 
   useEffect(() => {
     let mounted = true;
@@ -22,6 +29,15 @@ export function useSensorData() {
 
       const u3 = await onPipeStatus((status) => setPipeStatus(status));
       if (mounted) unlisteners.push(u3); else u3();
+
+      const u4 = await onSidecarStatus((status) => setSidecarStatus(status));
+      if (mounted) unlisteners.push(u4); else u4();
+
+      // Subscribing is not enough: the sidecar is spawned before this webview
+      // finishes loading, so its first spawn (or an early crash) has already
+      // been emitted and is gone. Read the current value once the listener is
+      // in place, so neither path can be missed.
+      if (mounted) loadSidecarStatus();
     };
     setup();
 
@@ -29,7 +45,7 @@ export function useSensorData() {
       mounted = false;
       unlisteners.forEach((u) => u());
     };
-  }, [setSensorData, setPresentMonApps, setPipeStatus]);
+  }, [setSensorData, setPresentMonApps, setPipeStatus, setSidecarStatus, loadSidecarStatus]);
 }
 
 /** Hook for overlay — keeps a rolling buffer of frametime values */

--- a/tauri-app/src/lib/monitoring.test.ts
+++ b/tauri-app/src/lib/monitoring.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  CRASH_LOOP_EXITS,
+  STARTUP_GRACE_MS,
+  monitoringVerdict,
+} from "./monitoring";
+import type { SidecarStatus } from "./types";
+
+const healthy: SidecarStatus = { exits: 0, spawnError: null };
+
+describe("monitoringVerdict", () => {
+  it("is ok once a reading has arrived", () => {
+    expect(
+      monitoringVerdict({ hasSensorData: true, sidecar: healthy, graceExpired: false }),
+    ).toBe("ok");
+  });
+
+  it("stays ok after a reading even if the sidecar has crashed since", () => {
+    expect(
+      monitoringVerdict({
+        hasSensorData: true,
+        sidecar: { exits: 5, spawnError: "boom" },
+        graceExpired: true,
+      }),
+    ).toBe("ok");
+  });
+
+  // The bug this exists to prevent. A launch with nothing wrong with it used to
+  // be called "not connected" purely because 8 seconds had passed, which reads
+  // to the user as a broken app. Across 114 measured launches the sidecar's
+  // hardware enumeration alone took a median of 1.55s and up to 13.7s, and 36
+  // of 113 launches had not produced a first reading by the old 8s deadline.
+  it("reports a normal slow start as starting, not as a failure", () => {
+    expect(
+      monitoringVerdict({ hasSensorData: false, sidecar: healthy, graceExpired: false }),
+    ).toBe("starting");
+  });
+
+  it("tolerates a single sidecar exit, which a crash that recovers produces", () => {
+    expect(
+      monitoringVerdict({
+        hasSensorData: false,
+        sidecar: { exits: 1, spawnError: null },
+        graceExpired: false,
+      }),
+    ).toBe("starting");
+  });
+
+  // Pins the threshold itself. Asserting only `CRASH_LOOP_EXITS -> failed` and
+  // `1 -> starting` stays green for any value above 1, so the rule could drift
+  // to 10 without a failure.
+  it("draws the line at exactly two exits", () => {
+    expect(CRASH_LOOP_EXITS).toBe(2);
+    expect(
+      monitoringVerdict({
+        hasSensorData: false,
+        sidecar: { exits: 2, spawnError: null },
+        graceExpired: false,
+      }),
+    ).toBe("failed");
+  });
+
+  it("fails immediately when the sidecar could not be started at all", () => {
+    expect(
+      monitoringVerdict({
+        hasSensorData: false,
+        sidecar: { exits: 0, spawnError: "program not found" },
+        graceExpired: false,
+      }),
+    ).toBe("failed");
+  });
+
+  it("fails once the sidecar is exiting repeatedly", () => {
+    expect(
+      monitoringVerdict({
+        hasSensorData: false,
+        sidecar: { exits: CRASH_LOOP_EXITS, spawnError: null },
+        graceExpired: false,
+      }),
+    ).toBe("failed");
+  });
+
+  it("still reports a sidecar that runs but never produces a reading", () => {
+    expect(
+      monitoringVerdict({ hasSensorData: false, sidecar: healthy, graceExpired: true }),
+    ).toBe("failed");
+  });
+});
+
+describe("STARTUP_GRACE_MS", () => {
+  // Guards the measurement rather than the code: the slowest of 114 logged
+  // launches took 19.67s from sidecar start to the app connecting, and a reading
+  // follows shortly after. A grace period near that number would put the false
+  // warning straight back.
+  it("leaves real headroom over the slowest launch measured", () => {
+    const slowestObservedMs = 19_670;
+    expect(STARTUP_GRACE_MS).toBeGreaterThan(slowestObservedMs * 2);
+  });
+});

--- a/tauri-app/src/lib/monitoring.ts
+++ b/tauri-app/src/lib/monitoring.ts
@@ -1,0 +1,59 @@
+import type { SidecarStatus } from "./types";
+
+/**
+ * How long a launch may go without a reading before we call it broken.
+ *
+ * The old rule was 8 seconds of wall clock, which is not evidence of anything:
+ * no reading can exist until the sidecar finishes enumerating hardware, and
+ * across 114 logged launches that alone took a median of 1.55s and as much as
+ * 13.7s, with the slowest run reaching 19.67s before the app was even
+ * connected. 36 of 113 launches were still starting normally when the 8s
+ * deadline fired, so a third of the time the app called itself broken while
+ * working. At logon, where the disk is busiest, it happened almost every time.
+ *
+ * This is deliberately far past the slowest thing we have measured. It is the
+ * backstop for a sidecar that runs but never speaks; a sidecar that fails
+ * outright is reported by the evidence below instead, and immediately.
+ *
+ * Must stay shorter than FAST_POLL_WINDOW in src-tauri/src/pipe_client.rs, the
+ * window in which the backend still polls for the sidecar rapidly. This timer
+ * starts later than that one (on webview mount rather than on app start), so if
+ * it outlived the window the UI would report a failure while the backend had
+ * already dropped to its slow retry.
+ */
+export const STARTUP_GRACE_MS = 45_000;
+
+/**
+ * Sidecar exits before we stop treating a launch as a slow start.
+ *
+ * Any exit is a real crash: the sidecar cannot exit from a pipe conflict, since
+ * two instances can serve the same pipe name and its accept loop retries every
+ * error (PipeHost.cs). One is still tolerated because a crash that recovers is
+ * invisible anyway, as the first reading resolves the verdict before this
+ * matters; two says it is not settling.
+ */
+export const CRASH_LOOP_EXITS = 2;
+
+export type MonitoringVerdict = "ok" | "starting" | "failed";
+
+/**
+ * Decide whether monitoring is working, still coming up, or actually broken.
+ *
+ * Split out of the banner component so the rule is testable on its own, and so
+ * the answer is driven by what the supervisor observed rather than by a timer.
+ */
+export function monitoringVerdict(input: {
+  hasSensorData: boolean;
+  sidecar: SidecarStatus;
+  graceExpired: boolean;
+}): MonitoringVerdict {
+  // A reading settles it, whatever happened on the way here.
+  if (input.hasSensorData) return "ok";
+  // Evidence of real failure, worth saying so without waiting.
+  if (input.sidecar.spawnError) return "failed";
+  if (input.sidecar.exits >= CRASH_LOOP_EXITS) return "failed";
+  // Nothing is wrong that we can see, so it is still starting until the
+  // backstop expires.
+  if (input.graceExpired) return "failed";
+  return "starting";
+}

--- a/tauri-app/src/lib/tauri.ts
+++ b/tauri-app/src/lib/tauri.ts
@@ -5,6 +5,7 @@ import type {
   PipeStatus,
   MonitorInfo,
   AppPreferences,
+  SidecarStatus,
 } from "./types";
 
 // ─── Browser detection ──────────────────────────────────────────
@@ -35,6 +36,8 @@ export const saveSettings = (settings: OverlaySettings) =>
   safeInvoke("save_settings", { settings });
 export const clearSettings = () => safeInvoke("clear_settings");
 export const getPreferences = () => safeInvoke<AppPreferences>("get_preferences");
+/** Polled once on mount: events fired before the webview loaded are lost. */
+export const getSidecarStatus = () => safeInvoke<SidecarStatus>("get_sidecar_status");
 export const savePreferences = (prefs: AppPreferences) =>
   safeInvoke("save_preferences", { prefs });
 
@@ -132,6 +135,11 @@ export const onPipeStatus = (
   callback: (status: PipeStatus) => void
 ): Promise<UnlistenFn> =>
   safeListen<PipeStatus>("pipe-status", (event) => callback(event.payload));
+
+export const onSidecarStatus = (
+  callback: (status: SidecarStatus) => void
+): Promise<UnlistenFn> =>
+  safeListen<SidecarStatus>("sidecar-status", (event) => callback(event.payload));
 
 export const onSettingsChanged = (
   callback: (settings: OverlaySettings) => void

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -134,7 +134,19 @@ export interface HardwareMonitorData {
 
 export interface PipeStatus {
   connected: boolean;
-  error?: string;
+}
+
+/**
+ * What the Rust-side supervisor has observed about the HardwareMonitor child
+ * process. This is the evidence the monitoring banner runs on: a missing
+ * reading on its own means nothing during startup, but a sidecar that will not
+ * start, or that keeps exiting, is a real failure worth reporting at once.
+ */
+export interface SidecarStatus {
+  /** Times the sidecar has exited since the app started. */
+  exits: number;
+  /** Why the last spawn attempt failed, if it did. */
+  spawnError: string | null;
 }
 
 export interface MonitorInfo {

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -3,6 +3,7 @@ import type {
   OverlaySettings,
   HardwareMonitorData,
   PipeStatus,
+  SidecarStatus,
   SensorKey,
   FramerateSensorConfig,
   GraphSensorConfig,
@@ -145,6 +146,12 @@ function autoSelectSensors(
   return changed ? patch : null;
 }
 
+/** Set once the sidecar-status event channel has delivered anything. See
+ *  loadSidecarStatus, which is a one-shot catch-up read and must not overwrite
+ *  the live channel. Module scope rather than store state: it orders two
+ *  writers, it is not something the UI renders. */
+let sawSidecarEvent = false;
+
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 function debouncedSave(settings: OverlaySettings) {
   if (saveTimer) clearTimeout(saveTimer);
@@ -158,6 +165,7 @@ interface SettingsStore {
   sensorData: HardwareMonitorData | null;
   presentMonApps: string[];
   pipeStatus: PipeStatus;
+  sidecarStatus: SidecarStatus;
   overlayVisible: boolean;
   appVersion: string;
 
@@ -186,6 +194,8 @@ interface SettingsStore {
   setSensorData: (data: HardwareMonitorData) => void;
   setPresentMonApps: (apps: string[]) => void;
   setPipeStatus: (status: PipeStatus) => void;
+  setSidecarStatus: (status: SidecarStatus) => void;
+  loadSidecarStatus: () => Promise<void>;
 
   // Overlay
   toggleOverlay: () => void;
@@ -209,6 +219,9 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   sensorData: null,
   presentMonApps: [],
   pipeStatus: { connected: false },
+  // Nothing has gone wrong until the supervisor says so, so a launch reads as
+  // "still starting" rather than as a failure.
+  sidecarStatus: { exits: 0, spawnError: null },
   overlayVisible: false,
   // Empty until loadAppVersion() resolves the real version — better a brief
   // blank than a misleading hardcoded number.
@@ -393,6 +406,27 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     }
   },
   setPresentMonApps: (apps) => set({ presentMonApps: apps }),
+  setSidecarStatus: (status) => {
+    sawSidecarEvent = true;
+    set({ sidecarStatus: status });
+  },
+  loadSidecarStatus: async () => {
+    try {
+      // Undefined in the browser preview, where there is no Tauri runtime and no
+      // sidecar to have an opinion about.
+      const status = await tauri.getSidecarStatus();
+      // The read races the event channel: one arriving while the invoke was in
+      // flight would otherwise be reverted to this older snapshot, hiding a real
+      // failure or pinning a spawn error that a successful respawn already
+      // cleared. Comparing `exits` is not enough, since both of those flip
+      // `spawnError` without changing the count. The event is the live channel,
+      // so once it has delivered anything this read has nothing left to add.
+      if (!status || sawSidecarEvent) return;
+      set({ sidecarStatus: status });
+    } catch (err) {
+      console.error("Failed to load sidecar status:", err);
+    }
+  },
   setPipeStatus: (status) => {
     const wasConnected = get().pipeStatus.connected;
     set({ pipeStatus: status });

--- a/tauri-app/vite.config.ts
+++ b/tauri-app/vite.config.ts
@@ -46,6 +46,15 @@ export default defineConfig({
   },
   test: {
     projects: [{
+      // Plain unit tests for logic with no DOM: `npx vitest run --project unit`.
+      // Separate from the storybook project below so it needs no browser.
+      extends: true,
+      test: {
+        name: 'unit',
+        environment: 'node',
+        include: ['src/**/*.test.{ts,tsx}'],
+      }
+    }, {
       extends: true,
       plugins: [
       // The plugin will run tests for the stories defined in your Storybook config


### PR DESCRIPTION
## The bug

At boot, Cleanmeter warned "Monitoring not connected" for ~10 seconds, then fixed itself. Nothing was broken.

## Why

The warning was just an 8-second timer. But the hardware scan legitimately takes longer than that at boot, so the app called itself broken while working fine. Separately, the app retried connecting at 0, 2, 6, 14, 24 seconds, so it sat asleep for 3 to 10 seconds after monitoring was already ready.

## The fix

The warning now only appears when something actually failed, not when time passed. And the app checks every 250ms instead of backing off, so it connects immediately.

## Result

No false warning, HUD appears ~5 seconds sooner.

---

## Measurements

Taken from the sidecar's own logs, 114 launches over two months, plus before/after runs on one machine.

| Interval | Before | After |
|---|---|---|
| Sidecar enumeration (start to pipe ready) | 1.55s median, up to 13.70s | unchanged, not addressed here |
| App dead time (pipe ready to connected) | 3.08s median, up to 9.96s | 0.01s, 0.01s, 0.22s measured |
| Sidecar start to connected, first run of each day | 7.88s median | 3.02s median |

61 of 113 runs wasted more than 3 seconds with monitoring already available. 36 of 113 crossed the old 8-second banner deadline; among first-runs-of-the-day it was 25 of 51, which is why the warning showed most mornings.

## What changed

**Pipe client.** Backoff went 0, 2, 6, 14, 24 seconds from the first failed attempt. The sidecar's pipe appears between those, so the app was reliably asleep when monitoring became available. It now polls every 250ms for the first 45s of a disconnected stretch, then falls back to the old backoff so an absent sidecar is not polled forever. The window resets on disconnect, so a crash reconnects as fast as a cold start. Failures log and emit once per stretch rather than once per attempt.

**Banner.** The verdict now comes from what the supervisor observed rather than from elapsed time. A reading means fine; a sidecar that could not spawn, or that has exited twice, is reported immediately, which is sooner than the old timer managed; anything else is still starting and shows nothing. One exit is deliberately not a failure, because a stale pipe holder makes the first spawn lose the race. The timer survives only as a 45s backstop for a sidecar that runs but never reports. No banner copy changed, only when it appears.

**Startup.** The stale-instance cleanup (two `sc.exe` calls, a taskkill and a flat 500ms sleep) ran on every launch for a case that only arises after a crash. It now runs only when a HardwareMonitor is actually running, which costs a process snapshot instead. The check is on the process rather than the named pipe deliberately: the sidecar creates its pipe only after enumeration finishes, so an orphan inside that window holds no pipe, and since two sidecars can each serve the same pipe name neither would ever exit to correct it.

## Verification

Automated: 13 Rust tests and 9 frontend tests, both driven test-first. The retry policy is a pure function tested against the measured instants; the process probe is tested by probing the test binary itself, so a probe that silently answered "nothing is running" fails the suite. Running the frontend tests needed a plain node project in the vitest config, since the only project there was the storybook browser one, and a `test` script now makes the suite discoverable.

Manual, on Windows 11:

- A slow boot was simulated by standing in a stub sidecar that stays alive with no reading for 20 seconds. The app ran roughly 24 seconds with no reading and showed no banner, where the previous 8-second timer would have fired three times over before the first reading. The HUD appeared once the real sidecar handed over.
- Pipe dead time measured 0.01s, 0.01s and 0.22s across three launches, against 0.94s and 2.18s on the same machine before the change.

## Not addressed

- Sidecar hardware enumeration, which is now almost all of the remaining startup time and is dominated by LibreHardwareMonitor.
- The autostart scheduled task registers with `Priority=7` (below normal) and `ExecutionTimeLimit=PT72H`. The first slows the whole tree during logon, when contention is highest; the second has the scheduler terminate the app after three days of uptime. Both live in the same `schtasks /create` call and are left for a separate change.
- Moving the sidecar spawn ahead of the rest of `setup()` was tried and measured at 443ms against 446ms, so it was reverted. `setup()` does not begin until roughly 443ms into the process; that time is framework startup before the setup hook runs.
- No test step exists in CI. `build.yml` fires only on release tags, so adding one would gate releases on the suite, which is a separate decision.
- The banner has no `role="status"`, while the sibling update banner does. The markup is unchanged here, but it now mounts asynchronously, so the right fix is an always-mounted live region rather than an attribute on a conditionally rendered element.
- `commands::launch_hardware_monitor` still installs the CleanMeterHW service that startup deletes. That contradiction predates this change; it is now documented in the code rather than resolved.
