### PR TITLE
fix: keep the monitor app dropdown visible, and stop losing the app list

### DIFF
--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -270,9 +270,11 @@ public class MonitorPoller(
         using var memoryStream = new MemoryStream();
         using var writer = new BinaryWriter(memoryStream);
 
-        // Take a snapshot under PresentMonPoller's _stateLock — iterating
-        // CurrentApps directly would race with ParseData's Add on the
-        // PresentMon callback thread.
+        // Take a snapshot under PresentMonPoller's _stateLock: reading its app
+        // dictionary directly would race with ParseData's write on the
+        // PresentMon callback thread. The snapshot also drops apps that have
+        // not presented a frame recently, so this list is what is currently
+        // monitorable rather than everything ever seen.
         var apps = _presentMonPoller.SnapshotCurrentApps();
         writer.Write((short)MonitorPacketCommand.PresentMonApps);
         writer.Write((short)apps.Length);

--- a/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
@@ -249,7 +249,16 @@ public class PresentMonPoller(ILogger logger)
         // log template, so neither is passed straight through.
         process.ErrorDataReceived += (sender, args) =>
         {
-            if (!string.IsNullOrWhiteSpace(args.Data))
+            if (string.IsNullOrWhiteSpace(args.Data)) return;
+
+            // PresentMon writes warnings to stderr alongside errors, and every
+            // restart produces "a trace session named HardwareMonitor is
+            // already running", so logging the stream at Error would make a
+            // healthy restart read as a failure in the one place someone looks
+            // to tell the two apart.
+            if (args.Data.TrimStart().StartsWith("warning", StringComparison.OrdinalIgnoreCase))
+                logger.LogWarning("PresentMon: {Output}", args.Data);
+            else
                 logger.LogError("PresentMon: {Output}", args.Data);
         };
 

--- a/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
@@ -123,6 +123,11 @@ public class PresentMonPoller(ILogger logger)
     // on every push. Only touched by the push loop.
     private string _lastLoggedApps = "";
 
+    // Whether the PresentMon stderr line currently being read belongs to a
+    // warning rather than an error, so indented continuation lines can inherit
+    // it. Only touched by the stderr callback, which delivers lines in order.
+    private bool _stderrIsWarning;
+
     [DllImport("user32.dll")]
     private static extern IntPtr GetForegroundWindow();
 
@@ -255,8 +260,14 @@ public class PresentMonPoller(ILogger logger)
             // restart produces "a trace session named HardwareMonitor is
             // already running", so logging the stream at Error would make a
             // healthy restart read as a failure in the one place someone looks
-            // to tell the two apart.
-            if (args.Data.TrimStart().StartsWith("warning", StringComparison.OrdinalIgnoreCase))
+            // to tell the two apart. A warning's continuation lines are
+            // indented and carry no prefix of their own, so they inherit the
+            // level of the line they belong to rather than being read as a
+            // second, unrelated error.
+            if (!char.IsWhiteSpace(args.Data[0]))
+                _stderrIsWarning = args.Data.StartsWith("warning", StringComparison.OrdinalIgnoreCase);
+
+            if (_stderrIsWarning)
                 logger.LogWarning("PresentMon: {Output}", args.Data);
             else
                 logger.LogError("PresentMon: {Output}", args.Data);
@@ -525,8 +536,9 @@ public class PresentMonPoller(ILogger logger)
     // causes and have different fixes.
     private void LogAppListIfChanged()
     {
+        // Already sorted by SnapshotCurrentApps, which is what makes comparing
+        // the joined string against the last one a reliable change check.
         var apps = SnapshotCurrentApps();
-        Array.Sort(apps, StringComparer.OrdinalIgnoreCase);
         var joined = apps.Length == 0 ? "(none)" : string.Join(", ", apps);
         if (joined == _lastLoggedApps) return;
 
@@ -537,10 +549,17 @@ public class PresentMonPoller(ILogger logger)
     // Returns the apps seen within APP_TTL_MS and drops the rest, for callers
     // on other threads (e.g. MonitorPoller serializing the dropdown payload to
     // the pipe). The dictionary is not safe to enumerate concurrently with
-    // ParseData's write, so this runs under _stateLock.
+    // ParseData's write, so the read runs under _stateLock.
+    //
+    // Sorted because dictionary order is an implementation detail that shifts
+    // once a key has been removed, and this array is the order of the settings
+    // dropdown: without it, entries can reorder under the cursor on any of the
+    // pushes that happen while the menu is open.
     public string[] SnapshotCurrentApps()
     {
         var cutoffMs = Environment.TickCount64 - APP_TTL_MS;
+        string[] apps;
+
         lock (_stateLock)
         {
             // Materialised before removing: a Dictionary cannot be modified
@@ -554,8 +573,13 @@ public class PresentMonPoller(ILogger logger)
                 _appLastSeenMs.Remove(app);
             }
 
-            return _appLastSeenMs.Keys.ToArray();
+            apps = _appLastSeenMs.Keys.ToArray();
         }
+
+        // Outside the lock: the array is already a private copy, and ParseData
+        // is on the hot path for every CSV row.
+        Array.Sort(apps, StringComparer.OrdinalIgnoreCase);
+        return apps;
     }
 
     // Single foreground resolution — used both for the synchronous warm-up

--- a/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
@@ -19,9 +19,32 @@ public class PresentMonPoller(ILogger logger)
     public PresentMonSensor Displayed { get; private set; }
     public PresentMonSensor Presented { get; private set; }
     public PresentMonSensor Frametime { get; private set; }
-    public HashSet<string> CurrentApps { get; private set; }
 
     public Action OnUpdateApps;
+
+    // Apps seen presenting, against the TickCount64 of their most recent frame.
+    //
+    // This used to be a HashSet wiped in full every 10 seconds, immediately
+    // after being pushed to the app, which made the settings dropdown a
+    // 10-second sample of the machine rather than a list of apps: it emptied
+    // itself whenever a game stopped presenting for a moment, and the settings
+    // UI hid the whole control while it was empty. Ageing entries out one by
+    // one keeps a running game listed across the gap.
+    //
+    // Case-insensitive for the same reason the old set was: PresentMon reports
+    // column 0 in the exe's filesystem casing (e.g. "MyGame.EXE") while
+    // Process.ProcessName + ".exe" is whatever Windows reports, and two
+    // spellings would list the app twice and miss matches in the foreground
+    // filter. The indexer keeps the first spelling seen, so the entry does not
+    // flip casing under the user mid-session.
+    private readonly Dictionary<string, long> _appLastSeenMs = new(StringComparer.OrdinalIgnoreCase);
+
+    // How long an app stays listed after its last observed frame. Comfortably
+    // longer than APP_PUSH_INTERVAL_MS so an app is never dropped between two
+    // pushes, and long enough to survive alt-tabbing out of a game to reach
+    // Settings, which is the only way to see the dropdown at all.
+    private const int APP_TTL_MS = 30_000;
+    private const int APP_PUSH_INTERVAL_MS = 10_000;
 
     private Process _process;
     private CultureInfo _cultureInfo = (CultureInfo)CultureInfo.CurrentCulture.Clone();
@@ -87,6 +110,19 @@ public class PresentMonPoller(ILogger logger)
     private int _shortRowCount;
     private int _totalRowCount;
 
+    // Restart policy for the PresentMon process. A denied trace session fails
+    // the same way every time, so a failing start backs off instead of
+    // spinning; a process that ran normally for PRESENTMON_HEALTHY_RUN_MS
+    // before dying starts again from the short delay rather than inheriting an
+    // old backoff.
+    private const int PRESENTMON_MIN_RESTART_MS = 2_000;
+    private const int PRESENTMON_MAX_RESTART_MS = 30_000;
+    private const int PRESENTMON_HEALTHY_RUN_MS = 60_000;
+
+    // Last app list written to the log, so a change is logged once rather than
+    // on every push. Only touched by the push loop.
+    private string _lastLoggedApps = "";
+
     [DllImport("user32.dll")]
     private static extern IntPtr GetForegroundWindow();
 
@@ -100,12 +136,6 @@ public class PresentMonPoller(ILogger logger)
         Displayed = new PresentMonSensor(_hardware, "displayed", 0, "Displayed Frames");
         Presented = new PresentMonSensor(_hardware, "presented", 1, "Presented Frames");
         Frametime = new PresentMonSensor(_hardware, "frametime", 2, "Frametime");
-        // OrdinalIgnoreCase: PresentMon CSV column 0 is filesystem-cased
-        // (e.g. "MyGame.EXE") while Process.ProcessName + ".exe" is whatever
-        // Windows reports (often lowercase). A case-sensitive set would
-        // populate the dropdown with duplicates and miss matches in the
-        // foreground filter.
-        CurrentApps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // Resolve the foreground app once, synchronously, before PresentMon
         // starts emitting rows. Without this, the first ~500ms of CSV output
@@ -119,7 +149,84 @@ public class PresentMonPoller(ILogger logger)
             .Select(x => $"--exclude {x.Trim()}");
         var filteredApps = string.Join(" ", text);
 
-        await TerminateCurrentPresentMon();
+        _ = PushAppsPeriodicallyAsync(stoppingToken);
+        _ = PollForegroundAsync(stoppingToken);
+        _ = LogFpsDiagnosticsAsync(stoppingToken);
+
+        await RunPresentMonAsync(filteredApps, stoppingToken);
+    }
+
+    // Keeps PresentMon running for as long as the sidecar runs.
+    //
+    // This method used to start the process once and await its exit with
+    // nothing after the await. If PresentMon died, whether its trace session
+    // was refused, another capture tool stopped it, the exe was quarantined,
+    // or it simply crashed, the sidecar carried on serving sensors while FPS
+    // sat at 0 and the app list stayed empty for the rest of the session, with
+    // no exit code written anywhere. Nothing in the UI could report that,
+    // because from the app's point of view monitoring was connected and fine.
+    //
+    // The body is guarded because a throw here used to take the whole sidecar
+    // down: Start is async void, so an exception out of Process.Start (a
+    // missing presentmon.exe, for one) reached the thread pool unhandled.
+    private async Task RunPresentMonAsync(string filteredApps, CancellationToken stoppingToken)
+    {
+        // Pre-flight once. Restarts do not repeat it: the launch arguments
+        // already carry --stop_existing_session, which clears a session left
+        // behind by the instance that just died.
+        try
+        {
+            await TerminateCurrentPresentMon();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Could not terminate an existing PresentMon session");
+        }
+
+        var restartDelayMs = PRESENTMON_MIN_RESTART_MS;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var startedAtMs = Environment.TickCount64;
+
+            try
+            {
+                StartPresentMonProcess(filteredApps);
+                await _process.WaitForExitAsync(stoppingToken);
+                if (stoppingToken.IsCancellationRequested) break;
+                logger.LogError(
+                    "PresentMon exited with code {ExitCode}. FPS and the monitored-app list are unavailable until it restarts.",
+                    _process.ExitCode);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "PresentMon could not be started. FPS and the monitored-app list are unavailable.");
+            }
+
+            if (stoppingToken.IsCancellationRequested) break;
+
+            if (Environment.TickCount64 - startedAtMs > PRESENTMON_HEALTHY_RUN_MS)
+                restartDelayMs = PRESENTMON_MIN_RESTART_MS;
+
+            try
+            {
+                await Task.Delay(restartDelayMs, stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+
+            restartDelayMs = Math.Min(restartDelayMs * 2, PRESENTMON_MAX_RESTART_MS);
+        }
+    }
+
+    private void StartPresentMonProcess(string filteredApps)
+    {
         var processStartInfo = new ProcessStartInfo
         {
             CreateNoWindow = true,
@@ -132,24 +239,51 @@ public class PresentMonPoller(ILogger logger)
         };
         logger.LogInformation("Starting PresentMon process with {Arguments}", processStartInfo.Arguments);
 
-        _process = new Process();
-        _process.StartInfo = processStartInfo;
-        _process.OutputDataReceived += (sender, args) => ParseData(args.Data);
-        _process.ErrorDataReceived += (sender, args) => logger.LogError(args.Data);
+        var process = new Process();
+        process.StartInfo = processStartInfo;
+        process.OutputDataReceived += (sender, args) => ParseData(args.Data);
+        // PresentMon states its reason for refusing to start here (no
+        // elevation, a session held by another capture tool, a blocked exe),
+        // which is the only field evidence of why FPS never appears. Null
+        // arrives when the stream closes, and a raw message would be read as a
+        // log template, so neither is passed straight through.
+        process.ErrorDataReceived += (sender, args) =>
+        {
+            if (!string.IsNullOrWhiteSpace(args.Data))
+                logger.LogError("PresentMon: {Output}", args.Data);
+        };
 
-        _process.Start();
-        _process.BeginOutputReadLine();
-        _process.BeginErrorReadLine();
+        try
+        {
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+        }
+        catch
+        {
+            // A failed start still holds an OS handle, and the caller retries
+            // on a timer, so this would accumulate one per attempt.
+            process.Dispose();
+            throw;
+        }
 
-        _ = ClearCurrentAppsAsync(stoppingToken);
-        _ = PollForegroundAsync(stoppingToken);
-        _ = LogFpsDiagnosticsAsync(stoppingToken);
-        await _process.WaitForExitAsync(stoppingToken);
+        var previous = _process;
+        _process = process;
+        previous?.Dispose();
     }
 
     public void Stop()
     {
-        _process.Kill(true);
+        // Null before the first launch and between restarts, and already gone
+        // if PresentMon exited on its own. Shutdown is not the place to throw.
+        try
+        {
+            _process?.Kill(true);
+        }
+        catch (Exception ex)
+        {
+            logger.LogInformation("PresentMon was already stopped: {Message}", ex.Message);
+        }
     }
 
     private void ParseData(string? argsData)
@@ -176,17 +310,22 @@ public class PresentMonPoller(ILogger logger)
         }
 
         var rowApp = parts[0];
+
+        // PresentMon writes the CSV header before the first frame row, and it
+        // is wide enough to survive the length check above. Its first column
+        // is the literal "Application", which would otherwise be offered as an
+        // app to monitor; a real entry always carries the .exe suffix.
+        if (string.Equals(rowApp, "Application", StringComparison.Ordinal)) return;
+
         var nowMs = Environment.TickCount64;
 
         bool match;
         lock (_stateLock)
         {
-            // Add inside the lock — HashSet<T> is not thread-safe, and
-            // CurrentApps is also touched by ClearCurrentAppsAsync (timer)
-            // and MonitorPoller's SendPresentMonAppsToClients (pipe
-            // serializer). The set is case-insensitive, so duplicate-cased
-            // entries collapse.
-            CurrentApps.Add(rowApp);
+            // Record inside the lock: Dictionary<K,V> is not thread-safe, and
+            // _appLastSeenMs is also read by SnapshotCurrentApps on the pipe
+            // serializer's thread and pruned there.
+            _appLastSeenMs[rowApp] = nowMs;
 
 
             // Decide attribution under the lock so a foreground swap or
@@ -343,29 +482,70 @@ public class PresentMonPoller(ILogger logger)
         await process.WaitForExitAsync();
     }
 
-    private async Task ClearCurrentAppsAsync(CancellationToken cancellationToken)
+    // Pushes the current app list to connected clients on a fixed cadence.
+    //
+    // The previous version cleared the whole set immediately after each push,
+    // which is what made the list a 10-second sample; entries now expire
+    // individually in SnapshotCurrentApps. The cadence is unchanged so the
+    // shape of the pipe traffic stays exactly as it was.
+    private async Task PushAppsPeriodicallyAsync(CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested) return;
-        await Task.Delay(10_000, cancellationToken);
-        OnUpdateApps?.Invoke();
-        lock (_stateLock)
+        while (!cancellationToken.IsCancellationRequested)
         {
-            CurrentApps.Clear();
+            try
+            {
+                await Task.Delay(APP_PUSH_INTERVAL_MS, cancellationToken);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+
+            LogAppListIfChanged();
+            OnUpdateApps?.Invoke();
         }
-        _ = ClearCurrentAppsAsync(cancellationToken);
     }
 
-    // Returns a point-in-time copy of CurrentApps for callers on other
-    // threads (e.g. MonitorPoller serializing the dropdown payload to
-    // the pipe). HashSet<T> is not safe to enumerate concurrently with
-    // ParseData's Add, so the snapshot is taken under _stateLock.
+    // One log line per change to the app list.
+    //
+    // Serilog runs at its default Information level (the sidecar ships no
+    // appsettings.json), so every LogDebug in this file is dropped before it
+    // reaches disk. Without this line, a report of "the monitored-app dropdown
+    // is empty" has nothing in the log to separate "nothing was presenting"
+    // from "PresentMon never emitted a row on this machine", which are the two
+    // causes and have different fixes.
+    private void LogAppListIfChanged()
+    {
+        var apps = SnapshotCurrentApps();
+        Array.Sort(apps, StringComparer.OrdinalIgnoreCase);
+        var joined = apps.Length == 0 ? "(none)" : string.Join(", ", apps);
+        if (joined == _lastLoggedApps) return;
+
+        _lastLoggedApps = joined;
+        logger.LogInformation("PresentMon apps: {Apps}", joined);
+    }
+
+    // Returns the apps seen within APP_TTL_MS and drops the rest, for callers
+    // on other threads (e.g. MonitorPoller serializing the dropdown payload to
+    // the pipe). The dictionary is not safe to enumerate concurrently with
+    // ParseData's write, so this runs under _stateLock.
     public string[] SnapshotCurrentApps()
     {
+        var cutoffMs = Environment.TickCount64 - APP_TTL_MS;
         lock (_stateLock)
         {
-            var snapshot = new string[CurrentApps.Count];
-            CurrentApps.CopyTo(snapshot);
-            return snapshot;
+            // Materialised before removing: a Dictionary cannot be modified
+            // while it is being enumerated.
+            var expired = _appLastSeenMs
+                .Where(entry => entry.Value < cutoffMs)
+                .Select(entry => entry.Key)
+                .ToList();
+            foreach (var app in expired)
+            {
+                _appLastSeenMs.Remove(app);
+            }
+
+            return _appLastSeenMs.Keys.ToArray();
         }
     }
 

--- a/tauri-app/src/components/settings/stats/FpsSection.tsx
+++ b/tauri-app/src/components/settings/stats/FpsSection.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/shadcn/select";
 import { useSettingsStore } from "@/stores/settings-store";
+import { AUTO_OPTION, monitorAppOptions } from "@/lib/fps-apps";
 import { SectionCard } from "./SectionCard";
 
 export function FpsSection() {
@@ -18,6 +19,12 @@ export function FpsSection() {
   const { framerate, frametime } = settings.sensors;
   const anyEnabled = framerate.isEnabled || frametime.isEnabled;
   const prevState = useRef<{ framerate: boolean; frametime: boolean } | null>(null);
+  // `|| ""` guards a settings.json written before targetAppName existed, where
+  // the field is absent at runtime whatever the type says.
+  const { value: selectedApp, options: appOptions } = monitorAppOptions({
+    apps: presentMonApps,
+    target: framerate.targetAppName || "",
+  });
 
   return (
     <SectionCard
@@ -52,37 +59,42 @@ export function FpsSection() {
         </label>
       </div>
 
-      {presentMonApps.length > 0 && (
-        <div className="flex flex-col gap-3">
-          <Select
-            value={framerate.targetAppName || "__auto__"}
-            onValueChange={(v) =>
-              updateSensor("framerate", { targetAppName: v === "__auto__" ? "" : v })
-            }
-          >
-            <SelectTrigger className="h-10 rounded-[8px] text-[14px]">
-              <span className="flex items-center gap-2">
-                <span className="text-[14px] font-normal text-muted-foreground">Monitor app:</span>
-                <SelectValue placeholder="Auto" />
-              </span>
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__auto__">Auto</SelectItem>
-              {presentMonApps.map((app) => (
-                <SelectItem key={app} value={app}>
-                  {app}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <div className="flex items-center gap-1">
-            <Info className="size-4 text-muted-foreground" strokeWidth={2} />
-            <span className="text-[12px] font-medium text-muted-foreground">
-              Apps are auto updated every 10 seconds.
+      {/* Always rendered. This used to be gated on the app list having
+          entries, but that list is only what PresentMon saw presenting
+          recently, so the control disappeared at the desktop and whenever a
+          fullscreen game stopped presenting, taking Auto (and any pick the
+          user wanted to undo) with it. See monitorAppOptions. */}
+      <div className="flex flex-col gap-3">
+        <Select
+          value={selectedApp}
+          onValueChange={(v) =>
+            updateSensor("framerate", { targetAppName: v === AUTO_OPTION ? "" : v })
+          }
+        >
+          <SelectTrigger className="h-10 rounded-[8px] text-[14px]">
+            <span className="flex items-center gap-2">
+              <span className="text-[14px] font-normal text-muted-foreground">Monitor app:</span>
+              <SelectValue placeholder="Auto" />
             </span>
-          </div>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={AUTO_OPTION}>Auto</SelectItem>
+            {appOptions.map((app) => (
+              <SelectItem key={app} value={app}>
+                {app}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <div className="flex items-center gap-1">
+          <Info className="size-4 text-muted-foreground" strokeWidth={2} />
+          <span className="text-[12px] font-medium text-muted-foreground">
+            {presentMonApps.length > 0
+              ? "Apps are auto updated every 10 seconds."
+              : "No apps detected yet. Auto follows the app in focus."}
+          </span>
         </div>
-      )}
+      </div>
     </SectionCard>
   );
 }

--- a/tauri-app/src/lib/fps-apps.test.ts
+++ b/tauri-app/src/lib/fps-apps.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { AUTO_OPTION, monitorAppOptions } from "./fps-apps";
+
+describe("monitorAppOptions", () => {
+  it("selects Auto when nothing is picked", () => {
+    expect(monitorAppOptions({ apps: ["Game.exe"], target: "" })).toEqual({
+      value: AUTO_OPTION,
+      options: ["Game.exe"],
+    });
+  });
+
+  // The bug this exists to prevent. The section was rendered only when the
+  // list had entries, so at the desktop, or after alt-tabbing out of a
+  // fullscreen game, the whole control vanished. Auto has to stay reachable
+  // with an empty list, which means the caller always renders it and this
+  // function always returns a usable value.
+  it("still offers Auto when no app is presenting", () => {
+    expect(monitorAppOptions({ apps: [], target: "" })).toEqual({
+      value: AUTO_OPTION,
+      options: [],
+    });
+  });
+
+  it("keeps a picked app selectable while it is not running", () => {
+    expect(monitorAppOptions({ apps: [], target: "Game.exe" })).toEqual({
+      value: "Game.exe",
+      options: ["Game.exe"],
+    });
+  });
+
+  it("does not list a picked app twice once it starts presenting", () => {
+    expect(monitorAppOptions({ apps: ["Game.exe", "Other.exe"], target: "Game.exe" })).toEqual({
+      value: "Game.exe",
+      options: ["Game.exe", "Other.exe"],
+    });
+  });
+
+  // PresentMon reports the exe's filesystem casing and the stored pick may
+  // differ, while Radix matches option values by exact string. Returning the
+  // stored spelling here would match no option and blank the trigger.
+  it("follows the live spelling when the pick differs only by case", () => {
+    expect(monitorAppOptions({ apps: ["Game.exe"], target: "GAME.EXE" })).toEqual({
+      value: "Game.exe",
+      options: ["Game.exe"],
+    });
+  });
+});

--- a/tauri-app/src/lib/fps-apps.ts
+++ b/tauri-app/src/lib/fps-apps.ts
@@ -1,0 +1,45 @@
+/**
+ * Sentinel for "no manual pick": the empty string cannot be a Radix Select
+ * value, so Auto needs one of its own. `framerate.targetAppName` stores the
+ * empty string for the same state, which is what the C# poller reads as
+ * foreground-follow mode.
+ */
+export const AUTO_OPTION = "__auto__";
+
+/**
+ * Decide what the Monitor app dropdown shows.
+ *
+ * `apps` is not a list of installed applications. It is whatever PresentMon
+ * saw presenting frames recently, so it is empty on a desktop with no game
+ * running (DWM and the browsers are excluded from the capture), and it can
+ * empty itself while the user is looking at Settings, because reaching
+ * Settings means leaving the game.
+ *
+ * The dropdown used to be hidden whenever that list was empty. Auto went with
+ * it, and so did any app the user had already picked, which left the one
+ * control that could correct a stale selection unreachable exactly when the
+ * selection was stale. Nothing here filters: the caller always renders the
+ * Select, and this decides its contents.
+ *
+ * A picked app that is not currently presenting is carried as its own option
+ * so the trigger states the truth rather than falling back to the Auto
+ * placeholder. When it *is* presenting, the live spelling wins: PresentMon
+ * reports the filesystem casing of the exe and the stored value may have been
+ * saved from a differently-cased source, and Radix matches option values by
+ * exact string.
+ */
+export function monitorAppOptions(input: { apps: string[]; target: string }): {
+  /** Value for the Select, `AUTO_OPTION` when nothing is picked. */
+  value: string;
+  /** Options to render below Auto, in display order. */
+  options: string[];
+} {
+  const { apps, target } = input;
+
+  if (!target) return { value: AUTO_OPTION, options: apps };
+
+  const live = apps.find((app) => app.toLowerCase() === target.toLowerCase());
+  if (live) return { value: live, options: apps };
+
+  return { value: target, options: [target, ...apps] };
+}


### PR DESCRIPTION
The Monitor app dropdown in the FPS settings card is missing for some users.

## Cause

The dropdown was rendered only when the app list had entries:

```tsx
{presentMonApps.length > 0 && ( ... )}
```

That list is not a list of installed applications. It is whatever PresentMon saw presenting frames recently, and DWM and the browsers are excluded from the capture, so it is legitimately empty on a desktop with nothing rendering. Reaching Settings also means leaving the game, so a fullscreen title that stops presenting empties it while the user is looking at the page. On a machine where PresentMon never starts at all, it is empty permanently.

Hiding the control hid Auto along with it, and any app the user had already picked, so a stale selection could not be undone: the one control that could correct it disappeared precisely because the picked app was not running.

Two sidecar behaviours made the list emptier than it needed to be:

- `CurrentApps` was wiped in full every 10 seconds, immediately after being pushed to the app, so the list was a 10-second sample rather than a list of apps.
- PresentMon was started once and awaited with nothing after the await. If it died, whether its trace session was refused, another capture tool stopped it, the exe was quarantined, or it crashed, the sidecar carried on serving sensors while FPS sat at 0 and the app list stayed empty for the rest of the session, with no exit code written anywhere.

## Changes

Settings UI:

- The Select always renders. Auto is always reachable.
- `monitorAppOptions` (new, unit tested) decides its contents. A picked app that is not currently presenting is carried as its own option so the trigger states the truth instead of falling back to the Auto placeholder. When that app is presenting, its live spelling wins, since PresentMon reports the exe filesystem casing while the stored value may have been saved from a differently-cased source and Radix matches option values by exact string.
- The hint line reports the empty state rather than promising a refresh that has nothing to list.

Sidecar:

- Apps carry the timestamp of their most recent frame and expire individually after 30s, comfortably longer than the push interval, so a running game stays listed across an alt-tab. The push cadence is unchanged, so the pipe traffic keeps its existing shape.
- PresentMon restarts with a backoff reaching 30s, so a machine that can never grant the trace session costs one attempt every 30s rather than a hot loop, and a run that lasted a minute resets the delay.
- The launch is guarded. `Start` is async void, so an exception out of `Process.Start`, a missing presentmon.exe for one, reached the thread pool unhandled and took the sidecar down with it.
- Two diagnostics, because Serilog runs at its default Information level and the sidecar ships no appsettings.json, so every `LogDebug` in that file is dropped before it reaches disk. PresentMon stderr is logged with warnings at Warning and errors at Error, and the app list is logged when it changes. Together they separate "nothing was presenting" from "PresentMon never emitted a row on this machine" in a user log, which are the two causes of an empty dropdown and have different fixes.
- The CSV header row is skipped, whose first column is the literal `Application` and was being offered as an app to monitor.

## Verification

Frontend: `npm test` 14/14, `npm run build`, eslint clean on the changed files. The empty-list state was rendered and checked: dropdown present, on Auto, with the new hint.

Sidecar: built Release, then run elevated as the real app. Its log showed the app list arriving 10s after start with four presenting apps and no phantom `Application` entry. Killing PresentMon under the running sidecar produced:

```
[Error] PresentMon exited with code 1. FPS and the monitored-app list are unavailable until it restarts.
[Information] Starting PresentMon process with ...
```

Restart landed 2.014s after the exit, on the 2s floor, with a new child process under the same sidecar, and the app list held across the gap.

## Not included

`ignored-processes.txt` lives in a user-writable directory and its contents are interpolated into the argument string of a process the elevated sidecar spawns. That line is untouched here and predates this branch, but it is worth its own issue.
