### PR TITLE
Add “How is Cleanmeter built?” to the in-app FAQ

### DIFF
--- a/tauri-app/src/components/settings/help/FaqSection.tsx
+++ b/tauri-app/src/components/settings/help/FaqSection.tsx
@@ -22,6 +22,11 @@ const FAQ_ITEMS: FaqItem[] = [
     answer:
       "No! Cleanmeter is designed to be lightweight and efficient, ensuring it runs\nsmoothly without impacting your system’s performance.",
   },
+  {
+    question: "How is Cleanmeter built?",
+    answer:
+      "Interface is built with React and TypeScript. Rust handles the overlay,\nhotkeys, and settings. Hardware readings are done using LibreHardwareMonitor\nfor CPU, GPU, RAM, and network sensors. PresentMon for frames and frametime.",
+  },
 ];
 
 export function FaqSection() {

--- a/tauri-app/src/components/settings/help/FaqSection.tsx
+++ b/tauri-app/src/components/settings/help/FaqSection.tsx
@@ -13,11 +13,6 @@ const FAQ_ITEMS: FaqItem[] = [
     answer: "Cleanmeter currently doesn’t support fullscreen in games.",
   },
   {
-    question: "Why does Windows say that Cleanmeter is not secure?",
-    answer:
-      "Windows shows that warning for any app that isn't signed with a paid code-\nsigning certificate, it flags the missing signature, not anything in the app itself.",
-  },
-  {
     question: "Is Cleanmeter resource-heavy?",
     answer:
       "No! Cleanmeter is designed to be lightweight and efficient, ensuring it runs\nsmoothly without impacting your system’s performance.",


### PR DESCRIPTION
Adds “How is Cleanmeter built?” to the in-app Help FAQ (`FaqSection.tsx`) and removes “Why does Windows say that Cleanmeter is not secure?”. Shows under Settings → Help → Frequently asked questions.

Build copy is the version pasted in chat, with “Hardware reading are” → “Hardware readings are”. Website/Notion untouched.