### PR TITLE
chore: bump version to 2.2.15

### DIFF
--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleanmeter",
   "private": true,
-  "version": "2.2.14",
+  "version": "2.2.15",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "cleanmeter"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "byteorder",
  "dirs",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cleanmeter"
-version = "2.2.14"
+version = "2.2.15"
 description = "Gaming performance overlay"
 authors = ["Cleanmeter"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui/toolkits/refs/heads/main/tauri/schema.json",
   "productName": "Cleanmeter",
   "identifier": "com.cleanmeter.desktop",
-  "version": "2.2.14",
+  "version": "2.2.15",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
@
Bumps the app version 2.2.14 -> 2.2.15 across the four files that must stay in sync (`tauri.conf.json`, `package.json`, `Cargo.toml`, `Cargo.lock`).

Covers the fixes merged since v2.2.14:

- #41 gauge threshold colors and Discord invite link
- #42 sidecar: send sensors that activate after the initial snapshot
- #43 settings: stop an unreadable settings.json from wiping every setting
- #44 startup: stop the false "monitoring not connected" warning, connect sooner
- #45 keep the monitor app dropdown visible, stop losing the app list

Once merged, tagging `v2.2.15` triggers `build.yml`, which builds and signs the installer and creates a draft release.
@