### PR TITLE
Optional HWiNFO shared-memory sensors with LHM fallback

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,6 +65,10 @@ jobs:
         working-directory: HardwareMonitor/HardwareMonitor
         run: dotnet build -c Release
 
+      - name: Test sidecar
+        working-directory: HardwareMonitor/HardwareMonitor.Tests
+        run: dotnet test -c Release
+
   rust:
     name: Rust (clippy, tests)
     runs-on: windows-latest

--- a/HardwareMonitor/HardwareMonitor.Tests/HardwareMonitor.Tests.csproj
+++ b/HardwareMonitor/HardwareMonitor.Tests/HardwareMonitor.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\HardwareMonitor\HardwareMonitor.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/HardwareMonitor/HardwareMonitor.Tests/HwInfoParserTests.cs
+++ b/HardwareMonitor/HardwareMonitor.Tests/HwInfoParserTests.cs
@@ -1,0 +1,252 @@
+using System.Text;
+using HardwareMonitor.HwInfo;
+using HardwareMonitor.Monitor;
+using Xunit;
+
+namespace HardwareMonitor.Tests;
+
+public class HwInfoParserTests
+{
+    [Fact]
+    public void DeadSignatureIsDeadNotActive()
+    {
+        var buffer = Header(HwInfoParser.SignatureDead, sensorCount: 1, readingCount: 1);
+        var result = HwInfoParser.Parse(buffer);
+        Assert.Equal(HwInfoParseStatus.Dead, result.Status);
+        Assert.Null(result.Snapshot);
+    }
+
+    [Fact]
+    public void MissingBufferIsInvalid()
+    {
+        var result = HwInfoParser.Parse([]);
+        Assert.Equal(HwInfoParseStatus.Invalid, result.Status);
+    }
+
+    [Fact]
+    public void TruncatedHeaderIsInvalid()
+    {
+        var result = HwInfoParser.Parse(new byte[20]);
+        Assert.Equal(HwInfoParseStatus.Invalid, result.Status);
+    }
+
+    [Fact]
+    public void UnknownSignatureIsInvalid()
+    {
+        var buffer = Header(0x464F4F42, sensorCount: 1, readingCount: 1);
+        Assert.Equal(HwInfoParseStatus.Invalid, HwInfoParser.Parse(buffer).Status);
+    }
+
+    [Fact]
+    public void ActiveHeaderWithNoReadingsFallsBack()
+    {
+        var buffer = Header(HwInfoParser.SignatureActive, sensorCount: 0, readingCount: 0);
+        Assert.Equal(HwInfoParseStatus.Invalid, HwInfoParser.Parse(buffer).Status);
+    }
+
+    [Fact]
+    public void ActiveSnapshotMapsStableIdsAndLeavesLabelsForDisplay()
+    {
+        var buffer = BuildSnapshot(
+            sensorId: 0xE0000200,
+            sensorInst: 1,
+            sensorName: "CPU [#0]: AMD Ryzen",
+            readings:
+            [
+                (1, 0x100u, "CPU Package", "°C", 67.5),
+                (7, 0x200u, "CPU Total Load", "%", 22.0),
+            ]);
+
+        var result = HwInfoParser.Parse(buffer);
+        Assert.Equal(HwInfoParseStatus.Ok, result.Status);
+        var snapshot = result.Snapshot!;
+        Assert.Equal(1, snapshot.Header.NumSensorElements);
+        Assert.Equal(500, snapshot.Header.PollingPeriod);
+        Assert.Equal("/hwinfo/e0000200/1", snapshot.Hardwares[0].Identifier);
+        Assert.Equal(HwInfoParser.HardwareCpu, snapshot.Hardwares[0].HardwareType);
+        Assert.Equal("CPU Package", snapshot.Sensors[0].Name);
+        Assert.Equal("/hwinfo/e0000200/1/100", snapshot.Sensors[0].Identifier);
+        Assert.Equal("/hwinfo/e0000200/1", snapshot.Sensors[0].HardwareIdentifier);
+        Assert.Equal(HwInfoParser.SensorTemperature, snapshot.Sensors[0].SensorType);
+        Assert.Equal(67.5f, snapshot.Sensors[0].Value, 3);
+        Assert.Equal(HwInfoParser.SensorLoad, snapshot.Sensors[1].SensorType);
+    }
+
+    [Fact]
+    public void IdentifiersStayStableWhenEnglishLabelsChange()
+    {
+        var first = HwInfoParser.Parse(BuildSnapshot(
+            0x1000, 0, "GPU", [(1, 0x10u, "GPU Core", "°C", 40)])).Snapshot!;
+        var second = HwInfoParser.Parse(BuildSnapshot(
+            0x1000, 0, "GPU", [(1, 0x10u, "GPU Nucleo", "°C", 41)])).Snapshot!;
+
+        Assert.Equal(first.Sensors[0].Identifier, second.Sensors[0].Identifier);
+        Assert.Equal("GPU Nucleo", second.Sensors[0].Name);
+    }
+
+    [Fact]
+    public void OtherNetworkRateBecomesThroughputFromUnit()
+    {
+        Assert.Equal(HwInfoParser.SensorThroughput, HwInfoParser.MapReadingType(8, "KB/s"));
+        Assert.Equal(HwInfoParser.SensorLoad, HwInfoParser.MapReadingType(7, "%"));
+        Assert.Equal(HwInfoParser.SensorTemperature, HwInfoParser.MapReadingType(1, "C"));
+        Assert.Equal(HwInfoParser.SensorSmallData, HwInfoParser.InferFromUnit("MB"));
+    }
+
+    [Fact]
+    public void HardwareTypeUsesSensorNameNotReadingLabel()
+    {
+        Assert.Equal(HwInfoParser.HardwareGpuNvidia, HwInfoParser.InferHardwareType("GPU [#0]: NVIDIA GeForce RTX 4090"));
+        Assert.Equal(HwInfoParser.HardwareGpuAmd, HwInfoParser.InferHardwareType("GPU [#1]: AMD Radeon RX 7800 XT"));
+        Assert.Equal(HwInfoParser.HardwareMemory, HwInfoParser.InferHardwareType("Memory"));
+        Assert.Equal(HwInfoParser.HardwareNetwork, HwInfoParser.InferHardwareType("Network: Intel Ethernet"));
+        Assert.Equal(HwInfoParser.HardwareCpu, HwInfoParser.InferHardwareType("CPU [#0]: Intel Core i7"));
+    }
+
+    [Theory]
+    [InlineData(44)]
+    [InlineData(48)]
+    public void HeaderLayoutAcceptsClassicAndPollingPeriodSizes(int headerBytes)
+    {
+        var buffer = Header(
+            HwInfoParser.SignatureActive,
+            sensorCount: 1,
+            readingCount: 1,
+            headerSize: headerBytes);
+        WriteSensor(buffer, 0, 0x1, 0, "CPU");
+        WriteReading(buffer, 0, readingType: 7, sensorIndex: 0, readingId: 1, "Load", "%", 10);
+
+        Assert.True(HwInfoParser.TryReadHeader(buffer, out var header));
+        Assert.Equal(HwInfoParser.SignatureActive, header.Signature);
+        Assert.Equal(headerBytes >= 48 ? 500 : 0, header.PollingPeriod);
+        Assert.Equal(HwInfoParseStatus.Ok, HwInfoParser.Parse(buffer).Status);
+    }
+
+    private static byte[] BuildSnapshot(
+        uint sensorId,
+        uint sensorInst,
+        string sensorName,
+        (int type, uint id, string label, string unit, double value)[] readings)
+    {
+        var buffer = Header(
+            HwInfoParser.SignatureActive,
+            sensorCount: 1,
+            readingCount: readings.Length);
+        WriteSensor(buffer, 0, sensorId, sensorInst, sensorName);
+        for (var i = 0; i < readings.Length; i++)
+        {
+            var r = readings[i];
+            WriteReading(buffer, i, r.type, 0, r.id, r.label, r.unit, r.value);
+        }
+
+        return buffer;
+    }
+
+    private static byte[] Header(
+        uint signature,
+        int sensorCount,
+        int readingCount,
+        int headerSize = HwInfoParser.HeaderSizeWithPollingPeriod)
+    {
+        var sensorOffset = Math.Max(headerSize, HwInfoParser.HeaderSizeWithPollingPeriod);
+        var readingOffset = sensorOffset + HwInfoParser.DefaultSensorElementSize * Math.Max(sensorCount, 1);
+        var total = readingOffset + HwInfoParser.DefaultReadingElementSize * Math.Max(readingCount, 1);
+        var buffer = new byte[total];
+
+        WriteU32(buffer, 0, signature);
+        WriteU32(buffer, 4, 2);
+        WriteU32(buffer, 8, 1);
+        WriteI64(buffer, 12, 0);
+        WriteI32(buffer, 20, sensorOffset);
+        WriteI32(buffer, 24, HwInfoParser.DefaultSensorElementSize);
+        WriteI32(buffer, 28, sensorCount);
+        WriteI32(buffer, 32, readingOffset);
+        WriteI32(buffer, 36, HwInfoParser.DefaultReadingElementSize);
+        WriteI32(buffer, 40, readingCount);
+        if (headerSize >= HwInfoParser.HeaderSizeWithPollingPeriod)
+            WriteI32(buffer, 44, 500);
+
+        return buffer;
+    }
+
+    private static void WriteSensor(byte[] buffer, int index, uint id, uint inst, string name)
+    {
+        Assert.True(HwInfoParser.TryReadHeader(buffer, out var header));
+        var offset = header.OffsetOfSensorSection + header.SizeOfSensorElement * index;
+        WriteU32(buffer, offset, id);
+        WriteU32(buffer, offset + 4, inst);
+        WriteFixed(buffer, offset + 8, name, HwInfoParser.SensorNameLength);
+        WriteFixed(buffer, offset + 8 + HwInfoParser.SensorNameLength, name, HwInfoParser.SensorNameLength);
+    }
+
+    private static void WriteReading(
+        byte[] buffer,
+        int index,
+        int readingType,
+        int sensorIndex,
+        uint readingId,
+        string label,
+        string unit,
+        double value)
+    {
+        Assert.True(HwInfoParser.TryReadHeader(buffer, out var header));
+        var offset = header.OffsetOfReadingSection + header.SizeOfReadingElement * index;
+        WriteI32(buffer, offset, readingType);
+        WriteI32(buffer, offset + 4, sensorIndex);
+        WriteU32(buffer, offset + 8, readingId);
+        WriteFixed(buffer, offset + 12, label, HwInfoParser.SensorNameLength);
+        WriteFixed(buffer, offset + 12 + HwInfoParser.SensorNameLength, label, HwInfoParser.SensorNameLength);
+        WriteFixed(buffer, offset + 12 + HwInfoParser.SensorNameLength * 2, unit, HwInfoParser.UnitLength);
+        WriteDouble(buffer, offset + 12 + HwInfoParser.SensorNameLength * 2 + HwInfoParser.UnitLength, value);
+    }
+
+    private static void WriteU32(byte[] buffer, int offset, uint value) =>
+        BitConverter.TryWriteBytes(buffer.AsSpan(offset, 4), value);
+
+    private static void WriteI32(byte[] buffer, int offset, int value) =>
+        BitConverter.TryWriteBytes(buffer.AsSpan(offset, 4), value);
+
+    private static void WriteI64(byte[] buffer, int offset, long value) =>
+        BitConverter.TryWriteBytes(buffer.AsSpan(offset, 8), value);
+
+    private static void WriteDouble(byte[] buffer, int offset, double value) =>
+        BitConverter.TryWriteBytes(buffer.AsSpan(offset, 8), value);
+
+    private static void WriteFixed(byte[] buffer, int offset, string value, int length)
+    {
+        var bytes = Encoding.Latin1.GetBytes(value);
+        var n = Math.Min(bytes.Length, length - 1);
+        Array.Copy(bytes, 0, buffer, offset, n);
+    }
+}
+
+public class HwInfoSourcePolicyTests
+{
+    [Fact]
+    public void AutoUsesHwInfoWhenHealthyAndFallsBackSilentlyIfNeverSeen()
+    {
+        Assert.True(HwInfoSourcePolicy.WantsHwInfo(SensorSourcePreference.Auto));
+        Assert.False(HwInfoSourcePolicy.ShouldReportFallback(
+            SensorSourcePreference.Auto, usingHwInfo: false, hwInfoSeenThisSession: false));
+        Assert.True(HwInfoSourcePolicy.ShouldReportFallback(
+            SensorSourcePreference.Auto, usingHwInfo: false, hwInfoSeenThisSession: true));
+    }
+
+    [Fact]
+    public void ForcedHwInfoReportsFallbackWhenSharedMemoryIsMissingOrDead()
+    {
+        Assert.True(HwInfoSourcePolicy.WantsHwInfo(SensorSourcePreference.Hwinfo));
+        Assert.True(HwInfoSourcePolicy.ShouldReportFallback(
+            SensorSourcePreference.Hwinfo, usingHwInfo: false, hwInfoSeenThisSession: false));
+        Assert.False(HwInfoSourcePolicy.ShouldReportFallback(
+            SensorSourcePreference.Hwinfo, usingHwInfo: true, hwInfoSeenThisSession: true));
+    }
+
+    [Fact]
+    public void LhmNeverTouchesHwInfoAndNeverReportsFallback()
+    {
+        Assert.False(HwInfoSourcePolicy.WantsHwInfo(SensorSourcePreference.Lhm));
+        Assert.False(HwInfoSourcePolicy.ShouldReportFallback(
+            SensorSourcePreference.Lhm, usingHwInfo: false, hwInfoSeenThisSession: true));
+    }
+}

--- a/HardwareMonitor/HardwareMonitor.Tests/HwInfoParserTests.cs
+++ b/HardwareMonitor/HardwareMonitor.Tests/HwInfoParserTests.cs
@@ -94,6 +94,32 @@ public class HwInfoParserTests
     }
 
     [Fact]
+    public void NetworkRatesInKilobytesPerSecondAreConvertedToBytesPerSecond()
+    {
+        Assert.Equal(1024, HwInfoParser.ThroughputBytesPerSecondScale("KB/s"));
+        Assert.Equal(1024d * 1024, HwInfoParser.ThroughputBytesPerSecondScale("MB/s"));
+        Assert.Equal(1, HwInfoParser.ThroughputBytesPerSecondScale("B/s"));
+
+        var snapshot = HwInfoParser.Parse(BuildSnapshot(
+            0x2000, 0, "Network: Intel Ethernet",
+            [
+                (8, 0x1u, "Current DL rate", "KB/s", 100),
+                (8, 0x2u, "Current UP rate", "KB/s", 2.5),
+            ])).Snapshot!;
+
+        Assert.Equal(HwInfoParser.SensorThroughput, snapshot.Sensors[0].SensorType);
+        Assert.Equal(100 * 1024, snapshot.Sensors[0].Value, 1);
+        Assert.Equal(2.5f * 1024, snapshot.Sensors[1].Value, 1);
+    }
+
+    [Fact]
+    public void NonThroughputReadingsAreNotScaledByUnit()
+    {
+        Assert.Equal(67.5f, HwInfoParser.NormalizeReadingValue(HwInfoParser.SensorTemperature, "°C", 67.5), 3);
+        Assert.Equal(22f, HwInfoParser.NormalizeReadingValue(HwInfoParser.SensorLoad, "%", 22), 3);
+    }
+
+    [Fact]
     public void HardwareTypeUsesSensorNameNotReadingLabel()
     {
         Assert.Equal(HwInfoParser.HardwareGpuNvidia, HwInfoParser.InferHardwareType("GPU [#0]: NVIDIA GeForce RTX 4090"));

--- a/HardwareMonitor/HardwareMonitor.sln
+++ b/HardwareMonitor/HardwareMonitor.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HardwareMonitorTester", "Ha
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Updater", "Updater\Updater.csproj", "{A5991FC1-069F-43D7-8E8D-158D1EE8DE02}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HardwareMonitor.Tests", "HardwareMonitor.Tests\HardwareMonitor.Tests.csproj", "{B7E2C4A1-9F3D-4E8A-B251-0D6C8E91A4F2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{A5991FC1-069F-43D7-8E8D-158D1EE8DE02}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5991FC1-069F-43D7-8E8D-158D1EE8DE02}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A5991FC1-069F-43D7-8E8D-158D1EE8DE02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7E2C4A1-9F3D-4E8A-B251-0D6C8E91A4F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7E2C4A1-9F3D-4E8A-B251-0D6C8E91A4F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7E2C4A1-9F3D-4E8A-B251-0D6C8E91A4F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7E2C4A1-9F3D-4E8A-B251-0D6C8E91A4F2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/HardwareMonitor/HardwareMonitor/HwInfo/HwInfoParser.cs
+++ b/HardwareMonitor/HardwareMonitor/HwInfo/HwInfoParser.cs
@@ -1,0 +1,384 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace HardwareMonitor.HwInfo;
+
+public enum HwInfoParseStatus
+{
+    Ok,
+    Dead,
+    Invalid,
+}
+
+public sealed class HwInfoHeader
+{
+    public uint Signature { get; init; }
+    public uint Version { get; init; }
+    public uint Revision { get; init; }
+    public long PollTime { get; init; }
+    public int OffsetOfSensorSection { get; init; }
+    public int SizeOfSensorElement { get; init; }
+    public int NumSensorElements { get; init; }
+    public int OffsetOfReadingSection { get; init; }
+    public int SizeOfReadingElement { get; init; }
+    public int NumReadingElements { get; init; }
+    public int PollingPeriod { get; init; }
+}
+
+public sealed class HwInfoHardware
+{
+    public required string Name { get; init; }
+    public required string Identifier { get; init; }
+    public required int HardwareType { get; init; }
+}
+
+public sealed class HwInfoReading
+{
+    public required string Name { get; init; }
+    public required string Identifier { get; init; }
+    public required string HardwareIdentifier { get; init; }
+    public required int SensorType { get; init; }
+    public required float Value { get; init; }
+}
+
+public sealed class HwInfoSnapshot
+{
+    public required HwInfoHeader Header { get; init; }
+    public required List<HwInfoHardware> Hardwares { get; init; }
+    public required List<HwInfoReading> Sensors { get; init; }
+}
+
+public readonly struct HwInfoParseResult
+{
+    public HwInfoParseStatus Status { get; init; }
+    public HwInfoSnapshot? Snapshot { get; init; }
+
+    public static HwInfoParseResult Ok(HwInfoSnapshot snapshot) => new()
+    {
+        Status = HwInfoParseStatus.Ok,
+        Snapshot = snapshot,
+    };
+
+    public static HwInfoParseResult Dead() => new() { Status = HwInfoParseStatus.Dead };
+
+    public static HwInfoParseResult Invalid() => new() { Status = HwInfoParseStatus.Invalid };
+}
+
+/// <summary>
+/// Parses an HWiNFO sensor shared-memory buffer into the existing
+/// HardwareMonitor hardware/sensor list shape.
+/// </summary>
+public static class HwInfoParser
+{
+    public const uint SignatureActive = 0x53695748; // "HWiS"
+    public const uint SignatureDead = 0x44414544;   // "DEAD"
+
+    public const int MinHeaderSize = 44;
+    public const int HeaderSizeWithPollingPeriod = 48;
+    public const int SensorNameLength = 128;
+    public const int UnitLength = 16;
+    public const int DefaultSensorElementSize = 264;
+    public const int DefaultReadingElementSize = 316;
+    public const int MaxSharedMemoryBytes = 16 * 1024 * 1024;
+    public const int MaxElements = 10_000;
+
+    // Integer codes match LibreHardwareMonitor's HardwareType / SensorType.
+    public const int HardwareMotherboard = 0;
+    public const int HardwareCpu = 2;
+    public const int HardwareMemory = 3;
+    public const int HardwareGpuNvidia = 4;
+    public const int HardwareGpuAmd = 5;
+    public const int HardwareGpuIntel = 6;
+    public const int HardwareStorage = 7;
+    public const int HardwareNetwork = 8;
+    public const int HardwarePsu = 11;
+    public const int HardwareBattery = 12;
+
+    public const int SensorVoltage = 0;
+    public const int SensorCurrent = 1;
+    public const int SensorPower = 2;
+    public const int SensorClock = 3;
+    public const int SensorTemperature = 4;
+    public const int SensorLoad = 5;
+    public const int SensorFan = 7;
+    public const int SensorFactor = 11;
+    public const int SensorSmallData = 13;
+    public const int SensorThroughput = 14;
+    public const int SensorTimeSpan = 15;
+
+    public static HwInfoParseResult Parse(ReadOnlySpan<byte> buffer)
+    {
+        if (!TryReadHeader(buffer, out var header))
+            return HwInfoParseResult.Invalid();
+
+        if (header.Signature == SignatureDead)
+            return HwInfoParseResult.Dead();
+
+        if (header.Signature != SignatureActive)
+            return HwInfoParseResult.Invalid();
+
+        if (!IsHeaderSane(header, buffer.Length))
+            return HwInfoParseResult.Invalid();
+
+        if (header.NumSensorElements == 0 || header.NumReadingElements == 0)
+            return HwInfoParseResult.Invalid();
+
+        var sensors = ReadSensors(buffer, header);
+        if (sensors.Count != header.NumSensorElements)
+            return HwInfoParseResult.Invalid();
+
+        var readings = ReadReadings(buffer, header, sensors);
+        if (readings.Count == 0)
+            return HwInfoParseResult.Invalid();
+
+        return HwInfoParseResult.Ok(new HwInfoSnapshot
+        {
+            Header = header,
+            Hardwares = sensors.ConvertAll(s => s.Hardware),
+            Sensors = readings,
+        });
+    }
+
+    public static bool TryReadHeader(ReadOnlySpan<byte> buffer, out HwInfoHeader header)
+    {
+        header = null!;
+        if (buffer.Length < MinHeaderSize)
+            return false;
+
+        header = new HwInfoHeader
+        {
+            Signature = ReadU32(buffer, 0),
+            Version = ReadU32(buffer, 4),
+            Revision = ReadU32(buffer, 8),
+            PollTime = ReadI64(buffer, 12),
+            OffsetOfSensorSection = ReadI32(buffer, 20),
+            SizeOfSensorElement = ReadI32(buffer, 24),
+            NumSensorElements = ReadI32(buffer, 28),
+            OffsetOfReadingSection = ReadI32(buffer, 32),
+            SizeOfReadingElement = ReadI32(buffer, 36),
+            NumReadingElements = ReadI32(buffer, 40),
+            PollingPeriod = buffer.Length >= HeaderSizeWithPollingPeriod ? ReadI32(buffer, 44) : 0,
+        };
+        return true;
+    }
+
+    public static bool IsHealthyActiveHeader(HwInfoHeader header) =>
+        header.Signature == SignatureActive
+        && IsHeaderSane(header, int.MaxValue)
+        && header.NumSensorElements > 0
+        && header.NumReadingElements > 0;
+
+    private static bool IsHeaderSane(HwInfoHeader header, int bufferLength)
+    {
+        if (header.SizeOfSensorElement < DefaultSensorElementSize
+            || header.SizeOfReadingElement < DefaultReadingElementSize)
+            return false;
+
+        if (header.NumSensorElements is < 0 or > MaxElements)
+            return false;
+        if (header.NumReadingElements is < 0 or > MaxElements)
+            return false;
+
+        if (header.OffsetOfSensorSection < MinHeaderSize
+            || header.OffsetOfReadingSection < MinHeaderSize)
+            return false;
+
+        long sensorEnd = (long)header.OffsetOfSensorSection
+            + (long)header.SizeOfSensorElement * header.NumSensorElements;
+        long readingEnd = (long)header.OffsetOfReadingSection
+            + (long)header.SizeOfReadingElement * header.NumReadingElements;
+
+        if (sensorEnd > MaxSharedMemoryBytes || readingEnd > MaxSharedMemoryBytes)
+            return false;
+        if (sensorEnd > bufferLength || readingEnd > bufferLength)
+            return false;
+
+        return true;
+    }
+
+    private readonly record struct ParsedHardware(uint SensorId, uint SensorInst, HwInfoHardware Hardware);
+
+    private static List<ParsedHardware> ReadSensors(ReadOnlySpan<byte> buffer, HwInfoHeader header)
+    {
+        var list = new List<ParsedHardware>(header.NumSensorElements);
+        for (var i = 0; i < header.NumSensorElements; i++)
+        {
+            var offset = header.OffsetOfSensorSection + (header.SizeOfSensorElement * i);
+            if (offset + DefaultSensorElementSize > buffer.Length)
+                return [];
+
+            var sensorId = ReadU32(buffer, offset);
+            var sensorInst = ReadU32(buffer, offset + 4);
+            var nameOrig = ReadFixedString(buffer, offset + 8, SensorNameLength);
+            var nameUser = ReadFixedString(buffer, offset + 8 + SensorNameLength, SensorNameLength);
+            var name = string.IsNullOrWhiteSpace(nameUser) ? nameOrig : nameUser;
+            if (string.IsNullOrWhiteSpace(name))
+                name = $"Sensor {sensorId:x}";
+
+            list.Add(new ParsedHardware(sensorId, sensorInst, new HwInfoHardware
+            {
+                Name = SanitizeName(name),
+                Identifier = HardwareIdentifier(sensorId, sensorInst),
+                HardwareType = InferHardwareType(nameOrig, nameUser),
+            }));
+        }
+
+        return list;
+    }
+
+    private static List<HwInfoReading> ReadReadings(
+        ReadOnlySpan<byte> buffer,
+        HwInfoHeader header,
+        List<ParsedHardware> sensors)
+    {
+        var list = new List<HwInfoReading>(header.NumReadingElements);
+        for (var i = 0; i < header.NumReadingElements; i++)
+        {
+            var offset = header.OffsetOfReadingSection + (header.SizeOfReadingElement * i);
+            if (offset + DefaultReadingElementSize > buffer.Length)
+                return [];
+
+            var readingType = ReadI32(buffer, offset);
+            var sensorIndex = ReadI32(buffer, offset + 4);
+            var readingId = ReadU32(buffer, offset + 8);
+            var labelOrig = ReadFixedString(buffer, offset + 12, SensorNameLength);
+            var labelUser = ReadFixedString(buffer, offset + 12 + SensorNameLength, SensorNameLength);
+            var unit = ReadFixedString(buffer, offset + 12 + SensorNameLength * 2, UnitLength);
+            var value = ReadDouble(buffer, offset + 12 + SensorNameLength * 2 + UnitLength);
+
+            if (sensorIndex < 0 || sensorIndex >= sensors.Count)
+                continue;
+
+            var parsed = sensors[sensorIndex];
+            var label = string.IsNullOrWhiteSpace(labelUser) ? labelOrig : labelUser;
+            if (string.IsNullOrWhiteSpace(label))
+                label = $"Reading {readingId}";
+
+            list.Add(new HwInfoReading
+            {
+                Name = SanitizeName(label),
+                Identifier = ReadingIdentifier(parsed.SensorId, parsed.SensorInst, readingId),
+                HardwareIdentifier = parsed.Hardware.Identifier,
+                SensorType = MapReadingType(readingType, unit),
+                Value = double.IsNaN(value) || double.IsInfinity(value) ? 0f : (float)value,
+            });
+        }
+
+        return list;
+    }
+
+    public static string HardwareIdentifier(uint sensorId, uint sensorInst) =>
+        $"/hwinfo/{sensorId:x}/{sensorInst:x}";
+
+    public static string ReadingIdentifier(uint sensorId, uint sensorInst, uint readingId) =>
+        $"/hwinfo/{sensorId:x}/{sensorInst:x}/{readingId:x}";
+
+    public static int InferHardwareType(string nameOrig, string nameUser = "")
+    {
+        var n = $"{nameOrig} {nameUser}".ToLowerInvariant();
+
+        if (ContainsAny(n, "nvidia", "geforce", "quadro", "rtx", "gtx"))
+            return HardwareGpuNvidia;
+        if (ContainsAny(n, "radeon", "rx ", "vega", "amd gpu"))
+            return HardwareGpuAmd;
+        if (ContainsAny(n, "intel arc", "iris", "uhd graphics", "intel gpu"))
+            return HardwareGpuIntel;
+        if (n.Contains("gpu") || n.Contains("graphics"))
+        {
+            if (n.Contains("amd")) return HardwareGpuAmd;
+            if (n.Contains("intel")) return HardwareGpuIntel;
+            return HardwareGpuNvidia;
+        }
+
+        if (ContainsAny(n, "cpu", "processor", "ryzen", "core i", "threadripper", "epyc", "xeon"))
+            return HardwareCpu;
+        if (ContainsAny(n, "memory", "ram", "dimm", "sdram"))
+            return HardwareMemory;
+        if (ContainsAny(n, "network", "lan", "wifi", "wi-fi", "ethernet", "nic", "killer"))
+            return HardwareNetwork;
+        if (ContainsAny(n, "nvme", "ssd", "hdd", "drive", "s.m.a.r.t", "smart"))
+            return HardwareStorage;
+        if (n.Contains("battery"))
+            return HardwareBattery;
+        if (n.Contains("psu") || n.Contains("power supply"))
+            return HardwarePsu;
+
+        return HardwareMotherboard;
+    }
+
+    public static int MapReadingType(int readingType, string unit)
+    {
+        return readingType switch
+        {
+            1 => SensorTemperature,
+            2 => SensorVoltage,
+            3 => SensorFan,
+            4 => SensorCurrent,
+            5 => SensorPower,
+            6 => SensorClock,
+            7 => SensorLoad,
+            _ => InferFromUnit(unit),
+        };
+    }
+
+    public static int InferFromUnit(string unit)
+    {
+        var u = unit.Trim().ToLowerInvariant();
+        if (u is "%" or "percent")
+            return SensorLoad;
+        if (u is "c" or "°c" or "f" or "°f" or "degc" or "degf")
+            return SensorTemperature;
+        if (u is "w" or "mw" or "kw")
+            return SensorPower;
+        if (u is "v" or "mv")
+            return SensorVoltage;
+        if (u is "a" or "ma")
+            return SensorCurrent;
+        if (u is "rpm")
+            return SensorFan;
+        if (u is "mhz" or "ghz" or "hz" or "khz")
+            return SensorClock;
+        if (u.Contains("/s") || u is "kbps" or "mbps" or "gbps")
+            return SensorThroughput;
+        if (u is "mb" or "gb" or "tb" or "kb")
+            return SensorSmallData;
+        if (u is "ms" or "s")
+            return SensorTimeSpan;
+        return SensorFactor;
+    }
+
+    private static string SanitizeName(string name) =>
+        Regex.Replace(name, "[^a-zA-Z0-9_ .]+", "_", RegexOptions.Compiled);
+
+    private static bool ContainsAny(string haystack, params string[] needles)
+    {
+        foreach (var needle in needles)
+        {
+            if (haystack.Contains(needle))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static uint ReadU32(ReadOnlySpan<byte> buffer, int offset) =>
+        BitConverter.ToUInt32(buffer.Slice(offset, 4));
+
+    private static int ReadI32(ReadOnlySpan<byte> buffer, int offset) =>
+        BitConverter.ToInt32(buffer.Slice(offset, 4));
+
+    private static long ReadI64(ReadOnlySpan<byte> buffer, int offset) =>
+        BitConverter.ToInt64(buffer.Slice(offset, 8));
+
+    private static double ReadDouble(ReadOnlySpan<byte> buffer, int offset) =>
+        BitConverter.ToDouble(buffer.Slice(offset, 8));
+
+    private static string ReadFixedString(ReadOnlySpan<byte> buffer, int offset, int maxLen)
+    {
+        var limit = Math.Min(offset + maxLen, buffer.Length);
+        var end = offset;
+        while (end < limit && buffer[end] != 0)
+            end++;
+        return Encoding.Latin1.GetString(buffer.Slice(offset, end - offset)).Trim();
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/HwInfo/HwInfoParser.cs
+++ b/HardwareMonitor/HardwareMonitor/HwInfo/HwInfoParser.cs
@@ -254,13 +254,14 @@ public static class HwInfoParser
             if (string.IsNullOrWhiteSpace(label))
                 label = $"Reading {readingId}";
 
+            var sensorType = MapReadingType(readingType, unit);
             list.Add(new HwInfoReading
             {
                 Name = SanitizeName(label),
                 Identifier = ReadingIdentifier(parsed.SensorId, parsed.SensorInst, readingId),
                 HardwareIdentifier = parsed.Hardware.Identifier,
-                SensorType = MapReadingType(readingType, unit),
-                Value = double.IsNaN(value) || double.IsInfinity(value) ? 0f : (float)value,
+                SensorType = sensorType,
+                Value = NormalizeReadingValue(sensorType, unit, value),
             });
         }
 
@@ -345,6 +346,36 @@ public static class HwInfoParser
         if (u is "ms" or "s")
             return SensorTimeSpan;
         return SensorFactor;
+    }
+
+    /// <summary>
+    /// Overlay/LHM throughput is bytes/s. HWiNFO publishes KB/s (and similar)
+    /// for Current DL/UP rate, so convert at the mapping boundary.
+    /// </summary>
+    public static float NormalizeReadingValue(int sensorType, string unit, double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+            return 0f;
+
+        if (sensorType == SensorThroughput)
+            value *= ThroughputBytesPerSecondScale(unit);
+
+        return (float)value;
+    }
+
+    public static double ThroughputBytesPerSecondScale(string unit)
+    {
+        var u = unit.Trim().ToLowerInvariant().Replace(" ", "");
+        return u switch
+        {
+            "kb/s" or "kbyte/s" or "kbytes/s" or "kib/s" or "kib/sec" => 1024,
+            "mb/s" or "mbyte/s" or "mbytes/s" or "mib/s" => 1024d * 1024,
+            "gb/s" or "gbyte/s" or "gbytes/s" or "gib/s" => 1024d * 1024 * 1024,
+            "kbps" or "kbit/s" => 1000d / 8,
+            "mbps" or "mbit/s" => 1_000_000d / 8,
+            "gbps" or "gbit/s" => 1_000_000_000d / 8,
+            _ => 1,
+        };
     }
 
     private static string SanitizeName(string name) =>

--- a/HardwareMonitor/HardwareMonitor/HwInfo/HwInfoReader.cs
+++ b/HardwareMonitor/HardwareMonitor/HwInfo/HwInfoReader.cs
@@ -1,0 +1,180 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace HardwareMonitor.HwInfo;
+
+public enum HwInfoReadStatus
+{
+    Success,
+    Busy,
+    Unavailable,
+}
+
+public readonly struct HwInfoReadAttempt
+{
+    public HwInfoReadStatus Status { get; init; }
+    public HwInfoSnapshot? Snapshot { get; init; }
+
+    public static HwInfoReadAttempt Success(HwInfoSnapshot snapshot) => new()
+    {
+        Status = HwInfoReadStatus.Success,
+        Snapshot = snapshot,
+    };
+
+    public static HwInfoReadAttempt Busy() => new() { Status = HwInfoReadStatus.Busy };
+
+    public static HwInfoReadAttempt Unavailable() => new() { Status = HwInfoReadStatus.Unavailable };
+}
+
+/// <summary>
+/// Reads HWiNFO sensor shared memory for one poll, then releases the mapping.
+/// The mapping is recreated when the sensor set changes; holding the old handle
+/// can crash HWiNFO, so every call opens, copies, and closes.
+/// </summary>
+public sealed class HwInfoReader(ILogger logger)
+{
+    public const string MappingName = @"Global\HWiNFO_SENS_SM2";
+    public const string MutexName = @"Global\HWiNFO_SM2_MUTEX";
+    private const int MutexTimeoutMs = 200;
+    private const uint FileMapRead = 0x0004;
+
+    public HwInfoReadAttempt TryRead()
+    {
+        Mutex? mutex = null;
+        var acquired = false;
+        try
+        {
+            try
+            {
+                mutex = Mutex.OpenExisting(MutexName);
+            }
+            catch (WaitHandleCannotBeOpenedException)
+            {
+                return HwInfoReadAttempt.Unavailable();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return HwInfoReadAttempt.Unavailable();
+            }
+
+            if (mutex is null)
+                return HwInfoReadAttempt.Unavailable();
+
+            try
+            {
+                acquired = mutex.WaitOne(MutexTimeoutMs);
+            }
+            catch (AbandonedMutexException)
+            {
+                acquired = true;
+            }
+
+            if (!acquired)
+                return HwInfoReadAttempt.Busy();
+
+            var handle = NativeMethods.OpenFileMapping(FileMapRead, false, MappingName);
+            if (handle == IntPtr.Zero)
+                return HwInfoReadAttempt.Unavailable();
+
+            try
+            {
+                var view = NativeMethods.MapViewOfFile(handle, FileMapRead, 0, 0, UIntPtr.Zero);
+                if (view == IntPtr.Zero)
+                    return HwInfoReadAttempt.Unavailable();
+
+                try
+                {
+                    var bytes = CopyMapping(view);
+                    if (bytes.Length == 0)
+                        return HwInfoReadAttempt.Unavailable();
+
+                    var parsed = HwInfoParser.Parse(bytes);
+                    return parsed.Status == HwInfoParseStatus.Ok && parsed.Snapshot != null
+                        ? HwInfoReadAttempt.Success(parsed.Snapshot)
+                        : HwInfoReadAttempt.Unavailable();
+                }
+                finally
+                {
+                    NativeMethods.UnmapViewOfFile(view);
+                }
+            }
+            finally
+            {
+                NativeMethods.CloseHandle(handle);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "HWiNFO shared memory read failed");
+            return HwInfoReadAttempt.Unavailable();
+        }
+        finally
+        {
+            if (acquired)
+            {
+                try { mutex?.ReleaseMutex(); }
+                catch (ApplicationException) { }
+            }
+
+            mutex?.Dispose();
+        }
+    }
+
+    private static byte[] CopyMapping(IntPtr view)
+    {
+        var header = new byte[HwInfoParser.HeaderSizeWithPollingPeriod];
+        try
+        {
+            Marshal.Copy(view, header, 0, header.Length);
+        }
+        catch (AccessViolationException)
+        {
+            var shortHeader = new byte[HwInfoParser.MinHeaderSize];
+            Marshal.Copy(view, shortHeader, 0, shortHeader.Length);
+            header = shortHeader;
+        }
+
+        if (!HwInfoParser.TryReadHeader(header, out var parsedHeader))
+            return [];
+
+        if (parsedHeader.Signature == HwInfoParser.SignatureDead)
+            return header;
+
+        if (!HwInfoParser.IsHealthyActiveHeader(parsedHeader))
+            return header;
+
+        long sensorEnd = (long)parsedHeader.OffsetOfSensorSection
+            + (long)parsedHeader.SizeOfSensorElement * parsedHeader.NumSensorElements;
+        long readingEnd = (long)parsedHeader.OffsetOfReadingSection
+            + (long)parsedHeader.SizeOfReadingElement * parsedHeader.NumReadingElements;
+        var total = (int)Math.Max(sensorEnd, readingEnd);
+        if (total <= 0 || total > HwInfoParser.MaxSharedMemoryBytes)
+            return [];
+
+        var bytes = new byte[total];
+        Marshal.Copy(view, bytes, 0, total);
+        return bytes;
+    }
+
+    private static class NativeMethods
+    {
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern IntPtr OpenFileMapping(uint dwDesiredAccess, bool bInheritHandle, string lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr MapViewOfFile(
+            IntPtr hFileMappingObject,
+            uint dwDesiredAccess,
+            uint dwFileOffsetHigh,
+            uint dwFileOffsetLow,
+            UIntPtr dwNumberOfBytesToMap);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool UnmapViewOfFile(IntPtr lpBaseAddress);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CloseHandle(IntPtr hObject);
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/HwInfo/HwInfoSourcePolicy.cs
+++ b/HardwareMonitor/HardwareMonitor/HwInfo/HwInfoSourcePolicy.cs
@@ -1,0 +1,26 @@
+using HardwareMonitor.Monitor;
+
+namespace HardwareMonitor.HwInfo;
+
+public static class HwInfoSourcePolicy
+{
+    public static bool WantsHwInfo(SensorSourcePreference preference) =>
+        preference != SensorSourcePreference.Lhm;
+
+    public static bool ShouldReportFallback(
+        SensorSourcePreference preference,
+        bool usingHwInfo,
+        bool hwInfoSeenThisSession)
+    {
+        if (usingHwInfo)
+            return false;
+
+        return preference switch
+        {
+            SensorSourcePreference.Lhm => false,
+            SensorSourcePreference.Hwinfo => true,
+            SensorSourcePreference.Auto => hwInfoSeenThisSession,
+            _ => false,
+        };
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPacketCommand.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPacketCommand.cs
@@ -6,5 +6,19 @@ public enum MonitorPacketCommand : short
     RefreshPresentMonApps = 1,
     SelectPresentMonApp = 2,
     PresentMonApps = 3,
-    SelectPollingRate = 4
+    SelectPollingRate = 4,
+    SelectSensorSource = 5,
+}
+
+public enum SensorSourcePreference : short
+{
+    Auto = 0,
+    Lhm = 1,
+    Hwinfo = 2,
+}
+
+public enum ActiveSensorSource : byte
+{
+    Lhm = 0,
+    Hwinfo = 1,
 }

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -3,6 +3,7 @@
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using HardwareMonitor.HwInfo;
 using HardwareMonitor.PresentMon;
 using HardwareMonitor.SharedMemory;
 using HardwareMonitor.Sockets;
@@ -32,9 +33,14 @@ public class MonitorPoller(
 
     private PipeHost _socketHost = new(logger);
     private readonly PresentMonPoller _presentMonPoller = new(logger);
+    private readonly HwInfoReader _hwInfoReader = new(logger);
 
     private short _pollingRate = 500;
     private const short MinimalPollingRate = 33;
+    private SensorSourcePreference _sensorSource = SensorSourcePreference.Auto;
+    private bool _mappedFromHwInfo;
+    private bool _hwInfoSeenThisSession;
+    private HwInfoSnapshot? _lastHwInfoSnapshot;
 
     // How many times a change to the active sensor set is worth logging.
     private const int SensorSetChangeLogLimit = 5;
@@ -122,48 +128,70 @@ public class MonitorPoller(
                 continue;
             }
 
-            foreach (var hardware in sharedMemoryData.Hardwares)
+            var usingHwInfo = TryMapHwInfo(sharedMemoryData);
+            if (usingHwInfo)
             {
-                try
-                {
-                    hardware.Update();
-                }
-                catch
-                {
-                    hardware.StopUpdates();
-                    logger.LogError("Stopping updates of {HardwareName} - {HardwareIdentifier}", hardware.Name, hardware.Identifier);
-                }
+                sharedMemoryData.ActiveSensorSource = ActiveSensorSource.Hwinfo;
+                sharedMemoryData.SensorSourceFallback = false;
             }
-
-            // LibreHardwareMonitor only exposes a sensor once it has produced a
-            // reading (Hardware.Sensors returns the activated set). AMD GPUs read
-            // temperature, power, core load and memory load through ADL's PMLog
-            // sampling session, which has no sample yet on the first Update(),
-            // so those sensors activate a poll or two later: after the snapshot
-            // above was taken, and so were never sent to the app. Re-map the
-            // sensor list when that set changes so late arrivals still land.
-            //
-            // Hardware is re-mapped alongside it so a sensor is never sent
-            // referencing hardware the client has no entry for; MapHardwares
-            // reuses existing entries, so a StopUpdates() suspension above
-            // survives. On GPUs that activate everything up front (e.g. NVIDIA
-            // via NvAPI) the count never moves and this whole block is a no-op.
-            var activeSensorCount = CountActiveSensors();
-            if (activeSensorCount != knownSensorCount)
+            else
             {
-                // Capped: a sensor that flaps in and out would otherwise write a
-                // line every poll (CPU core temperatures deactivate themselves
-                // when a read fails). Only the logging is capped, never the
-                // re-map, so the data stays correct either way.
-                if (sensorSetChanges++ < SensorSetChangeLogLimit)
+                if (_mappedFromHwInfo)
                 {
                     logger.LogInformation(
-                        "Active sensor set changed ({Previous} -> {Current}); refreshing sensor list",
-                        knownSensorCount, activeSensorCount);
+                        "HWiNFO shared memory unavailable; falling back to LibreHardwareMonitor");
+                    MapHardwareData(sharedMemoryData);
+                    knownSensorCount = CountActiveSensors();
+                    _mappedFromHwInfo = false;
                 }
 
-                knownSensorCount = activeSensorCount;
-                MapHardwareData(sharedMemoryData);
+                foreach (var hardware in sharedMemoryData.Hardwares)
+                {
+                    try
+                    {
+                        hardware.Update();
+                    }
+                    catch
+                    {
+                        hardware.StopUpdates();
+                        logger.LogError("Stopping updates of {HardwareName} - {HardwareIdentifier}", hardware.Name, hardware.Identifier);
+                    }
+                }
+
+                // LibreHardwareMonitor only exposes a sensor once it has produced a
+                // reading (Hardware.Sensors returns the activated set). AMD GPUs read
+                // temperature, power, core load and memory load through ADL's PMLog
+                // sampling session, which has no sample yet on the first Update(),
+                // so those sensors activate a poll or two later: after the snapshot
+                // above was taken, and so were never sent to the app. Re-map the
+                // sensor list when that set changes so late arrivals still land.
+                //
+                // Hardware is re-mapped alongside it so a sensor is never sent
+                // referencing hardware the client has no entry for; MapHardwares
+                // reuses existing entries, so a StopUpdates() suspension above
+                // survives. On GPUs that activate everything up front (e.g. NVIDIA
+                // via NvAPI) the count never moves and this whole block is a no-op.
+                var activeSensorCount = CountActiveSensors();
+                if (activeSensorCount != knownSensorCount)
+                {
+                    // Capped: a sensor that flaps in and out would otherwise write a
+                    // line every poll (CPU core temperatures deactivate themselves
+                    // when a read fails). Only the logging is capped, never the
+                    // re-map, so the data stays correct either way.
+                    if (sensorSetChanges++ < SensorSetChangeLogLimit)
+                    {
+                        logger.LogInformation(
+                            "Active sensor set changed ({Previous} -> {Current}); refreshing sensor list",
+                            knownSensorCount, activeSensorCount);
+                    }
+
+                    knownSensorCount = activeSensorCount;
+                    MapHardwareData(sharedMemoryData);
+                }
+
+                sharedMemoryData.ActiveSensorSource = ActiveSensorSource.Lhm;
+                sharedMemoryData.SensorSourceFallback = HwInfoSourcePolicy.ShouldReportFallback(
+                    _sensorSource, usingHwInfo: false, _hwInfoSeenThisSession);
             }
 
             WriteDataToStream(writer, sharedMemoryData);
@@ -213,7 +241,7 @@ public class MonitorPoller(
 
         foreach (var sensor in sharedMemoryData.Sensors)
         {
-            var value = sensor.HardwareSensor.Value ?? 0f;
+            var value = sensor.HardwareSensor?.Value ?? sensor.Value;
             var floatValue = (IsNaN(value) ? 0f : value).ToString(CultureInfo.InvariantCulture);
             sensor.Value = float.Parse(floatValue, CultureInfo.InvariantCulture);
 
@@ -226,6 +254,11 @@ public class MonitorPoller(
             writer.Write((int)sensor.SensorType);
             writer.Write((float)sensor.Value);
         }
+
+        writer.Write((byte)sharedMemoryData.ActiveSensorSource);
+        writer.Write(sharedMemoryData.SensorSourceFallback ? (byte)1 : (byte)0);
+        writer.Flush();
+        writer.BaseStream.SetLength(writer.BaseStream.Position);
     }
 
     private void OnClientConnected()
@@ -248,6 +281,9 @@ public class MonitorPoller(
             case MonitorPacketCommand.SelectPollingRate:
                 SelectPollingRate(data);
                 break;
+            case MonitorPacketCommand.SelectSensorSource:
+                SelectSensorSource(data);
+                break;
 
             // server -> client cases 
             case MonitorPacketCommand.Data:
@@ -264,6 +300,87 @@ public class MonitorPoller(
         var pollingRate = BitConverter.ToInt16(data, 2);
         _pollingRate = Math.Max(pollingRate, MinimalPollingRate);
         logger.LogInformation("Selected polling rate of {PollingRate}", _pollingRate);
+    }
+
+    private void SelectSensorSource(byte[] data)
+    {
+        var source = (SensorSourcePreference)BitConverter.ToInt16(data, 2);
+        if (!Enum.IsDefined(source))
+        {
+            logger.LogWarning("Ignoring unknown sensor source {Source}", source);
+            return;
+        }
+
+        _sensorSource = source;
+        if (source == SensorSourcePreference.Lhm)
+        {
+            _hwInfoSeenThisSession = false;
+            _lastHwInfoSnapshot = null;
+        }
+
+        logger.LogInformation("Selected sensor source {Source}", _sensorSource);
+    }
+
+    /// <summary>
+    /// Tries to replace the published hardware/sensor lists with HWiNFO SHM
+    /// readings. Returns false when LHM should be used instead. PresentMon
+    /// sensors are always appended so FPS stays on our session.
+    /// </summary>
+    private bool TryMapHwInfo(SharedMemoryData sharedMemoryData)
+    {
+        if (!HwInfoSourcePolicy.WantsHwInfo(_sensorSource))
+            return false;
+
+        var attempt = _hwInfoReader.TryRead();
+        HwInfoSnapshot? snapshot = null;
+        switch (attempt.Status)
+        {
+            case HwInfoReadStatus.Success:
+                snapshot = attempt.Snapshot;
+                break;
+            case HwInfoReadStatus.Busy:
+                if (_mappedFromHwInfo)
+                    snapshot = _lastHwInfoSnapshot;
+                break;
+        }
+
+        if (snapshot == null || snapshot.Sensors.Count == 0)
+            return false;
+
+        if (!_mappedFromHwInfo)
+            logger.LogInformation("Hardware sensors now from HWiNFO shared memory");
+
+        _hwInfoSeenThisSession = true;
+        _lastHwInfoSnapshot = snapshot;
+        _mappedFromHwInfo = true;
+        MapHwInfoData(sharedMemoryData, snapshot);
+        return true;
+    }
+
+    private void MapHwInfoData(SharedMemoryData sharedMemoryData, HwInfoSnapshot snapshot)
+    {
+        sharedMemoryData.Hardwares = snapshot.Hardwares.ConvertAll(hardware => new SharedMemoryHardware
+        {
+            Name = hardware.Name,
+            Identifier = hardware.Identifier,
+            HardwareType = (LibreHardwareMonitor.Hardware.HardwareType)hardware.HardwareType,
+        });
+        var sensorList = new List<SharedMemorySensor>(snapshot.Sensors.Count + 3);
+        foreach (var sensor in snapshot.Sensors)
+        {
+            sensorList.Add(new SharedMemorySensor
+            {
+                Name = sensor.Name,
+                Identifier = sensor.Identifier,
+                HardwareIdentifier = sensor.HardwareIdentifier,
+                SensorType = (LibreHardwareMonitor.Hardware.SensorType)sensor.SensorType,
+                Value = sensor.Value,
+            });
+        }
+        sensorList.Add(MapSensor(_presentMonPoller.Displayed));
+        sensorList.Add(MapSensor(_presentMonPoller.Presented));
+        sensorList.Add(MapSensor(_presentMonPoller.Frametime));
+        sharedMemoryData.Sensors = sensorList;
     }
 
     private void SelectPresentMonApp(byte[] data)

--- a/HardwareMonitor/HardwareMonitor/SharedMemory/SharedMemory.cs
+++ b/HardwareMonitor/HardwareMonitor/SharedMemory/SharedMemory.cs
@@ -1,4 +1,5 @@
-﻿using LibreHardwareMonitor.Hardware;
+﻿using HardwareMonitor.Monitor;
+using LibreHardwareMonitor.Hardware;
 
 namespace HardwareMonitor.SharedMemory;
 
@@ -30,7 +31,7 @@ public static class SharedMemoryConsts
 
 public class SharedMemoryHardware
 {
-    public required IHardware Hardware;
+    public IHardware? Hardware;
     public required string Name { get; set; }
     public required string Identifier { get; set; }
     public required HardwareType HardwareType { get; set; }
@@ -39,7 +40,7 @@ public class SharedMemoryHardware
 
     public void Update()
     {
-        if (_isActive)
+        if (_isActive && Hardware != null)
         {
             Hardware.Update();
         }
@@ -53,7 +54,7 @@ public class SharedMemoryHardware
 
 public class SharedMemorySensor
 {
-    public required ISensor HardwareSensor;
+    public ISensor? HardwareSensor;
     public required string Name { get; set; }
     public required string Identifier { get; set; }
     public required string HardwareIdentifier { get; set; }
@@ -66,4 +67,6 @@ public class SharedMemoryData
     public long LastPollTime { get; set; }
     public List<SharedMemoryHardware> Hardwares { get; set; } = [];
     public List<SharedMemorySensor> Sensors { get; set; } = [];
+    public ActiveSensorSource ActiveSensorSource { get; set; } = ActiveSensorSource.Lhm;
+    public bool SensorSourceFallback { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A clean, minimal performance overlay for gamers. Monitor your system stats witho
 
 - **Real-time overlay** — FPS, CPU, GPU, RAM, and network stats displayed as a clean pill bar on your screen
 - **Auto-start monitoring** — sensors connect automatically on launch, overlay shows up instantly
+- **Optional HWiNFO** — use HWiNFO shared memory for hardware sensors when you enable it; FPS still comes from PresentMon
 - **Light & dark mode** — overlay adapts to your preference with proper contrast
 - **Customizable** — adjust font sizes, opacity, and choose which sensors to display
 - **Borderless fullscreen support** — overlay stays on top in borderless windowed games

--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -278,6 +278,23 @@ pub async fn set_polling_rate(
         .map_err(|e| format!("Failed to send command: {}", e))
 }
 
+#[tauri::command]
+pub async fn set_sensor_source(
+    source: String,
+    sender: State<'_, PipeCommandSender>,
+) -> Result<(), String> {
+    let value: u16 = match source.as_str() {
+        "lhm" => 1,
+        "hwinfo" => 2,
+        _ => 0,
+    };
+    sender
+        .0
+        .send(PipeCommand::SelectSensorSource(value))
+        .await
+        .map_err(|e| format!("Failed to send command: {}", e))
+}
+
 // ─── System Commands ────────────────────────────────────────────
 
 // Autostart via a Scheduled Task rather than the HKCU Run key. The exe is

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -664,6 +664,7 @@ pub fn run() {
             commands::select_present_mon_app,
             commands::refresh_present_mon_apps,
             commands::set_polling_rate,
+            commands::set_sensor_source,
             commands::check_dotnet_runtime,
             commands::set_auto_start,
             commands::get_auto_start,

--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -44,6 +44,7 @@ pub enum PipeCommand {
     RefreshPresentMonApps,
     SelectPresentMonApp(String),
     SelectPollingRate(u16),
+    SelectSensorSource(u16),
 }
 
 /// Parse a Data packet (command 0) from raw bytes
@@ -165,6 +166,23 @@ fn parse_data_packet(data: &[u8]) -> Result<HardwareMonitorData, String> {
         });
     }
 
+    let mut active_sensor_source = ActiveSensorSource::Lhm;
+    let mut sensor_source_fallback = false;
+    if cursor.position() as usize + 2 <= data.len() {
+        let source = cursor
+            .read_u8()
+            .map_err(|e| format!("active sensor source: {}", e))?;
+        let fallback = cursor
+            .read_u8()
+            .map_err(|e| format!("sensor source fallback: {}", e))?;
+        active_sensor_source = if source == 1 {
+            ActiveSensorSource::Hwinfo
+        } else {
+            ActiveSensorSource::Lhm
+        };
+        sensor_source_fallback = fallback != 0;
+    }
+
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -174,6 +192,8 @@ fn parse_data_packet(data: &[u8]) -> Result<HardwareMonitorData, String> {
         hardwares,
         sensors,
         last_poll_time: now,
+        active_sensor_source,
+        sensor_source_fallback,
     })
 }
 
@@ -221,6 +241,10 @@ fn build_command(cmd: &PipeCommand) -> Vec<u8> {
         PipeCommand::SelectPollingRate(rate) => {
             buf.write_u16::<LittleEndian>(4).unwrap();
             buf.write_u16::<LittleEndian>(*rate).unwrap();
+        }
+        PipeCommand::SelectSensorSource(source) => {
+            buf.write_u16::<LittleEndian>(5).unwrap();
+            buf.write_u16::<LittleEndian>(*source).unwrap();
         }
     }
     buf
@@ -572,6 +596,19 @@ mod tests {
         assert_eq!(parsed.sensors.len(), 2);
         assert_eq!(parsed.hardwares[0].name, "CPU");
         assert_eq!(parsed.sensors[1].name, "GPU Core");
+        assert_eq!(parsed.active_sensor_source, ActiveSensorSource::Lhm);
+        assert!(!parsed.sensor_source_fallback);
+    }
+
+    #[test]
+    fn source_status_trailer_is_parsed() {
+        let mut packet = data_packet(&[("CPU", "/hwinfo/e0000200/0")], &[("CPU Package", "/hwinfo/e0000200/0/100", "/hwinfo/e0000200/0")]);
+        packet.push(1); // HWiNFO
+        packet.push(1); // fallback
+        let parsed = parse_data_packet(&packet).expect("trailer must parse");
+        assert_eq!(parsed.active_sensor_source, ActiveSensorSource::Hwinfo);
+        assert!(parsed.sensor_source_fallback);
+        assert_eq!(parsed.sensors[0].identifier, "/hwinfo/e0000200/0/100");
     }
 
     /// An empty snapshot is what the sidecar sends before LibreHardwareMonitor

--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -9,6 +9,7 @@ pub enum Command {
     SelectPresentMonApp = 2,
     PresentMonApps = 3,
     SelectPollingRate = 4,
+    SelectSensorSource = 5,
 }
 
 impl TryFrom<u16> for Command {
@@ -20,6 +21,7 @@ impl TryFrom<u16> for Command {
             2 => Ok(Command::SelectPresentMonApp),
             3 => Ok(Command::PresentMonApps),
             4 => Ok(Command::SelectPollingRate),
+            5 => Ok(Command::SelectSensorSource),
             _ => Err(format!("Unknown command: {}", value)),
         }
     }
@@ -115,6 +117,23 @@ impl From<u32> for SensorType {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SensorSource {
+    #[default]
+    Auto,
+    Lhm,
+    Hwinfo,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ActiveSensorSource {
+    #[default]
+    Lhm,
+    Hwinfo,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Hardware {
     pub name: String,
@@ -140,6 +159,10 @@ pub struct HardwareMonitorData {
     pub sensors: Vec<Sensor>,
     #[serde(rename = "lastPollTime")]
     pub last_poll_time: i64,
+    #[serde(rename = "activeSensorSource", default)]
+    pub active_sensor_source: ActiveSensorSource,
+    #[serde(rename = "sensorSourceFallback", default)]
+    pub sensor_source_fallback: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
@@ -349,6 +372,11 @@ pub struct OverlaySettings {
     // struct comment above).
     #[serde(rename = "pixelShift", default)]
     pub pixel_shift: bool,
+    // Hardware sensor backend. `auto` uses HWiNFO shared memory when that
+    // mapping is healthy and LibreHardwareMonitor otherwise. FPS always stays
+    // on Cleanmeter's PresentMon session.
+    #[serde(rename = "sensorSource", default)]
+    pub sensor_source: SensorSource,
     pub sensors: SensorsConfig,
 }
 
@@ -379,6 +407,7 @@ impl Default for OverlaySettings {
             polling_rate: 500,
             is_logging_enabled: false,
             pixel_shift: false,
+            sensor_source: SensorSource::Auto,
             sensors: SensorsConfig::default(),
         }
     }
@@ -442,4 +471,45 @@ pub struct MonitorInfo {
     pub x: i32,
     pub y: i32,
     pub primary: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sensor_source_round_trips_on_overlay_settings() {
+        let mut settings = OverlaySettings::default();
+        assert_eq!(settings.sensor_source, SensorSource::Auto);
+
+        settings.sensor_source = SensorSource::Hwinfo;
+        let json = serde_json::to_string(&settings).expect("serialize");
+        assert!(json.contains("\"sensorSource\":\"hwinfo\""), "{json}");
+
+        let back: OverlaySettings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.sensor_source, SensorSource::Hwinfo);
+
+        settings.sensor_source = SensorSource::Lhm;
+        let json = serde_json::to_string(&settings).expect("serialize");
+        let back: OverlaySettings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.sensor_source, SensorSource::Lhm);
+    }
+
+    #[test]
+    fn missing_sensor_source_defaults_to_auto() {
+        let json = serde_json::to_string(&OverlaySettings::default()).unwrap();
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        value.as_object_mut().unwrap().remove("sensorSource");
+        let stripped = serde_json::to_string(&value).unwrap();
+        let loaded: OverlaySettings = serde_json::from_str(&stripped).unwrap();
+        assert_eq!(loaded.sensor_source, SensorSource::Auto);
+    }
+
+    #[test]
+    fn hardware_monitor_data_defaults_source_status() {
+        let json = r#"{"hardwares":[],"sensors":[],"lastPollTime":1}"#;
+        let data: HardwareMonitorData = serde_json::from_str(json).unwrap();
+        assert_eq!(data.active_sensor_source, ActiveSensorSource::Lhm);
+        assert!(!data.sensor_source_fallback);
+    }
 }

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -50,32 +50,47 @@ function MonitoringBanner() {
       .catch(() => {});
   }, [verdict]);
 
-  if (verdict !== "failed") return null;
+  if (verdict === "failed") {
+    return (
+      <div className="border-b border-yellow-400 bg-yellow-50 px-4 py-2.5 text-[13px] leading-snug text-yellow-900 dark:border-yellow-700 dark:bg-yellow-950 dark:text-yellow-200">
+        <strong>Monitoring not connected.</strong>
+        {dotnetMissing ? (
+          <span>
+            {" "}.NET 8 Desktop Runtime is required but not installed.{" "}
+            <a
+              href="https://dotnet.microsoft.com/en-us/download/dotnet/8.0"
+              target="_blank"
+              rel="noreferrer"
+              className="text-blue-600 underline dark:text-blue-400"
+            >
+              Download it here
+            </a>
+            , install it, then restart Cleanmeter.
+          </span>
+        ) : (
+          <span>
+            {" "}HardwareMonitor is not responding. Try restarting the app.
+            {!pipeStatus.connected && " (Pipe not connected)"}
+          </span>
+        )}
+      </div>
+    );
+  }
 
-  return (
-    <div className="border-b border-yellow-400 bg-yellow-50 px-4 py-2.5 text-[13px] leading-snug text-yellow-900 dark:border-yellow-700 dark:bg-yellow-950 dark:text-yellow-200">
-      <strong>Monitoring not connected.</strong>
-      {dotnetMissing ? (
+  if (sensorData?.sensorSourceFallback) {
+    return (
+      <div className="border-b border-yellow-400 bg-yellow-50 px-4 py-2.5 text-[13px] leading-snug text-yellow-900 dark:border-yellow-700 dark:bg-yellow-950 dark:text-yellow-200">
+        <strong>Using LibreHardwareMonitor.</strong>
         <span>
-          {" "}.NET 8 Desktop Runtime is required but not installed.{" "}
-          <a
-            href="https://dotnet.microsoft.com/en-us/download/dotnet/8.0"
-            target="_blank"
-            rel="noreferrer"
-            className="text-blue-600 underline dark:text-blue-400"
-          >
-            Download it here
-          </a>
-          , install it, then restart Cleanmeter.
+          {" "}HWiNFO shared memory dropped — Shared Memory Support may be off,
+          HWiNFO may have closed, or the free 12-hour limit may have deactivated
+          sharing. FPS still comes from PresentMon.
         </span>
-      ) : (
-        <span>
-          {" "}HardwareMonitor is not responding. Try restarting the app.
-          {!pipeStatus.connected && " (Pipe not connected)"}
-        </span>
-      )}
-    </div>
-  );
+      </div>
+    );
+  }
+
+  return null;
 }
 
 export default function App() {

--- a/tauri-app/src/components/settings/AboutTab.tsx
+++ b/tauri-app/src/components/settings/AboutTab.tsx
@@ -78,21 +78,28 @@ function HowToSetupCard() {
     <CollapsibleCard title="How to setup">
       <ol className="flex flex-col gap-3">
         <Step n={1}>
+          Launch Cleanmeter. Hardware sensors connect automatically through
+          LibreHardwareMonitor, and FPS comes from Cleanmeter&rsquo;s PresentMon.
+        </Step>
+        <Step n={2}>
+          Optional: run{" "}
           <a
             href="https://www.hwinfo.com/"
             target="_blank"
             rel="noreferrer noopener"
             className="underline underline-offset-2"
           >
-            Download HWinfo
+            HWiNFO
           </a>{" "}
-          and launch it, make sure to turn off other overlay&rsquo;s.
+          yourself and enable Shared Memory Support, then set Hardware sensors
+          to Auto or HWiNFO in Settings. Cleanmeter will not launch HWiNFO for
+          you.
         </Step>
-        <Step n={2}>
-          Under general setting, make sure to check the &ldquo;Shared Memory
-          Support&rdquo; box
+        <Step n={3}>
+          If HWiNFO shared memory drops (closed, sharing off, or the free
+          12-hour limit), sensors fall back to LibreHardwareMonitor so the
+          overlay keeps working.
         </Step>
-        <Step n={3}>That&rsquo;s it! it should run flawlessly now :D</Step>
       </ol>
 
       {WATCH_VIDEO_URL && (
@@ -154,8 +161,8 @@ function FaqCard() {
     <CollapsibleCard title="Frequently asked questions">
       <ol className="flex list-decimal flex-col gap-4 pl-5 marker:text-foreground marker:font-medium">
         <FaqItem
-          q="Why do I need to download a third party app to run it?"
-          a="It’s a workaround for now, we will try to make it a stand alone app in the future."
+          q="Do I need to download a third party app to run it?"
+          a="No. Sensors connect automatically. HWiNFO is optional if you want its shared-memory readings — run it yourself with Shared Memory Support enabled."
         />
         <FaqItem
           q="Need more support?"

--- a/tauri-app/src/components/settings/help/FaqSection.tsx
+++ b/tauri-app/src/components/settings/help/FaqSection.tsx
@@ -13,6 +13,11 @@ const FAQ_ITEMS: FaqItem[] = [
     answer: "Cleanmeter currently doesn’t support fullscreen in games.",
   },
   {
+    question: "Do I need HWiNFO?",
+    answer:
+      "No. Sensors connect automatically through LibreHardwareMonitor, and FPS\ncomes from Cleanmeter’s PresentMon. HWiNFO is optional: run it yourself,\nenable Shared Memory Support, and choose Auto or HWiNFO in Settings.\nThe free HWiNFO64 edition turns shared memory off after 12 hours; Cleanmeter\nfalls back to LibreHardwareMonitor so the overlay keeps working.",
+  },
+  {
     question: "Is Cleanmeter resource-heavy?",
     answer:
       "No! Cleanmeter is designed to be lightweight and efficient, ensuring it runs\nsmoothly without impacting your system’s performance.",

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -15,7 +15,7 @@ import { getAutoStart, setAutoStart } from "@/lib/tauri";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useUpdaterStore } from "@/stores/updater-store";
 import { POLLING_RATES } from "@/lib/types";
-import type { TemperatureUnit } from "@/lib/types";
+import type { SensorSource, TemperatureUnit } from "@/lib/types";
 import {
   BrowserUpdatedIcon,
   ChevronRightIcon,
@@ -205,6 +205,59 @@ function PollingRateSection() {
   );
 }
 
+const SENSOR_SOURCE_OPTIONS: { value: SensorSource; label: string }[] = [
+  { value: "auto", label: "Auto (HWiNFO when available)" },
+  { value: "lhm", label: "LibreHardwareMonitor" },
+  { value: "hwinfo", label: "HWiNFO" },
+];
+
+function HardwareSensorsSection() {
+  const sensorSource = useSettingsStore((s) => s.settings.sensorSource);
+  const updateSettings = useSettingsStore((s) => s.updateSettings);
+  const fallback = useSettingsStore((s) => s.sensorData?.sensorSourceFallback);
+
+  return (
+    <SectionCard title="Hardware sensors">
+      <div className="flex flex-col gap-3">
+        <Select
+          value={sensorSource ?? "auto"}
+          onValueChange={(v) => updateSettings({ sensorSource: v as SensorSource })}
+        >
+          <SelectTrigger className="w-full rounded-[8px] border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] font-medium shadow-[0_1px_2px_rgba(16,24,40,0.05)]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SENSOR_SOURCE_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <div className="flex items-start gap-2 text-[12px] font-medium text-muted-foreground">
+          <InfoIcon className="mt-0.5 size-4 shrink-0" />
+          <span>
+            Optional HWiNFO shared memory for CPU, GPU, RAM, and network sensors.
+            Run HWiNFO yourself and enable Shared Memory Support. FPS still comes
+            from Cleanmeter&apos;s PresentMon. The free HWiNFO64 edition turns
+            shared memory off after 12 hours.
+          </span>
+        </div>
+        {fallback && (
+          <div className="flex items-start gap-2 text-[12px] font-medium text-muted-foreground">
+            <InfoIcon className="mt-0.5 size-4 shrink-0" />
+            <span>
+              HWiNFO shared memory dropped, so sensors are using LibreHardwareMonitor.
+              Shared Memory Support may be off, HWiNFO may have closed, or the free
+              12-hour limit may have deactivated sharing.
+            </span>
+          </div>
+        )}
+      </div>
+    </SectionCard>
+  );
+}
+
 type ThemeChoice = "light" | "dark" | "system";
 
 const THEME_OPTIONS: {
@@ -388,6 +441,7 @@ export function SettingsTab() {
         <GeneralSection />
         <TemperatureUnitsSection />
         <PollingRateSection />
+        <HardwareSensorsSection />
         <AppearanceSection />
       </div>
       <div className="flex w-full flex-col gap-6">

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -234,7 +234,7 @@ function HardwareSensorsSection() {
             ))}
           </SelectContent>
         </Select>
-        <div className="flex items-start gap-2 text-[12px] font-medium text-muted-foreground">
+        <div className="flex items-start gap-2 text-[12px] font-medium text-[var(--textParagraph1)]">
           <InfoIcon className="mt-0.5 size-4 shrink-0" />
           <span>
             Optional HWiNFO shared memory for CPU, GPU, RAM, and network sensors.
@@ -244,7 +244,7 @@ function HardwareSensorsSection() {
           </span>
         </div>
         {fallback && (
-          <div className="flex items-start gap-2 text-[12px] font-medium text-muted-foreground">
+          <div className="flex items-start gap-2 text-[12px] font-medium text-[var(--textParagraph1)]">
             <InfoIcon className="mt-0.5 size-4 shrink-0" />
             <span>
               HWiNFO shared memory dropped, so sensors are using LibreHardwareMonitor.

--- a/tauri-app/src/components/settings/stats/NetworkSection.tsx
+++ b/tauri-app/src/components/settings/stats/NetworkSection.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { Info } from "lucide-react";
 import type { Sensor, Hardware } from "@/lib/types";
 import { HardwareType, SensorType } from "@/lib/types";
+import { isDownloadSensorName, isUploadSensorName } from "@/lib/sensor-source";
 import { useSettingsStore } from "@/stores/settings-store";
 import { Checkbox } from "@/components/shadcn/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/shadcn/radio-group";
@@ -33,13 +34,8 @@ export function NetworkSection({ sensors, hardwares }: Props) {
     const adapterSensors = sensors.filter(
       (s) => s.hardwareIdentifier === adapterId && s.sensorType === SensorType.Throughput,
     );
-    const down = adapterSensors.find(
-      (s) =>
-        s.name.toLowerCase().includes("download") || s.name.toLowerCase().includes("down"),
-    );
-    const up = adapterSensors.find(
-      (s) => s.name.toLowerCase().includes("upload") || s.name.toLowerCase().includes("up"),
-    );
+    const down = adapterSensors.find((s) => isDownloadSensorName(s.name));
+    const up = adapterSensors.find((s) => isUploadSensorName(s.name));
     if (down) updateSensor("downRate", { customReadingId: down.identifier });
     if (up) updateSensor("upRate", { customReadingId: up.identifier });
   };

--- a/tauri-app/src/lib/sensor-source.test.ts
+++ b/tauri-app/src/lib/sensor-source.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS } from "./types";
+import {
+  customReadingNeedsRefresh,
+  isDownloadSensorName,
+  isUploadSensorName,
+} from "./sensor-source";
+import type { Sensor } from "./types";
+import { SensorType } from "./types";
+
+describe("DEFAULT_SETTINGS.sensorSource", () => {
+  it("defaults to auto so HWiNFO is used when shared memory is healthy", () => {
+    expect(DEFAULT_SETTINGS.sensorSource).toBe("auto");
+  });
+});
+
+const sensor = (identifier: string): Sensor => ({
+  name: identifier,
+  identifier,
+  hardwareIdentifier: "/hw",
+  sensorType: SensorType.Load,
+  value: 1,
+});
+
+describe("customReadingNeedsRefresh", () => {
+  it("refills empty and stale LHM/HWiNFO ids, but never PresentMon", () => {
+    const live = [sensor("/hwinfo/e0000200/0/100")];
+    expect(customReadingNeedsRefresh("", live)).toBe(true);
+    expect(customReadingNeedsRefresh("/amdcpu/0/load/0", live)).toBe(true);
+    expect(customReadingNeedsRefresh("/hwinfo/e0000200/0/100", live)).toBe(false);
+    expect(customReadingNeedsRefresh("/presentmon/presented", live)).toBe(false);
+  });
+});
+
+describe("HWiNFO network labels", () => {
+  it("treats DL/UP rate labels as download/upload", () => {
+    expect(isDownloadSensorName("Current DL rate")).toBe(true);
+    expect(isUploadSensorName("Current UP rate")).toBe(true);
+    expect(isDownloadSensorName("Download")).toBe(true);
+    expect(isUploadSensorName("CPU")).toBe(false);
+  });
+});

--- a/tauri-app/src/lib/sensor-source.ts
+++ b/tauri-app/src/lib/sensor-source.ts
@@ -1,0 +1,21 @@
+import type { Sensor } from "./types";
+
+/** True when a saved customReadingId is missing from the live sensor list. */
+export function customReadingNeedsRefresh(
+  customReadingId: string,
+  sensors: Sensor[],
+): boolean {
+  if (!customReadingId) return true;
+  if (customReadingId.startsWith("/presentmon/")) return false;
+  return !sensors.some((s) => s.identifier === customReadingId);
+}
+
+export function isDownloadSensorName(name: string): boolean {
+  const n = name.toLowerCase();
+  return n.includes("download") || n.includes("down") || /(^|[^a-z])dl([^a-z]|$)/.test(n);
+}
+
+export function isUploadSensorName(name: string): boolean {
+  const n = name.toLowerCase();
+  return n.includes("upload") || /(^|[^a-z])up([^a-z]|$)/.test(n);
+}

--- a/tauri-app/src/lib/tauri.ts
+++ b/tauri-app/src/lib/tauri.ts
@@ -64,6 +64,8 @@ export const refreshPresentMonApps = () =>
   safeInvoke("refresh_present_mon_apps");
 export const setPollingRate = (intervalMs: number) =>
   safeInvoke("set_polling_rate", { intervalMs });
+export const setSensorSource = (source: OverlaySettings["sensorSource"]) =>
+  safeInvoke("set_sensor_source", { source });
 
 // ─── System Commands ────────────────────────────────────────────
 

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -81,6 +81,8 @@ export interface SensorsConfig {
 export type TemperatureUnit = "C" | "F";
 export type ThemeMode = "light" | "dark" | "system";
 export type GraphType = "ring" | "bar";
+export type SensorSource = "auto" | "lhm" | "hwinfo";
+export type ActiveSensorSource = "lhm" | "hwinfo";
 
 export interface OverlaySettings {
   isDarkTheme: boolean;
@@ -109,6 +111,9 @@ export interface OverlaySettings {
   // When true, the overlay is nudged a few pixels on a slow cycle to spread
   // OLED wear (burn-in mitigation). See pixel-shift logic in OverlayApp.
   pixelShift: boolean;
+  // Hardware sensors: HWiNFO shared memory when healthy (`auto`/`hwinfo`),
+  // otherwise LibreHardwareMonitor. FPS always stays on PresentMon.
+  sensorSource: SensorSource;
   sensors: SensorsConfig;
 }
 
@@ -130,6 +135,8 @@ export interface HardwareMonitorData {
   hardwares: Hardware[];
   sensors: Sensor[];
   lastPollTime: number;
+  activeSensorSource?: ActiveSensorSource;
+  sensorSourceFallback?: boolean;
 }
 
 export interface PipeStatus {
@@ -199,6 +206,7 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   pollingRate: 500,
   isLoggingEnabled: false,
   pixelShift: false,
+  sensorSource: "auto",
   sensors: {
     framerate: { isEnabled: true, customReadingId: "", targetAppName: "" },
     frametime: { isEnabled: true, customReadingId: "" },

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -14,6 +14,11 @@ import type {
 } from "@/lib/types";
 import { DEFAULT_SETTINGS, HardwareType, SensorType } from "@/lib/types";
 import * as tauri from "@/lib/tauri";
+import {
+  customReadingNeedsRefresh,
+  isDownloadSensorName,
+  isUploadSensorName,
+} from "@/lib/sensor-source";
 
 function findBest(
   sensors: Sensor[],
@@ -56,12 +61,11 @@ function autoSelectSensors(
     prefer: string[]
   ) => {
     const current = settings.sensors[key];
-    if (!current.customReadingId) {
-      const id = findBest(sensors, hardwares, hwTypes, sType, prefer);
-      if (id) {
-        patch[key] = { ...current, customReadingId: id } as OverlaySettings["sensors"][K];
-        changed = true;
-      }
+    if (!customReadingNeedsRefresh(current.customReadingId, sensors)) return;
+    const id = findBest(sensors, hardwares, hwTypes, sType, prefer);
+    if (id) {
+      patch[key] = { ...current, customReadingId: id } as OverlaySettings["sensors"][K];
+      changed = true;
     }
   };
 
@@ -75,7 +79,10 @@ function autoSelectSensors(
   tryFill("gpuConsumption", gpuHw, SensorType.Power, ["GPU Package", "GPU Power", "GPU"]);
   tryFill("ramUsage", [HardwareType.Memory], SensorType.Load, ["Memory Used", "Memory"]);
   // For network, pick the most active non-virtual adapter
-  if (!settings.sensors.downRate.customReadingId || !settings.sensors.upRate.customReadingId) {
+  if (
+    customReadingNeedsRefresh(settings.sensors.downRate.customReadingId, sensors) ||
+    customReadingNeedsRefresh(settings.sensors.upRate.customReadingId, sensors)
+  ) {
     const netHwIds = new Set(
       hardwares.filter((h) => h.hardwareType === HardwareType.Network).map((h) => h.identifier)
     );
@@ -93,12 +100,12 @@ function autoSelectSensors(
     if (sortedNics.length > 0) {
       const bestNicId = sortedNics[0][0];
       const nicSensors = netSensors.filter((s) => s.hardwareIdentifier === bestNicId);
-      if (!settings.sensors.downRate.customReadingId) {
-        const s = nicSensors.find((s) => s.name.toLowerCase().includes("download") || s.name.toLowerCase().includes("down"));
+      if (customReadingNeedsRefresh(settings.sensors.downRate.customReadingId, sensors)) {
+        const s = nicSensors.find((s) => isDownloadSensorName(s.name));
         if (s) { patch["downRate"] = { ...settings.sensors.downRate, customReadingId: s.identifier }; changed = true; }
       }
-      if (!settings.sensors.upRate.customReadingId) {
-        const s = nicSensors.find((s) => s.name.toLowerCase().includes("upload") || s.name.toLowerCase().includes("up"));
+      if (customReadingNeedsRefresh(settings.sensors.upRate.customReadingId, sensors)) {
+        const s = nicSensors.find((s) => isUploadSensorName(s.name));
         if (s) { patch["upRate"] = { ...settings.sensors.upRate, customReadingId: s.identifier }; changed = true; }
       }
     }
@@ -255,6 +262,9 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       if (!saved?.themeMode) {
         settings.themeMode = settings.isDarkTheme ? "dark" : "light";
       }
+      if (!saved?.sensorSource) {
+        settings.sensorSource = "auto";
+      }
       // Migrate older builds that wrote the chosen PresentMon app into
       // framerate.customReadingId. customReadingId is now strictly a sensor
       // identifier (e.g. "/presentmon/displayed"); the chosen app lives in
@@ -305,6 +315,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       // Push the persisted target-app to the C# poller so it starts in sync.
       // Empty string means Auto (foreground-window detection on the C# side).
       tauri.selectPresentMonApp(settings.sensors.framerate.targetAppName || "Auto");
+      tauri.setPollingRate(settings.pollingRate);
+      tauri.setSensorSource(settings.sensorSource);
     } catch (err) {
       // The store keeps DEFAULT_SETTINGS, which is a usable overlay — but say so
       // rather than swallowing it, otherwise a settings file that fails to parse
@@ -323,6 +335,9 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     }
     if (patch.pollingRate !== undefined) {
       tauri.setPollingRate(patch.pollingRate);
+    }
+    if (patch.sensorSource !== undefined) {
+      tauri.setSensorSource(patch.sensorSource);
     }
   },
 
@@ -436,6 +451,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     if (status.connected && !wasConnected) {
       const target = get().settings.sensors.framerate.targetAppName;
       tauri.selectPresentMonApp(target || "Auto");
+      tauri.setPollingRate(get().settings.pollingRate);
+      tauri.setSensorSource(get().settings.sensorSource);
     }
   },
 


### PR DESCRIPTION
Hardware sensors can optionally come from HWiNFO shared memory. FPS / frametime / displayed FPS stay on Cleanmeter’s PresentMon session. LibreHardwareMonitor is still the default and the fallback.

## What changed

- C# sidecar reads `Global\HWiNFO_SENS_SM2` under `Global\HWiNFO_SM2_MUTEX`, re-opens the mapping each poll, and maps readings into the existing `HardwareMonitorData` / named-pipe / `customReadingId` path.
- Stable identifiers are `/hwinfo/{sensorId}/{instance}/{readingId}` so the sensor picker does not depend on English labels.
- New settings field `sensorSource: "auto" | "lhm" | "hwinfo"` on both Rust `OverlaySettings` and the TypeScript settings type.
- `auto` uses HWiNFO when the mapping is healthy (`HWiS`), otherwise LHM. `hwinfo` prefers HWiNFO and still falls back. `lhm` stays on LHM.
- PresentMon sensors (`/presentmon/displayed`, `/presentmon/presented`, `/presentmon/frametime`) are always injected. HWiNFO is never launched or bundled.
- About/Help copy no longer tells users they must download HWiNFO to run Cleanmeter.
- Settings HWiNFO helper copy uses design-system text tokens (`--textParagraph1`), matching the rest of Settings.
- HWiNFO Current DL/UP rate is converted from KB/s to bytes/s at parse time so overlay network speeds match LHM throughput sensors.

## How to enable

1. Run your own HWiNFO.
2. Enable **Shared Memory Support** in HWiNFO (off by default).
3. In Cleanmeter Settings → Hardware sensors, leave **Auto** or choose **HWiNFO**.

## Fallback / 12-hour free edition

If the mapping is missing, the signature is `DEAD`, HWiNFO closes, or the free HWiNFO64 12-hour SHM timeout deactivates sharing, the sidecar switches to LibreHardwareMonitor. The overlay keeps updating; it does not go blank. Settings and the existing monitoring banner surface that SHM dropped.

## PresentMon

Unchanged. One PresentMon session (`HardwareMonitor`). FPS is not taken from HWiNFO.

## Tests

- C# unit tests parse fake SHM buffers: `HWiS` / `DEAD` / truncated header / 44- and 48-byte headers, stable IDs, type mapping, fallback policy, and KB/s → bytes/s network rates. No live HWiNFO required.
- TypeScript tests cover `sensorSource: "auto"` and stale `customReadingId` refresh when switching sources.
- Rust tests round-trip `sensorSource` on `OverlaySettings` and parse the data-packet trailer.
