### PR TITLE
fix: remove the elevated service command, harden the sidecar pipe, gate pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,3 +86,11 @@ jobs:
       - name: Clippy
         working-directory: tauri-app/src-tauri
         run: cargo clippy --target x86_64-pc-windows-msvc --all-targets
+
+      # --lib deliberately: the bin target's test executable inherits the app's
+      # requireAdministrator manifest, so running it fails with "requires
+      # elevation" (os error 740) rather than running any test. --lib covers
+      # every test that exists.
+      - name: Unit tests
+        working-directory: tauri-app/src-tauri
+        run: cargo test --lib --target x86_64-pc-windows-msvc

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,10 +66,32 @@ jobs:
         run: dotnet build -c Release
 
   rust:
-    name: Rust (clippy)
+    name: Rust (clippy, tests)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+
+      # The sidecar has to be published even though this job only checks Rust.
+      # tauri-build resolves tauri.conf.json's bundle.resources globs at build
+      # time, and they point into the sidecar's publish folder; on a cold
+      # checkout that folder does not exist and tauri-build panics with "path
+      # not found or didn't match any files" before clippy runs at all.
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Publish sidecar (satisfies the resource globs)
+        working-directory: HardwareMonitor/HardwareMonitor
+        # -p: not /p: — Git Bash mangles /p:... into a path argument (MSB1009).
+        run: dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+        shell: bash
+
+      - name: Stage PresentMon assets into the publish folder
+        # The csproj's CopyPresentMon target writes to $(TargetDir)/native/,
+        # not $(PublishDir), so the *.exe and *.txt globs need these copied in.
+        # Mirrors the same step in build.yml.
+        run: cp presentmon/* HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/
+        shell: bash
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -80,9 +102,9 @@ jobs:
         with:
           workspaces: tauri-app/src-tauri
 
-      # No frontend build first: tauri-build tolerates a missing frontendDist
-      # for a check-only pass, so this job stays independent of the frontend one.
-      # A release build does need it, and the release workflow builds it there.
+      # No frontend build: tauri-build tolerates a missing frontendDist for a
+      # check-only pass, confirmed by removing dist/, forcing build.rs to re-run
+      # and seeing cargo succeed. Only the resource globs above are required.
       - name: Clippy
         working-directory: tauri-app/src-tauri
         run: cargo clippy --target x86_64-pc-windows-msvc --all-targets

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,88 @@
+name: PR checks
+
+# Gates pull requests into main. Until this existed, nothing verified a PR: the
+# release workflow only triggers on v* tags, so the first build of any change
+# was the release build itself.
+#
+# Every command here is one that passes on main today, so a red check means the
+# pull request broke something rather than inheriting existing debt. Two known
+# red things are deliberately not gated: `tsc` reports five long-standing
+# type-level errors, and clippy reports five style warnings (clippy is run
+# without -D warnings for that reason).
+on:
+  pull_request:
+    branches: [main]
+
+# A new push to the same pull request supersedes the previous run.
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend (lint, test, build)
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: tauri-app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: tauri-app/package-lock.json
+
+      # npm ci, not npm install, so a pull request is checked against the
+      # committed lockfile rather than a freshly resolved tree.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build frontend
+        run: npm run build
+
+  sidecar:
+    name: Sidecar (HardwareMonitor)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Build sidecar
+        working-directory: HardwareMonitor/HardwareMonitor
+        run: dotnet build -c Release
+
+  rust:
+    name: Rust (clippy)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tauri-app/src-tauri
+
+      # No frontend build first: tauri-build tolerates a missing frontendDist
+      # for a check-only pass, so this job stays independent of the frontend one.
+      # A release build does need it, and the release workflow builds it there.
+      - name: Clippy
+        working-directory: tauri-app/src-tauri
+        run: cargo clippy --target x86_64-pc-windows-msvc --all-targets

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -93,7 +93,11 @@ public class MonitorPoller(
             if (logged >= 10) break;
         }
 
-        _presentMonPoller.Start(stoppingToken);
+        // Deliberately not awaited: Start runs for the lifetime of the sidecar.
+        // It returns a Task (rather than being async void) so a failure inside it
+        // can no longer reach the thread pool unhandled and kill the process; it
+        // logs and leaves sensors running instead.
+        _ = _presentMonPoller.Start(stoppingToken);
         _presentMonPoller.OnUpdateApps += SendPresentMonAppsToClients;
         _socketHost.StartServer();
         _socketHost.OnClientData += OnClientData;
@@ -178,7 +182,12 @@ public class MonitorPoller(
                 accumulator = 0;
             }
 
-            accumulator += 500;
+            // Advance by the interval actually being waited, not a hardcoded
+            // 500. The accumulator is meant to make this a once-a-second
+            // collection; with a fixed 500 it instead tracked poll count, so at
+            // the 33ms floor it forced a full GC roughly every 66ms, about 15x
+            // too often, and only matched its intent at the default rate.
+            accumulator += _pollingRate;
             await Task.Delay(_pollingRate, stoppingToken);
         }
 

--- a/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
@@ -134,31 +134,78 @@ public class PresentMonPoller(ILogger logger)
     [DllImport("user32.dll", SetLastError = true)]
     private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
 
-    public async void Start(CancellationToken stoppingToken)
+    // Returns a Task rather than being async void, and guards its whole body.
+    //
+    // As async void, anything that threw here reached the thread pool with no
+    // handler and killed the sidecar process. The console host has no
+    // SynchronizationContext to marshal it back to. The easiest way to trigger
+    // that was a missing ignored-processes.txt, opened below before any of the
+    // guarded work started, which a partial install, an antivirus quarantine or
+    // a dev-tree run can all produce. Because the app's supervisor respawns the
+    // sidecar on a flat one-second delay for as long as the app runs, a single
+    // absent text file became a permanent once-a-second crash loop rather than a
+    // degraded feature. The existing guard inside RunPresentMonAsync only ever
+    // covered the work after this point.
+    public async Task Start(CancellationToken stoppingToken)
     {
-        _cultureInfo.NumberFormat.NumberDecimalSeparator = ".";
+        try
+        {
+            _cultureInfo.NumberFormat.NumberDecimalSeparator = ".";
 
-        Displayed = new PresentMonSensor(_hardware, "displayed", 0, "Displayed Frames");
-        Presented = new PresentMonSensor(_hardware, "presented", 1, "Presented Frames");
-        Frametime = new PresentMonSensor(_hardware, "frametime", 2, "Frametime");
+            Displayed = new PresentMonSensor(_hardware, "displayed", 0, "Displayed Frames");
+            Presented = new PresentMonSensor(_hardware, "presented", 1, "Presented Frames");
+            Frametime = new PresentMonSensor(_hardware, "frametime", 2, "Frametime");
 
-        // Resolve the foreground app once, synchronously, before PresentMon
-        // starts emitting rows. Without this, the first ~500ms of CSV output
-        // is dropped (Auto mode) or attributed to stale state because
-        // PollForegroundAsync hasn't had a tick yet.
-        _foregroundAppName = ResolveForegroundProcessName();
+            // Resolve the foreground app once, synchronously, before PresentMon
+            // starts emitting rows. Without this, the first ~500ms of CSV output
+            // is dropped (Auto mode) or attributed to stale state because
+            // PollForegroundAsync hasn't had a tick yet.
+            _foregroundAppName = ResolveForegroundProcessName();
 
-        using var reader = new StreamReader(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ignored-processes.txt"));
-        var text = (await reader.ReadToEndAsync())
-            .Split("\n", StringSplitOptions.RemoveEmptyEntries)
-            .Select(x => $"--exclude {x.Trim()}");
-        var filteredApps = string.Join(" ", text);
+            var filteredApps = await ReadIgnoredProcessArgumentsAsync();
 
-        _ = PushAppsPeriodicallyAsync(stoppingToken);
-        _ = PollForegroundAsync(stoppingToken);
-        _ = LogFpsDiagnosticsAsync(stoppingToken);
+            _ = PushAppsPeriodicallyAsync(stoppingToken);
+            _ = PollForegroundAsync(stoppingToken);
+            _ = LogFpsDiagnosticsAsync(stoppingToken);
 
-        await RunPresentMonAsync(filteredApps, stoppingToken);
+            await RunPresentMonAsync(filteredApps, stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown.
+        }
+        catch (Exception ex)
+        {
+            // Sensors are polled independently of this, so the sidecar stays
+            // useful with FPS reading 0 rather than dying and being respawned.
+            logger.LogError(ex, "PresentMon poller stopped; FPS and the app list are unavailable for this session");
+        }
+    }
+
+    /// Builds the --exclude arguments from ignored-processes.txt.
+    ///
+    /// The file only suppresses noise in PresentMon's output, so an unreadable
+    /// one degrades to no exclusions instead of failing the poller: PresentMon
+    /// still runs and FPS still reports.
+    private async Task<string> ReadIgnoredProcessArgumentsAsync()
+    {
+        var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ignored-processes.txt");
+
+        try
+        {
+            var contents = await File.ReadAllTextAsync(path);
+            var excludes = contents
+                .Split("\n", StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .Where(x => x.Length > 0)
+                .Select(x => $"--exclude {x}");
+            return string.Join(" ", excludes);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Could not read {Path}; continuing with no process exclusions", path);
+            return string.Empty;
+        }
     }
 
     // Keeps PresentMon running for as long as the sidecar runs.

--- a/HardwareMonitor/HardwareMonitor/Sockets/PipeHost.cs
+++ b/HardwareMonitor/HardwareMonitor/Sockets/PipeHost.cs
@@ -12,6 +12,14 @@ public class PipeHost(ILogger logger)
     private CancellationTokenSource _cancellationTokenSource = new();
     private Task _serverTask;
 
+    /// Serializes sends. The pipe is PipeTransmissionMode.Byte, so two writers
+    /// on one stream interleave into a single jumbled byte run rather than
+    /// staying framed. Two callers exist: the sensor poll loop, and the
+    /// PresentMon app-list push, which fires on its own timer. Without this the
+    /// client reads a length prefix from the middle of another packet and acts
+    /// on it, which aborts the app rather than producing a parse error.
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+
     public Action<byte[]> OnClientData;
     public Action OnClientConnected;
 
@@ -135,6 +143,7 @@ public class PipeHost(ILogger logger)
         catch { }
 
         _cancellationTokenSource.Dispose();
+        _sendLock.Dispose();
     }
 
     public bool HasConnections()
@@ -151,41 +160,67 @@ public class PipeHost(ILogger logger)
         dataWithSize.InsertRange(2, BitConverter.GetBytes(dataWithSize.Count - 2));
         var finalData = dataWithSize.ToArray();
 
-        List<NamedPipeServerStream> clientsCopy;
-        lock (_clients)
+        // Hold the lock across write+flush so a whole packet reaches the stream
+        // before the next one starts. See _sendLock.
+        try
         {
-            clientsCopy = _clients.ToList();
+            await _sendLock.WaitAsync(_cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
         }
 
-        var tasks = clientsCopy.Select(async client =>
+        try
         {
-            try
+            List<NamedPipeServerStream> clientsCopy;
+            lock (_clients)
             {
-                if (client.IsConnected)
-                {
-                    await client.WriteAsync(finalData, 0, finalData.Length, _cancellationTokenSource.Token);
-                    await client.FlushAsync(_cancellationTokenSource.Token);
-                }
+                clientsCopy = _clients.ToList();
             }
-            catch (Exception ex)
+
+            foreach (var client in clientsCopy)
             {
-                logger.LogError(ex, "Error sending data to pipe client");
-
-                // Remove disconnected client
-                lock (_clients)
-                {
-                    _clients.Remove(client);
-                }
-
                 try
                 {
-                    client.Dispose();
+                    if (client.IsConnected)
+                    {
+                        await client.WriteAsync(finalData, 0, finalData.Length, _cancellationTokenSource.Token);
+                        await client.FlushAsync(_cancellationTokenSource.Token);
+                    }
                 }
-                catch { }
-            }
-        });
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Error sending data to pipe client");
 
-        await Task.WhenAll(tasks);
+                    // Remove disconnected client
+                    lock (_clients)
+                    {
+                        _clients.Remove(client);
+                    }
+
+                    try
+                    {
+                        client.Dispose();
+                    }
+                    catch { }
+                }
+            }
+        }
+        finally
+        {
+            // Close() disposes the lock, and sends are fire-and-forget, so a
+            // send already past WaitAsync can reach this after disposal.
+            try
+            {
+                _sendLock.Release();
+            }
+            catch (ObjectDisposedException) { }
+        }
     }
 
     // Synchronous version for compatibility

--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -440,63 +440,6 @@ pub fn grant_admin_consent(settings_mgr: State<'_, SettingsManager>) {
     settings_mgr.save_preferences(prefs);
 }
 
-#[tauri::command]
-pub fn launch_hardware_monitor(app: AppHandle) -> Result<(), String> {
-    // Find HardwareMonitor.exe relative to the app's resource directory
-    let exe_path = app
-        .path()
-        .resource_dir()
-        .ok()
-        .map(|p| p.join("HardwareMonitor.exe"))
-        .filter(|p| p.exists())
-        // Fallback: look next to the tauri exe in dev
-        .or_else(|| {
-            std::env::current_exe().ok().and_then(|exe| {
-                // Walk up to find the publish folder
-                let candidates = [
-                    exe.parent()?.join("HardwareMonitor.exe"),
-                ];
-                candidates.into_iter().find(|p| p.exists())
-            })
-        })
-        // Final fallback: hardcoded dev path
-        .unwrap_or_else(|| {
-            std::path::PathBuf::from(
-                r"C:\Users\alimm\cleanmeter\HardwareMonitor\HardwareMonitor\bin\Release\net8.0\win-x64\publish\HardwareMonitor.exe"
-            )
-        });
-
-    let exe_str = exe_path.to_string_lossy().to_string();
-
-    // Write a PowerShell script to a temp file, then execute it elevated.
-    // This installs HardwareMonitor as a Windows Service (runs as SYSTEM with
-    // full hardware access for LibreHardwareMonitor sensor readings).
-    let script = format!(
-        "$exe = '{}'\n\
-         $svc = Get-Service -Name 'CleanMeterHW' -ErrorAction SilentlyContinue\n\
-         if (-not $svc) {{ New-Service -Name 'CleanMeterHW' -BinaryPathName ('\"' + $exe + '\"') -DisplayName 'Cleanmeter Hardware Monitor' -StartupType Automatic }}\n\
-         $svc = Get-Service -Name 'CleanMeterHW' -ErrorAction SilentlyContinue\n\
-         if ($svc.Status -ne 'Running') {{ Start-Service 'CleanMeterHW' }}",
-        exe_str.replace('\'', "''")
-    );
-
-    let script_path = std::env::temp_dir().join("cleanmeter_hw_setup.ps1");
-    std::fs::write(&script_path, &script)
-        .map_err(|e| format!("Failed to write setup script: {}", e))?;
-
-    let script_str = script_path.to_string_lossy().to_string();
-    std::process::Command::new("powershell")
-        .args([
-            "-WindowStyle", "Hidden",
-            "-Command",
-            &format!("Start-Process powershell -Verb RunAs -ArgumentList '-ExecutionPolicy Bypass -File \"{}\"'", script_str),
-        ])
-        .spawn()
-        .map_err(|e| format!("Failed to launch elevated setup: {}", e))?;
-
-    Ok(())
-}
-
 #[derive(serde::Deserialize)]
 pub struct FeedbackInput {
     pub name: String,

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -181,12 +181,11 @@ mod process_probe_tests {
 /// Drop the CleanMeterHW service, which hosts a second copy of the sidecar.
 ///
 /// The app supervises its own sidecar now, so a service-hosted one is a
-/// duplicate: both poll ring0 and both drive PresentMon. Note this is not purely
-/// a migration from older builds. `commands::launch_hardware_monitor`, reachable
-/// from the admin-consent screen, still creates and starts the service, so this
-/// deletes what that flow installs on the next launch. That contradiction
-/// predates this change and is left alone here; it is called out so the next
-/// person does not read the deletion as dead legacy code.
+/// duplicate: both poll ring0 and both drive PresentMon. Nothing in the app
+/// creates the service any more — the admin-consent screen used to install it
+/// through a `launch_hardware_monitor` command, which this build removes — so
+/// this is now purely a migration that cleans up installs made by older
+/// versions.
 ///
 /// Runs once per launch (the caller's flag is loop-local), off the startup path.
 #[cfg(windows)]
@@ -311,26 +310,12 @@ pub fn run() {
             // and JS-side `center()` were both being overridden by Windows
             // restoring a stale position from prior runs.
             if let Some(window) = app.get_webview_window("settings") {
-                let log_path = std::env::temp_dir().join("cleanmeter-window.log");
-                let mut log_lines: Vec<String> = vec![format!(
-                    "setup start @ {}",
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_secs())
-                        .unwrap_or(0)
-                )];
-
                 let monitor = window.primary_monitor().ok().flatten();
-                log_lines.push(format!("primary_monitor: {}", monitor.is_some()));
 
                 if let Some(m) = monitor {
                     let m_size = m.size();
                     let m_pos = m.position();
                     let scale = m.scale_factor();
-                    log_lines.push(format!(
-                        "monitor: size={}x{} pos=({},{}) scale={}",
-                        m_size.width, m_size.height, m_pos.x, m_pos.y, scale
-                    ));
 
                     let want_w: f64 = 651.0;
                     let mut want_h: f64 = 900.0;
@@ -338,7 +323,6 @@ pub fn run() {
                     if want_h > monitor_logical_h - 80.0 {
                         want_h = (monitor_logical_h - 80.0).max(400.0);
                     }
-                    log_lines.push(format!("want: {}x{} logical", want_w, want_h));
 
                     let _ = window.set_size(tauri::Size::Logical(
                         tauri::LogicalSize::new(want_w, want_h),
@@ -348,12 +332,10 @@ pub fn run() {
                     let phys_h = (want_h * scale) as i32;
                     let x = m_pos.x + (m_size.width as i32 - phys_w) / 2;
                     let y = m_pos.y + (m_size.height as i32 - phys_h) / 2;
-                    log_lines.push(format!("set_position: phys ({},{}) size {}x{}", x, y, phys_w, phys_h));
 
-                    let r = window.set_position(tauri::Position::Physical(
+                    let _ = window.set_position(tauri::Position::Physical(
                         tauri::PhysicalPosition::new(x, y),
                     ));
-                    log_lines.push(format!("set_position result: {:?}", r));
                 } else {
                     let _ = window.set_size(tauri::Size::Logical(
                         tauri::LogicalSize::new(651.0, 900.0),
@@ -366,33 +348,6 @@ pub fn run() {
                     let _ = window.show();
                     let _ = window.set_focus();
                 }
-
-                if let Ok(pos) = window.outer_position() {
-                    log_lines.push(format!("t=0 after show outer_position: ({},{})", pos.x, pos.y));
-                }
-                if let Ok(size) = window.outer_size() {
-                    log_lines.push(format!("t=0 outer_size: {}x{}", size.width, size.height));
-                }
-
-                let _ = std::fs::write(&log_path, log_lines.join("\n"));
-
-                // Watch for position drift after show
-                let w2 = window.clone();
-                let lp2 = log_path.clone();
-                tauri::async_runtime::spawn(async move {
-                    for delay_ms in [300u64, 1000, 3000] {
-                        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                        if let Ok(mut f) = std::fs::OpenOptions::new().append(true).open(&lp2) {
-                            use std::io::Write;
-                            if let Ok(pos) = w2.outer_position() {
-                                let _ = writeln!(f, "\nt={}ms outer_position: ({},{})", delay_ms, pos.x, pos.y);
-                            }
-                            if let Ok(size) = w2.outer_size() {
-                                let _ = writeln!(f, "t={}ms outer_size: {}x{}", delay_ms, size.width, size.height);
-                            }
-                        }
-                    }
-                });
             }
 
             // Set up pipe client communication channel
@@ -715,7 +670,6 @@ pub fn run() {
             commands::get_monitors,
             commands::get_app_version,
             commands::grant_admin_consent,
-            commands::launch_hardware_monitor,
             commands::ui_debug_log,
             commands::submit_feedback,
             commands::prepare_for_update,

--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -9,6 +9,29 @@ use tokio::sync::mpsc;
 
 use crate::types::*;
 
+/// Upper bound on one pipe frame. The sidecar's largest real packet is a full
+/// sensor snapshot, which is tens of KB, so this leaves generous headroom.
+///
+/// The cap exists because every length prefix on this pipe arrives as a raw
+/// integer from the sidecar and is used directly as an allocation size. Rust
+/// aborts the process on allocation failure instead of unwinding, so a prefix
+/// that is garbled (by a partial write, or by two writers interleaving on the
+/// same byte-mode stream) takes the whole app down with no error path and no
+/// message. Validating the prefix turns that abort into a dropped connection,
+/// which the client already reconnects from.
+const MAX_PIPE_PAYLOAD: usize = 4 * 1024 * 1024;
+
+/// Smallest number of bytes one hardware entry can occupy: two u16 length
+/// prefixes plus a u32 type tag.
+const MIN_HARDWARE_BYTES: usize = 2 + 2 + 4;
+
+/// Smallest number of bytes one sensor entry can occupy: three u16 length
+/// prefixes, a u32 type tag and an f32 value.
+const MIN_SENSOR_BYTES: usize = 2 + 2 + 2 + 4 + 4;
+
+/// Fixed width of each entry in a PresentMonApps payload.
+const PRESENT_MON_APP_STRIDE: usize = 128;
+
 /// Events parsed from the pipe read thread
 enum ParsedEvent {
     SensorData(HardwareMonitorData),
@@ -33,6 +56,26 @@ fn parse_data_packet(data: &[u8]) -> Result<HardwareMonitorData, String> {
     let sensor_count = cursor
         .read_u32::<LittleEndian>()
         .map_err(|e| format!("Failed to read sensor_count: {}", e))?;
+
+    // Both counts are raw u32 off the wire and both are about to become
+    // allocation sizes. Reject anything the remaining bytes could not possibly
+    // describe before reserving, so a corrupt count is a parse error rather
+    // than an aborting allocation.
+    let remaining = data.len().saturating_sub(cursor.position() as usize);
+    let max_hardwares = remaining / MIN_HARDWARE_BYTES;
+    let max_sensors = remaining / MIN_SENSOR_BYTES;
+    if hw_count as usize > max_hardwares {
+        return Err(format!(
+            "hw_count {} exceeds the {} entries {} remaining bytes can hold",
+            hw_count, max_hardwares, remaining
+        ));
+    }
+    if sensor_count as usize > max_sensors {
+        return Err(format!(
+            "sensor_count {} exceeds the {} entries {} remaining bytes can hold",
+            sensor_count, max_sensors, remaining
+        ));
+    }
 
     let mut hardwares = Vec::with_capacity(hw_count as usize);
     for _ in 0..hw_count {
@@ -141,13 +184,16 @@ fn parse_present_mon_apps(data: &[u8]) -> Result<Vec<String>, String> {
         .read_u16::<LittleEndian>()
         .map_err(|e| format!("app count: {}", e))? as usize;
 
-    let mut apps = Vec::with_capacity(count);
+    // The loop below already stops when the payload runs out, but the
+    // reservation happens first, so clamp it to what the payload can hold.
+    let max_apps = data.len().saturating_sub(2) / PRESENT_MON_APP_STRIDE;
+    let mut apps = Vec::with_capacity(count.min(max_apps));
     for i in 0..count {
-        let start = 2 + (i * 128);
-        if start + 128 > data.len() {
+        let start = 2 + (i * PRESENT_MON_APP_STRIDE);
+        if start + PRESENT_MON_APP_STRIDE > data.len() {
             break;
         }
-        let raw = &data[start..start + 128];
+        let raw = &data[start..start + PRESENT_MON_APP_STRIDE];
         let name = String::from_utf8_lossy(raw)
             .trim_end_matches('\0')
             .trim()
@@ -298,6 +344,17 @@ pub async fn run_pipe_client(
                                 break;
                             }
                         };
+
+                        // Guard before allocating: see MAX_PIPE_PAYLOAD. A
+                        // garbled prefix drops the connection, which the
+                        // reconnect loop below already recovers from.
+                        if payload_size > MAX_PIPE_PAYLOAD {
+                            warn!(
+                                "Pipe payload size {} exceeds the {} byte cap; dropping the connection",
+                                payload_size, MAX_PIPE_PAYLOAD
+                            );
+                            break;
+                        }
 
                         let mut payload = vec![0u8; payload_size];
                         if payload_size > 0 {

--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -501,4 +501,98 @@ mod tests {
     fn the_poll_interval_bounds_the_remaining_delay() {
         assert!(FAST_POLL_INTERVAL <= Duration::from_millis(300));
     }
+
+    /// Builds a Data payload the way MonitorPoller writes one: both counts, then
+    /// the hardware entries, then the sensor entries.
+    fn data_packet(hardwares: &[(&str, &str)], sensors: &[(&str, &str, &str)]) -> Vec<u8> {
+        let mut b: Vec<u8> = Vec::new();
+        b.write_u32::<LittleEndian>(hardwares.len() as u32).unwrap();
+        b.write_u32::<LittleEndian>(sensors.len() as u32).unwrap();
+        for (name, id) in hardwares {
+            b.write_u16::<LittleEndian>(name.len() as u16).unwrap();
+            b.write_u16::<LittleEndian>(id.len() as u16).unwrap();
+            b.extend_from_slice(name.as_bytes());
+            b.extend_from_slice(id.as_bytes());
+            b.write_u32::<LittleEndian>(0).unwrap();
+        }
+        for (name, id, hw_id) in sensors {
+            b.write_u16::<LittleEndian>(name.len() as u16).unwrap();
+            b.write_u16::<LittleEndian>(id.len() as u16).unwrap();
+            b.write_u16::<LittleEndian>(hw_id.len() as u16).unwrap();
+            b.extend_from_slice(name.as_bytes());
+            b.extend_from_slice(id.as_bytes());
+            b.extend_from_slice(hw_id.as_bytes());
+            b.write_u32::<LittleEndian>(0).unwrap();
+            b.write_f32::<LittleEndian>(1.5).unwrap();
+        }
+        b
+    }
+
+    fn expect_rejected(packet: &[u8]) -> String {
+        match parse_data_packet(packet) {
+            Ok(_) => panic!("a corrupt count must be rejected, not parsed"),
+            Err(e) => e,
+        }
+    }
+
+    /// A count arriving off the wire used to reach `Vec::with_capacity`
+    /// unvalidated. Rust aborts the process on allocation failure instead of
+    /// unwinding, so an impossible count killed the app outright rather than
+    /// failing the parse — and unsynchronized writes on the byte-mode pipe made
+    /// a corrupt count reachable in ordinary operation.
+    #[test]
+    fn an_impossible_hardware_count_is_rejected_rather_than_allocated() {
+        let mut packet = data_packet(&[("CPU", "/amdcpu/0")], &[]);
+        packet[0..4].copy_from_slice(&u32::MAX.to_le_bytes());
+        let err = expect_rejected(&packet);
+        assert!(err.contains("hw_count"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn an_impossible_sensor_count_is_rejected_rather_than_allocated() {
+        let mut packet = data_packet(&[("CPU", "/amdcpu/0")], &[]);
+        packet[4..8].copy_from_slice(&u32::MAX.to_le_bytes());
+        let err = expect_rejected(&packet);
+        assert!(err.contains("sensor_count"), "unexpected error: {}", err);
+    }
+
+    /// The guard is worthless if it also turns away the packets the sidecar
+    /// really sends, which is the way a validation fix breaks a working app.
+    #[test]
+    fn a_well_formed_packet_still_parses() {
+        let packet = data_packet(
+            &[("CPU", "/amdcpu/0"), ("GPU", "/gpu-nvidia/0")],
+            &[
+                ("CPU Total", "/load/0", "/amdcpu/0"),
+                ("GPU Core", "/temperature/0", "/gpu-nvidia/0"),
+            ],
+        );
+        let parsed = parse_data_packet(&packet).expect("a well-formed packet must parse");
+        assert_eq!(parsed.hardwares.len(), 2);
+        assert_eq!(parsed.sensors.len(), 2);
+        assert_eq!(parsed.hardwares[0].name, "CPU");
+        assert_eq!(parsed.sensors[1].name, "GPU Core");
+    }
+
+    /// An empty snapshot is what the sidecar sends before LibreHardwareMonitor
+    /// has activated anything, so zero counts must stay valid.
+    #[test]
+    fn an_empty_snapshot_is_valid() {
+        let parsed = parse_data_packet(&data_packet(&[], &[])).expect("empty snapshot must parse");
+        assert!(parsed.hardwares.is_empty());
+        assert!(parsed.sensors.is_empty());
+    }
+
+    /// The app-list reservation is clamped to what the payload can actually
+    /// hold, so an inflated count cannot make it reserve for absent entries.
+    #[test]
+    fn an_inflated_app_count_yields_only_the_apps_present() {
+        let mut payload: Vec<u8> = Vec::new();
+        payload.write_u16::<LittleEndian>(9999).unwrap();
+        let mut entry = vec![0u8; PRESENT_MON_APP_STRIDE];
+        entry[.."game.exe".len()].copy_from_slice(b"game.exe");
+        payload.extend_from_slice(&entry);
+        let apps = parse_present_mon_apps(&payload).expect("payload must parse");
+        assert_eq!(apps, vec!["game.exe".to_string()]);
+    }
 }

--- a/tauri-app/src/components/settings/AdminConsent.tsx
+++ b/tauri-app/src/components/settings/AdminConsent.tsx
@@ -5,16 +5,19 @@ import {
   tokens,
 } from "@fluentui/react-components";
 import { ShieldCheckmark24Regular } from "@fluentui/react-icons";
-import { grantAdminConsent, launchHardwareMonitor, isBrowser } from "@/lib/tauri";
+import { grantAdminConsent, isBrowser } from "@/lib/tauri";
 import { useSettingsStore } from "@/stores/settings-store";
 
 export function AdminConsent() {
   const updatePreferences = useSettingsStore((s) => s.updatePreferences);
 
+  // Records consent only. This used to also invoke a command that installed
+  // HardwareMonitor as a SYSTEM service via an elevated PowerShell script; the
+  // app supervises its own sidecar, and startup deleted that service on the
+  // next launch anyway, so the command is gone.
   const handleAllow = async () => {
     await grantAdminConsent();
     updatePreferences({ adminConsent: true });
-    launchHardwareMonitor().catch(() => {});
   };
 
   const handleClose = async () => {

--- a/tauri-app/src/lib/tauri.ts
+++ b/tauri-app/src/lib/tauri.ts
@@ -81,7 +81,6 @@ export const getAppVersion = () =>
   // placeholder. The packaged app reads CARGO_PKG_VERSION via the Rust command.
   isBrowser ? Promise.resolve(__APP_VERSION__) : safeInvoke<string>("get_app_version");
 export const grantAdminConsent = () => safeInvoke("grant_admin_consent");
-export const launchHardwareMonitor = () => safeInvoke("launch_hardware_monitor");
 export const setAutoStart = (enabled: boolean) => safeInvoke("set_auto_start", { enabled });
 export const getAutoStart = () => isBrowser ? Promise.resolve(false) : safeInvoke<boolean>("get_auto_start");
 


### PR DESCRIPTION
Five findings from the security and correctness audit, plus the pull request check the repository did not have.

## Security: remove the hardware-monitor service command

`launch_hardware_monitor` wrote a PowerShell script to a fixed path in the user-writable temp directory and then ran it elevated, reading it back after the write. Anything that replaced the file between those two steps got code execution as SYSTEM, because the script registered HardwareMonitor as a SYSTEM service.

The service was also pointless. The app supervises its own sidecar, and `remove_legacy_service` already deleted the service on the next launch, so the two flows undid each other. The command additionally carried a hardcoded fallback path into a developer's home directory, shipping in a public repository.

Deleting the command removes all three at once. The admin-consent screen keeps its Allow button and still records consent; only the service install is gone. `remove_legacy_service` stays and is now purely a migration for installs made by older versions, and its comment no longer describes a contradiction that has been removed.

## Correctness: the pipe

Two findings that compound, which is why they are fixed together.

`SendToAllAsync` wrote and flushed with no lock while two callers could invoke it concurrently: the sensor poll loop, and the PresentMon app-list push on its own timer. The pipe is `PipeTransmissionMode.Byte`, so those writes interleaved into one unframed byte run instead of staying separate packets. A `SemaphoreSlim` now spans write and flush.

On the reading side, a `u32` payload size went straight off the wire into `vec![0u8; payload_size]`, and the hardware and sensor counts straight into `Vec::with_capacity`, with nothing validated first. Rust aborts the process on allocation failure rather than unwinding, so a garbled prefix killed the app with no error path and no message — and the unsynchronized writes above are what made a garbled prefix reachable in ordinary operation. Payloads are now capped, and a count larger than the remaining bytes could describe is rejected, which turns the abort into a dropped connection the client already reconnects from.

## Correctness: a missing text file no longer kills the sidecar

`PresentMonPoller.Start` was `async void` and opened `ignored-processes.txt` before any guarded work. A missing file therefore reached the thread pool unhandled and killed the sidecar process. Because the app's supervisor respawns the sidecar on a flat one-second delay for as long as the app runs, one absent text file became a permanent once-a-second crash loop rather than a degraded feature. A partial install, an antivirus quarantine, or a dev-tree run all produce that condition.

`Start` now returns a `Task` and guards its whole body, and the file read degrades to no exclusions, so PresentMon still runs and FPS still reports.

## Cleanup

The startup path wrote a window-geometry debug log to the temp directory on every launch, plus a task that appended to it for three seconds after the window appeared. Both are gone; the sizing and centering they instrumented are unchanged.

The sidecar's forced `GC.Collect` advanced its accumulator by a hardcoded 500 regardless of the configured polling rate, so it tracked poll count rather than elapsed time. At the 33ms floor that forced a full collection roughly every 66ms instead of the intended once per second. It now advances by the interval actually waited.

## Pull request checks

Nothing verified a pull request before this. The release workflow triggers only on `v*` tags, so the first build of any change was the release build itself.

Three parallel jobs on `windows-latest`: frontend (eslint, unit tests, vite build), sidecar (`dotnet build`), and Rust (clippy plus `cargo test --lib`). Installs use `npm ci` so a pull request is checked against the committed lockfile rather than a freshly resolved tree.

Every command in it passes on `main` today, so a red check means the pull request broke something rather than inheriting existing debt. Three known-red things are deliberately not gated: `tsc` reports five long-standing type-level errors, clippy runs without `-D warnings` because it reports five style warnings, and the Rust tests are scoped to `--lib` because the bin target's test executable inherits the app's `requireAdministrator` manifest and cannot launch from a normal shell.

Also enabled on the repository itself, outside this diff: secret scanning, secret scanning push protection, and Dependabot security updates.

## Verification

Against a baseline captured on the same commit before any change, all unchanged: `dotnet build` of the full solution (all three projects) 0 warnings 0 errors, `cargo clippy` exit 0 with the same five pre-existing style warnings, eslint clean, 14/14 frontend tests, frontend build clean, typecheck reporting the same five known errors, and a full release build succeeding. Rust tests go from 13 to 18, all passing.

Runtime, on Windows with the rebuilt sidecar staged next to the binary: sensors stream live CPU, GPU and RAM values to the overlay, so the pipe changes do not disturb the working path; the sidecar logs zero respawns over 30 seconds; no `CleanMeterHW` service is created; and no debug log appears in the temp directory.

The crash-loop fix was tested directly rather than reasoned about. With `ignored-processes.txt` deleted, the sidecar starts and stays up with zero respawns over 20 seconds while sensors keep flowing. That same condition previously killed it on a one-second cycle.

## Not addressed here

Hardware and sensor names are still length-prefixed as UTF-16 character counts while their payloads are written as UTF-8 bytes, so a non-ASCII name still misaligns the fields after it. The caps in this change turn the resulting corruption into a dropped connection instead of an abort, but the mismatch itself is a separate fix.

Serializing sends means a client that stops reading now delays subsequent sends rather than interleaving with them. With one consumer and a 500ms interval that is the correct trade, but there is no write timeout, so a wedged client would queue sends behind it. Worth revisiting if a second consumer is ever added.

Code scanning has still never run on this repository; it needs its own workflow.
