### PR TITLE
Fix the Low/Medium/High threshold inputs rewriting typed values

### DIFF
--- a/tauri-app/src/components/settings/stats/TempRangeControl.tsx
+++ b/tauri-app/src/components/settings/stats/TempRangeControl.tsx
@@ -1,8 +1,11 @@
+import { useRef, useState } from "react";
 import type { Boundaries } from "@/lib/types";
 import { useSettingsStore } from "@/stores/settings-store";
-
-const CLAMP = (v: number, min: number, max: number) =>
-  Math.max(min, Math.min(max, v));
+import {
+  applyBoundary,
+  isBoundaryInRange,
+  type BoundaryField,
+} from "@/lib/boundaries";
 
 /**
  * 3-segment range control from Figma. Defaults to a 0-100% scale (GPU/CPU
@@ -50,26 +53,44 @@ export function TempRangeControl({
 
   // Inputs hand over display-scale values; convert to °C first so the ±1
   // segment-gap invariants keep holding in the stored scale.
-  const setLowMax = (v: number) => {
-    const lv = CLAMP(fromDisplay(v), 0, boundaries.medium - 1);
-    onChange({ ...boundaries, low: lv });
-  };
-  const setMedMax = (v: number) => {
-    const mv = CLAMP(fromDisplay(v), boundaries.low + 1, (boundaries.high || max) - 1);
-    onChange({ ...boundaries, medium: mv });
-  };
-  const setHighMax = (v: number) => {
-    const hv = CLAMP(fromDisplay(v), boundaries.medium + 1, max);
-    onChange({ ...boundaries, high: hv });
-  };
+  //
+  // `accepts` is what stops the control fighting the typist. Clamping on every
+  // keystroke — which is what this used to do — rewrote the field's text after
+  // each key, so the first digit of a two-digit number was snapped to a segment
+  // edge and the second digit then appended to a number nobody typed. Typing 40
+  // into Medium produced 89, backspacing 80 to 8 sprang it back up, and
+  // emptying the field read as 0 and clamped to the minimum. Half-typed values
+  // are now simply not stored, and the commit keeps the number that was typed:
+  // editing Low or Medium moves whatever is in the way, while High clamps to
+  // sit above Medium rather than dragging the thresholds down. See
+  // lib/boundaries.ts for why the two directions differ.
+  const editor = (field: BoundaryField) => ({
+    accepts: (v: number) => isBoundaryInRange(field, fromDisplay(v), boundaries, max),
+    live: (v: number) => onChange({ ...boundaries, [field]: fromDisplay(v) }),
+    commit: (v: number) => onChange(applyBoundary(field, fromDisplay(v), boundaries, max)),
+    // Escape undoes whatever the live path stored during this edit. The value
+    // came from the store, so it needs no reordering.
+    revert: (v: number) => onChange({ ...boundaries, [field]: fromDisplay(v) }),
+  });
 
   return (
     <div className="flex gap-4">
-      <RangeSegment color="#17B26A" label="Low" min={lowMin} max={lowMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin onMaxChange={setLowMax} />
-      <RangeSegment color="#FEC84B" label="Medium" min={medMin} max={medMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin onMaxChange={setMedMax} />
-      <RangeSegment color="#F04438" label="High" min={highMin} max={highMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin onMaxChange={setHighMax} />
+      <RangeSegment color="#17B26A" label="Low" min={lowMin} max={lowMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin editor={editor("low")} />
+      <RangeSegment color="#FEC84B" label="Medium" min={medMin} max={medMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin editor={editor("medium")} />
+      <RangeSegment color="#F04438" label="High" min={highMin} max={highMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin editor={editor("high")} />
     </div>
   );
+}
+
+interface SegmentEditor {
+  /** Can this value be stored as typed, with no other bound moving? */
+  accepts: (v: number) => boolean;
+  /** Store a value that needs nothing else to move, while the field is focused. */
+  live: (v: number) => void;
+  /** Store the finished value, moving the neighbouring bounds to suit. */
+  commit: (v: number) => void;
+  /** Put back the value the field held when it gained focus. */
+  revert: (v: number) => void;
 }
 
 function RangeSegment({
@@ -80,7 +101,7 @@ function RangeSegment({
   unit,
   inputMax,
   readOnlyMin,
-  onMaxChange,
+  editor,
 }: {
   color: string;
   label: string;
@@ -89,7 +110,7 @@ function RangeSegment({
   unit: string;
   inputMax: number;
   readOnlyMin?: boolean;
-  onMaxChange: (v: number) => void;
+  editor: SegmentEditor;
 }) {
   return (
     <div className="flex flex-1 flex-col gap-2">
@@ -103,7 +124,7 @@ function RangeSegment({
           value={max}
           unit={unit}
           inputMax={inputMax}
-          onChange={onMaxChange}
+          editor={editor}
           className="-ml-px rounded-r-[8px]"
         />
       </div>
@@ -115,7 +136,7 @@ function ValueInput({
   value,
   unit,
   inputMax,
-  onChange,
+  editor,
   readOnly,
   muted,
   className,
@@ -123,11 +144,41 @@ function ValueInput({
   value: number;
   unit: string;
   inputMax: number;
-  onChange?: (v: number) => void;
+  editor?: SegmentEditor;
   readOnly?: boolean;
   muted?: boolean;
   className?: string;
 }) {
+  // The text the user is typing, held only while the field is focused. Null
+  // means "show the stored value" — the state the field returns to on commit.
+  const [draft, setDraft] = useState<string | null>(null);
+  // What the field held when it gained focus, so Escape can undo the values the
+  // live path stored while typing.
+  const valueOnFocus = useRef(value);
+  const text = draft ?? (Number.isFinite(value) ? String(value) : "0");
+
+  const handleChange = (raw: string) => {
+    setDraft(raw);
+    // An empty field is a backspace in progress, not a zero.
+    if (raw === "") return;
+    const typed = parseInt(raw, 10);
+    if (Number.isFinite(typed) && editor?.accepts(typed)) editor.live(typed);
+  };
+
+  const commit = () => {
+    if (draft === null) return;
+    const typed = parseInt(draft, 10);
+    // A field left empty or unparseable keeps whatever was stored.
+    if (Number.isFinite(typed)) editor?.commit(typed);
+    setDraft(null);
+  };
+
+  const revert = () => {
+    if (draft === null) return;
+    editor?.revert(valueOnFocus.current);
+    setDraft(null);
+  };
+
   return (
     <div
       className={`flex h-10 flex-1 items-center border border-[var(--borderBolder)] px-3 ${muted ? "bg-sub-card" : "bg-[var(--bgSurfaceRaised)]"} ${className ?? ""}`}
@@ -136,9 +187,18 @@ function ValueInput({
         type="number"
         min={0}
         max={inputMax}
-        value={Number.isFinite(value) ? value : 0}
+        value={text}
         readOnly={readOnly}
-        onChange={(e) => onChange?.(parseInt(e.target.value || "0", 10))}
+        onChange={(e) => handleChange(e.target.value)}
+        onFocus={() => { valueOnFocus.current = value; }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+          // Escape restores the value the field started with and leaves it
+          // focused. Blurring here instead would commit the draft: the onBlur
+          // handler runs in the same event, still closed over it.
+          if (e.key === "Escape") revert();
+        }}
         className="w-full bg-transparent text-[14px] font-medium text-foreground outline-none read-only:text-muted-foreground"
       />
       <span className="text-[14px] font-medium text-muted-foreground">{unit}</span>

--- a/tauri-app/src/components/settings/stats/TempRangeControl.tsx
+++ b/tauri-app/src/components/settings/stats/TempRangeControl.tsx
@@ -4,6 +4,7 @@ import { useSettingsStore } from "@/stores/settings-store";
 import {
   applyBoundary,
   isBoundaryInRange,
+  parseBoundaryInput,
   type BoundaryField,
 } from "@/lib/boundaries";
 
@@ -159,15 +160,13 @@ function ValueInput({
 
   const handleChange = (raw: string) => {
     setDraft(raw);
-    // An empty field is a backspace in progress, not a zero.
-    if (raw === "") return;
-    const typed = parseInt(raw, 10);
+    const typed = parseBoundaryInput(raw);
     if (Number.isFinite(typed) && editor?.accepts(typed)) editor.live(typed);
   };
 
   const commit = () => {
     if (draft === null) return;
-    const typed = parseInt(draft, 10);
+    const typed = parseBoundaryInput(draft);
     // A field left empty or unparseable keeps whatever was stored.
     if (Number.isFinite(typed)) editor?.commit(typed);
     setDraft(null);

--- a/tauri-app/src/lib/boundaries.test.ts
+++ b/tauri-app/src/lib/boundaries.test.ts
@@ -4,6 +4,7 @@ import {
   applyBoundary,
   boundaryRange,
   isBoundaryInRange,
+  parseBoundaryInput,
   type BoundaryField,
 } from "./boundaries";
 
@@ -68,6 +69,34 @@ function typeKeepingTheDraft(
 
 const ordered = (b: Boundaries, max = MAX) =>
   0 <= b.low && b.low < b.medium && b.medium < b.high && b.high <= max;
+
+describe("parseBoundaryInput", () => {
+  it("reads exponent form, which <input type=number> accepts as valid", () => {
+    // Verified in Chromium: typing 1e2 leaves input.value === "1e2" with
+    // valueAsNumber 100. parseInt read that as 1 and stored 1 as the threshold.
+    expect(parseBoundaryInput("1e2")).toBe(100);
+    expect(parseBoundaryInput("1.5e1")).toBe(15);
+    expect(parseBoundaryInput("2E1")).toBe(20);
+  });
+
+  it("rounds a fractional entry instead of truncating it", () => {
+    expect(parseBoundaryInput("4.5")).toBe(5);
+    expect(parseBoundaryInput("4.4")).toBe(4);
+  });
+
+  it("reads plain and signed integers unchanged", () => {
+    expect(parseBoundaryInput("20")).toBe(20);
+    expect(parseBoundaryInput("0")).toBe(0);
+    expect(parseBoundaryInput("-5")).toBe(-5);
+  });
+
+  it("has no value for an empty, blank or unparseable field", () => {
+    // Mid-backspace is not a zero: NaN tells the caller to leave the bound be.
+    for (const raw of ["", "   ", "abc", "-", "1e999"]) {
+      expect(parseBoundaryInput(raw), `"${raw}"`).toBeNaN();
+    }
+  });
+});
 
 describe("boundaryRange", () => {
   it("is the window in which no other bound has to move", () => {

--- a/tauri-app/src/lib/boundaries.test.ts
+++ b/tauri-app/src/lib/boundaries.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from "vitest";
+import type { Boundaries } from "./types";
+import {
+  applyBoundary,
+  boundaryRange,
+  isBoundaryInRange,
+  type BoundaryField,
+} from "./boundaries";
+
+const MAX = 100;
+const DEFAULTS: Boundaries = { low: 60, medium: 80, high: 90 };
+
+const nearestLegal = (
+  field: BoundaryField,
+  v: number,
+  b: Boundaries,
+  max = MAX,
+) => {
+  const { min, max: hi } = boundaryRange(field, b, max);
+  return Math.max(min, Math.min(hi, v));
+};
+
+/**
+ * The old control: a number input fully controlled by the store, whose onChange
+ * clamped every keystroke and wrote the clamped number straight back. The
+ * field's text was therefore replaced after each key, so the next digit
+ * appended to a number the user never typed.
+ */
+function typeClampingEveryKeystroke(
+  field: BoundaryField,
+  keys: string,
+  start: Boundaries,
+  max = MAX,
+): Boundaries {
+  let b = start;
+  let text = "";
+  for (const key of keys) {
+    text += key;
+    b = { ...b, [field]: nearestLegal(field, parseInt(text || "0", 10), b, max) };
+    text = String(b[field]); // controlled input snaps the text back
+  }
+  return b;
+}
+
+/**
+ * The control as it now behaves: the field keeps the user's own text, only a
+ * value needing no other field to move is stored while typing, and the commit
+ * keeps what was typed and moves the neighbours instead.
+ */
+function typeKeepingTheDraft(
+  field: BoundaryField,
+  keys: string,
+  start: Boundaries,
+  max = MAX,
+): Boundaries {
+  let b = start;
+  let text = "";
+  for (const key of keys) {
+    text += key;
+    const typed = parseInt(text, 10);
+    if (Number.isFinite(typed) && isBoundaryInRange(field, typed, b, max)) {
+      b = { ...b, [field]: typed };
+    }
+  }
+  const typed = parseInt(text, 10); // commit
+  return Number.isFinite(typed) ? applyBoundary(field, typed, b, max) : b;
+}
+
+const ordered = (b: Boundaries, max = MAX) =>
+  0 <= b.low && b.low < b.medium && b.medium < b.high && b.high <= max;
+
+describe("boundaryRange", () => {
+  it("is the window in which no other bound has to move", () => {
+    expect(boundaryRange("low", DEFAULTS, MAX)).toEqual({ min: 0, max: 79 });
+    expect(boundaryRange("medium", DEFAULTS, MAX)).toEqual({ min: 61, max: 89 });
+    expect(boundaryRange("high", DEFAULTS, MAX)).toEqual({ min: 81, max: 100 });
+  });
+
+  it("treats an unset high as the top of the scale", () => {
+    const b: Boundaries = { low: 60, medium: 80, high: 0 };
+    expect(boundaryRange("medium", b, MAX)).toEqual({ min: 61, max: 99 });
+  });
+});
+
+describe("clamping every keystroke (the reported bug)", () => {
+  // Reported 2026-08-19 against the v2.2.15 draft: GPU Usage ended up reading
+  // Low 0-20 / Medium 20-21 / High 21-81, and the fields refused typing,
+  // backspacing and editing. settings.json held exactly that triple.
+  it("turns three ordinary edits into 20 / 21 / 81", () => {
+    let b = DEFAULTS;
+    b = typeClampingEveryKeystroke("low", "20", b);
+    b = typeClampingEveryKeystroke("high", "8", b);
+    b = typeClampingEveryKeystroke("medium", "2", b);
+    expect(b).toEqual({ low: 20, medium: 21, high: 81 });
+  });
+
+  it("destroys a multi-digit value because the first digit is clamped first", () => {
+    // Typing 30 into Medium: "3" is clamped up to 61, the field becomes "61",
+    // and the trailing 0 turns it into 610, which clamps to the top of range.
+    expect(typeClampingEveryKeystroke("medium", "30", DEFAULTS)).toEqual({
+      low: 60,
+      medium: 89,
+      high: 90,
+    });
+  });
+
+  it("cannot clear a field, because an empty input reads as zero", () => {
+    // Backspacing "80" to "" parses as 0 and is clamped straight back up to the
+    // segment minimum, so the field never appears to empty.
+    expect(nearestLegal("medium", 0, DEFAULTS)).toBe(61);
+  });
+});
+
+describe("applyBoundary", () => {
+  it("keeps what was typed and pushes the neighbour up", () => {
+    // Reported 2026-08-19: typing 40 into Low became 39 whenever Medium was
+    // already 40. Medium yields instead.
+    expect(applyBoundary("low", 40, { low: 20, medium: 40, high: 90 }, MAX)).toEqual({
+      low: 40,
+      medium: 41,
+      high: 90,
+    });
+  });
+
+  it("leaves the neighbours alone when there is already room", () => {
+    expect(applyBoundary("low", 40, { low: 20, medium: 80, high: 90 }, MAX)).toEqual({
+      low: 40,
+      medium: 80,
+      high: 90,
+    });
+  });
+
+  it("pushes a threshold downward too", () => {
+    expect(applyBoundary("medium", 30, DEFAULTS, MAX)).toEqual({
+      low: 29,
+      medium: 30,
+      high: 90,
+    });
+  });
+
+  it("carries a push through both bounds when one is not enough", () => {
+    expect(applyBoundary("low", 100, { low: 20, medium: 80, high: 90 }, MAX)).toEqual({
+      low: 98,
+      medium: 99,
+      high: 100,
+    });
+  });
+
+  // getBoundaryColor reads low and medium and never high, so High is drawn but
+  // never compared against. It must not be able to drag the two values the
+  // colours depend on down with it.
+  it("clamps High rather than letting it rewrite the thresholds", () => {
+    expect(applyBoundary("high", 50, { low: 20, medium: 80, high: 90 }, MAX)).toEqual({
+      low: 20,
+      medium: 80,
+      high: 81,
+    });
+    expect(applyBoundary("high", 1, { low: 20, medium: 80, high: 90 }, MAX)).toEqual({
+      low: 20,
+      medium: 80,
+      high: 81,
+    });
+  });
+
+  it("still lets High move freely above medium", () => {
+    expect(applyBoundary("high", 95, { low: 20, medium: 80, high: 90 }, MAX)).toEqual({
+      low: 20,
+      medium: 80,
+      high: 95,
+    });
+  });
+
+  it("repairs a degenerate stored set rather than emitting one", () => {
+    // Only reachable from corrupted data: the medium branch caps medium at
+    // max - 1, so nothing this code writes can get here.
+    expect(applyBoundary("high", 50, { low: 98, medium: 100, high: 100 }, MAX)).toEqual({
+      low: 98,
+      medium: 99,
+      high: 100,
+    });
+  });
+
+  it("raises high to stay above a medium pushed past it", () => {
+    expect(applyBoundary("medium", 95, DEFAULTS, MAX)).toEqual({
+      low: 60,
+      medium: 95,
+      high: 96,
+    });
+  });
+
+  it("honours a non-percent scale", () => {
+    // Temperatures run to 120 °C.
+    expect(applyBoundary("high", 130, { low: 60, medium: 80, high: 90 }, 120)).toEqual({
+      low: 60,
+      medium: 80,
+      high: 120,
+    });
+  });
+
+  it("leaves the bound alone when handed a value that is not a number", () => {
+    expect(applyBoundary("medium", NaN, DEFAULTS, MAX)).toEqual(DEFAULTS);
+  });
+
+  it("always returns an ordered set, whatever it is handed", () => {
+    const wild = [-50, -1, 0, 1, 2, 39, 40, 41, 99, 100, 101, 5000, NaN];
+    const starts: Boundaries[] = [
+      { low: 60, medium: 80, high: 90 },
+      { low: 0, medium: 1, high: 2 },
+      { low: 20, medium: 40, high: 90 },
+      { low: 97, medium: 98, high: 99 },
+      { low: 60, medium: 80, high: 0 },
+    ];
+    for (const field of ["low", "medium", "high"] as BoundaryField[]) {
+      for (const start of starts) {
+        for (const v of wild) {
+          const out = applyBoundary(field, v, start, MAX);
+          expect(ordered(out), `${field}=${v} from ${JSON.stringify(start)} gave ${JSON.stringify(out)}`).toBe(true);
+        }
+      }
+    }
+  });
+});
+
+describe("keeping the draft while typing (the fix)", () => {
+  it("lands the values the user actually typed", () => {
+    let b = DEFAULTS;
+    b = typeKeepingTheDraft("low", "20", b);
+    b = typeKeepingTheDraft("high", "85", b);
+    b = typeKeepingTheDraft("medium", "40", b);
+    expect(b).toEqual({ low: 20, medium: 40, high: 85 });
+  });
+
+  it("lowers the two thresholds in either order", () => {
+    // The old control could only do this left to right; Medium below Low used
+    // to clamp instead of pushing Low down.
+    let left = DEFAULTS;
+    left = typeKeepingTheDraft("low", "20", left);
+    left = typeKeepingTheDraft("medium", "30", left);
+    expect(left).toEqual({ low: 20, medium: 30, high: 90 });
+
+    let right = DEFAULTS;
+    right = typeKeepingTheDraft("medium", "30", right);
+    right = typeKeepingTheDraft("low", "20", right);
+    expect(right).toEqual({ low: 20, medium: 30, high: 90 });
+  });
+
+  it("needs High lowered last, since it will not drag the thresholds down", () => {
+    let b = DEFAULTS;
+    b = typeKeepingTheDraft("low", "20", b);
+    b = typeKeepingTheDraft("medium", "30", b);
+    b = typeKeepingTheDraft("high", "40", b);
+    expect(b).toEqual({ low: 20, medium: 30, high: 40 });
+
+    // High first has nowhere to go while Medium is still 80: it settles just
+    // above it rather than pulling Medium and Low down.
+    expect(typeKeepingTheDraft("high", "40", DEFAULTS)).toEqual({
+      low: 60,
+      medium: 80,
+      high: 81,
+    });
+  });
+
+  it("leaves the stored values alone when the field is left empty", () => {
+    expect(typeKeepingTheDraft("medium", "", DEFAULTS)).toEqual(DEFAULTS);
+  });
+});
+
+describe("isBoundaryInRange", () => {
+  it("rejects the half-typed digit and accepts the finished number", () => {
+    expect(isBoundaryInRange("medium", 3, DEFAULTS, MAX)).toBe(false);
+    expect(isBoundaryInRange("medium", 30, { ...DEFAULTS, low: 20 }, MAX)).toBe(true);
+  });
+});

--- a/tauri-app/src/lib/boundaries.ts
+++ b/tauri-app/src/lib/boundaries.ts
@@ -54,6 +54,24 @@ export function boundaryRange(
 }
 
 /**
+ * Read a threshold out of an `<input type="number">` value.
+ *
+ * Not parseInt: exponent form is a valid floating-point number per the HTML
+ * spec, so the field hands over strings like "1e2" (valueAsNumber 100) and
+ * parseInt would read them as their leading digit — 1, stored and persisted as
+ * the threshold. Number() parses the whole string; thresholds are whole
+ * numbers, so a fractional entry rounds rather than truncating.
+ *
+ * Returns NaN for anything with no numeric value, including an empty field —
+ * mid-backspace is not a zero — which callers treat as "leave the bound alone".
+ */
+export function parseBoundaryInput(raw: string): number {
+  if (raw.trim() === "") return NaN;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? Math.round(parsed) : NaN;
+}
+
+/**
  * Whether a value can be stored as typed with nothing else moving. False means
  * "not yet" — the caller is mid-edit and should keep the user's text.
  */

--- a/tauri-app/src/lib/boundaries.ts
+++ b/tauri-app/src/lib/boundaries.ts
@@ -1,0 +1,118 @@
+import type { Boundaries } from "./types";
+
+/**
+ * Threshold editing for the three-segment range control.
+ *
+ * The segments are contiguous — Low is 0→low, Medium is low→medium, High is
+ * medium→high — so the three upper bounds have to stay ordered. Two rules keep
+ * that true without the control fighting whoever is typing:
+ *
+ *   - while a field is focused, only a value that needs nothing else to move is
+ *     stored (`isBoundaryInRange`), so a half-typed number is never written and
+ *     never rewrites the field's text;
+ *   - on commit, an edited threshold keeps the value it was given and whatever
+ *     is in the way moves by the minimum needed to stay ordered
+ *     (`applyBoundary`).
+ *
+ * Which bound wins follows from what the bounds mean. `getBoundaryColor` reads
+ * only `low` and `medium`; `high` is the top of the scale, drawn but never
+ * compared against. So the two thresholds outrank it — and each other, in the
+ * direction being edited — while `high` clamps instead of pushing, since a
+ * display bound has no business rewriting the values the colours depend on.
+ */
+
+export type BoundaryField = keyof Boundaries;
+
+export interface BoundaryLimits {
+  min: number;
+  max: number;
+}
+
+const clamp = (v: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, v));
+
+/** An unset `high` behaves as the top of the scale rather than as 0. */
+const topOf = (boundaries: Boundaries, max: number) => boundaries.high || max;
+
+/**
+ * Range a segment's upper bound can take with the other two left alone.
+ * Narrower than the scale: it is the "no neighbour has to move" window.
+ */
+export function boundaryRange(
+  field: BoundaryField,
+  boundaries: Boundaries,
+  max: number,
+): BoundaryLimits {
+  switch (field) {
+    case "low":
+      return { min: 0, max: boundaries.medium - 1 };
+    case "medium":
+      return { min: boundaries.low + 1, max: topOf(boundaries, max) - 1 };
+    case "high":
+      return { min: boundaries.medium + 1, max };
+  }
+}
+
+/**
+ * Whether a value can be stored as typed with nothing else moving. False means
+ * "not yet" — the caller is mid-edit and should keep the user's text.
+ */
+export function isBoundaryInRange(
+  field: BoundaryField,
+  value: number,
+  boundaries: Boundaries,
+  max: number,
+): boolean {
+  const limits = boundaryRange(field, boundaries, max);
+  return value >= limits.min && value <= limits.max;
+}
+
+/**
+ * Commit an edited bound, keeping 0 ≤ low < medium < high ≤ max.
+ *
+ * `low` and `medium` are the real thresholds, so an edit to either keeps the
+ * number it was given and moves whatever is in the way — including `high`,
+ * which is only the top of the scale. `high` does not get that power in
+ * return: it clamps to sit just above `medium` rather than dragging the two
+ * thresholds down with it, because a display bound must not be able to rewrite
+ * the values the gauge colours actually depend on.
+ */
+export function applyBoundary(
+  field: BoundaryField,
+  value: number,
+  boundaries: Boundaries,
+  max: number,
+): Boundaries {
+  let { low, medium } = boundaries;
+  let high = topOf(boundaries, max);
+
+  // NaN would survive Math.min/Math.max and be returned as a bound, so a
+  // non-finite value means "leave this one where it is". The caller guards
+  // before committing; this keeps the ordering guarantee true for every caller.
+  const v = Number.isFinite(value) ? value : { low, medium, high }[field];
+
+  switch (field) {
+    // Two bounds have to fit above Low, hence max - 2.
+    case "low":
+      low = clamp(v, 0, max - 2);
+      if (medium <= low) medium = low + 1;
+      if (high <= medium) high = medium + 1;
+      break;
+    case "medium":
+      medium = clamp(v, 1, max - 1);
+      if (low >= medium) low = medium - 1;
+      if (high <= medium) high = medium + 1;
+      break;
+    case "high":
+      // The floor keeps High above Medium without moving it. Math.min only
+      // matters if stored data is already degenerate (medium at the top of the
+      // scale); the two lines below then repair it. In normal use, where the
+      // medium branch caps medium at max - 1, neither can fire.
+      high = clamp(v, Math.min(medium + 1, max), max);
+      if (medium >= high) medium = high - 1;
+      if (low >= medium) low = medium - 1;
+      break;
+  }
+
+  return { low, medium, high };
+}

--- a/tauri-app/src/lib/utils.test.ts
+++ b/tauri-app/src/lib/utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { getBoundaryColor, formatValue } from "./utils";
+
+const GREEN = "var(--green500)";
+const YELLOW = "var(--yellow300)";
+const RED = "var(--red500)";
+
+// Thresholds are the UPPER bound of each segment, which is what the settings
+// control paints: Low 0→low, Medium low→medium, High medium→high.
+const B = { low: 20, medium: 40, high: 90 };
+
+describe("getBoundaryColor", () => {
+  it("matches the segments the settings control shows", () => {
+    expect(getBoundaryColor(0, B)).toBe(GREEN);
+    expect(getBoundaryColor(19, B)).toBe(GREEN);
+    expect(getBoundaryColor(21, B)).toBe(YELLOW);
+    expect(getBoundaryColor(39, B)).toBe(YELLOW);
+    expect(getBoundaryColor(41, B)).toBe(RED);
+    expect(getBoundaryColor(100, B)).toBe(RED);
+  });
+
+  it("treats each threshold as the last value inside its own segment", () => {
+    expect(getBoundaryColor(20, B)).toBe(GREEN);
+    expect(getBoundaryColor(40, B)).toBe(YELLOW);
+  });
+
+  it("never uses boundaries.high as a threshold — it is the scale top only", () => {
+    // 89 and 91 sit either side of `high` and must look the same.
+    expect(getBoundaryColor(89, B)).toBe(RED);
+    expect(getBoundaryColor(91, B)).toBe(RED);
+  });
+
+  // KNOWN OPEN ISSUE — this test pins current behaviour, not desired behaviour.
+  // If the gauge is changed to colour the same rounded number it prints, this
+  // test is expected to fail and should be updated rather than treated as a
+  // regression.
+  it("colours the value it is given, which is NOT the value the overlay prints", () => {
+    // The gauge prints formatValue(raw) but colours getBoundaryColor(raw), so a
+    // reading just above a threshold prints as the threshold and still steps
+    // to the next colour: the overlay reads "20 %" in yellow while the Low
+    // segment is labelled 0-20.
+    expect(formatValue(20.1)).toBe("20");
+    expect(getBoundaryColor(20.1, B)).toBe(YELLOW);
+
+    expect(formatValue(40.4)).toBe("40");
+    expect(getBoundaryColor(40.4, B)).toBe(RED);
+  });
+});


### PR DESCRIPTION
## The bug

The three threshold fields in the Low/Medium/High range control were fully controlled number inputs whose `onChange` clamped **every keystroke** against the neighbouring boundaries and wrote the clamped number straight back. The field's text was replaced after each key, so the first digit of a longer number snapped to a segment edge and the next digit appended to a number nobody typed.

Observed:

- typing `40` into Medium produced `89`
- backspacing `80` to `8` sprang straight back up
- clearing a field parsed as `0` and clamped to the segment minimum
- typing `40` into Low silently became `39` whenever Medium was already `40`

Reported against GPU Usage, which ended up stored as `low 20 / medium 21 / high 81`. That triple is reachable from three ordinary edits and is reproduced exactly in the tests. With medium at 21 the overlay ring also read red above 21%, so the corrupted thresholds were visible on the gauge.

## The fix

Segment ranges move to `lib/boundaries.ts` as plain functions, and editing runs in two stages.

**While focused** the field keeps the user's own text, and only a value that needs no other bound to move is stored. A half-typed number is never written and never rewrites the field.

**On commit** the value settles, and which bound gives way follows from what the bounds mean. `getBoundaryColor` reads `low` and `medium` and never `high`, which is the top of the scale for display. So the two thresholds outrank it: editing either keeps the number typed and moves whatever is in the way, `high` included. Lowering the two thresholds now works in either order, where before it only worked left to right.

`high` does not get that power in return — it clamps to sit just above `medium` rather than dragging the thresholds down, since a bound the colours never read must not rewrite the ones they do. Committing `8` into High still settles at `medium + 1` and leaves Low and Medium alone.

Enter commits. Escape restores the value the field held when it gained focus, including anything stored mid-edit. `applyBoundary` treats a non-finite value as "leave this bound alone", so its ordering guarantee holds for every caller.

This covers all seven threshold sets — CPU/GPU usage, CPU/GPU temperature, VRAM and RAM all share this control.

## Also included

Tests for `getBoundaryColor`, which had none despite being the subject of an earlier colour fix. They lock in that each threshold is the last value inside its own segment, and that `boundaries.high` is a display maximum rather than a threshold.

## Verification

- 39/39 unit tests, including a property check that every field across inputs from -50 to 5000, NaN included, always yields an ordered set
- eslint clean; `tsc` unchanged at its 5 long-standing errors; vite and tauri release builds clean
- Driven in a real browser against the actual component: 15 keystroke-level assertions covering typing, backspacing, Enter, Escape, both threshold edit orders and both reported cases
- On the running app, ring colours were sampled from the overlay pixels across a CPU load ramp and matched the configured thresholds in all 36 comparisons

## Known gap

The Escape and focus-snapshot path has no committed test. The unit project runs in node with no component-test setup, and no sibling component in this repo is tested either; it was verified in a browser instead.