### PR TITLE
Pin every GPU reading to one selected GPU

### DIFF
--- a/HardwareMonitor/HardwareMonitor/Monitor/DisplayAdapters.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/DisplayAdapters.cs
@@ -1,0 +1,292 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using LibreHardwareMonitor.Hardware;
+
+namespace HardwareMonitor.Monitor;
+
+/// <summary>
+/// The GPUs Windows reports as physically present, read from the PnP device
+/// tree rather than from a vendor SDK.
+///
+/// LibreHardwareMonitor builds its GPU list exactly once, in the constructors
+/// of AmdGpuGroup / NvidiaGroup / IntelGpuGroup, from ADL / NvAPI / IntelGcl.
+/// A vendor SDK that is not answering at that moment produces an empty group
+/// which is never retried, so a machine can run an entire session with a GPU
+/// the app never mentions. This is the second opinion that makes that
+/// detectable: CfgMgr32 walks the device tree, so it sees a card whether or
+/// not its vendor SDK is up, and whether or not the card is currently powered.
+///
+/// LibreHardwareMonitor runs the same enumeration internally, in
+/// D3DDisplayDevice.GetDeviceIdentifiers, but that type is `internal` and
+/// cannot be called from here.
+/// </summary>
+public static class DisplayAdapters
+{
+    /// <summary>A GPU the device tree reports as present.</summary>
+    public readonly record struct DisplayAdapter(
+        HardwareType Type,
+        string VendorId,
+        string DeviceId,
+        string InstanceId,
+        string Name);
+
+    // GUID_DISPLAY_DEVICE_ARRIVAL. The interface class every display adapter
+    // registers, which is what keeps this a GPU enumeration rather than a walk
+    // of the whole device tree.
+    private static Guid _displayDeviceArrival = new("1CA05180-A699-450A-9A0C-DE4FBE3DDD89");
+
+    private const uint CmGetDeviceInterfaceListPresent = 0x00000001;
+    private const uint CrSuccess = 0x00000000;
+    private const uint CrBufferSmall = 0x0000001A;
+    private const uint CmLocateDevNodeNormal = 0x00000000;
+    private const uint CmDrpDeviceDesc = 0x00000001;
+    private const uint RegSz = 0x00000001;
+
+    // The three PCI vendor IDs that ship GPUs LibreHardwareMonitor has a
+    // backend for. Anything else in the display class (Microsoft's Basic
+    // Render Driver lives under ROOT\BasicRender, and remote-desktop and VM
+    // software register their own virtual adapters) is not something we can
+    // read sensors from, so listing it would only offer the user a dead choice.
+    private const string VendorNvidia = "10DE";
+    private const string VendorAmd = "1002";
+    private const string VendorIntel = "8086";
+
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode, EntryPoint = "CM_Get_Device_Interface_List_SizeW")]
+    private static extern uint CM_Get_Device_Interface_List_Size(
+        out uint pulLen, ref Guid interfaceClassGuid, string? pDeviceId, uint ulFlags);
+
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode, EntryPoint = "CM_Get_Device_Interface_ListW")]
+    private static extern uint CM_Get_Device_Interface_List(
+        ref Guid interfaceClassGuid, string? pDeviceId, char[] buffer, uint bufferLen, uint ulFlags);
+
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode, EntryPoint = "CM_Locate_DevNodeW")]
+    private static extern uint CM_Locate_DevNode(out uint pdnDevInst, string pDeviceId, uint ulFlags);
+
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode, EntryPoint = "CM_Get_DevNode_Registry_PropertyW")]
+    private static extern uint CM_Get_DevNode_Registry_Property(
+        uint dnDevInst, uint ulProperty, out uint pulRegDataType, byte[]? buffer, ref uint pulLength, uint ulFlags);
+
+    /// <summary>
+    /// Every present GPU from the three vendors above. Returns an empty list
+    /// rather than throwing when the device tree cannot be read, so a failure
+    /// here degrades to "no second opinion" instead of taking the sidecar down.
+    /// </summary>
+    public static IReadOnlyList<DisplayAdapter> Enumerate()
+    {
+        var adapters = new List<DisplayAdapter>();
+
+        foreach (var path in GetInterfacePaths())
+        {
+            if (!TryParseInterfacePath(path, out var adapter))
+                continue;
+
+            adapters.Add(adapter with { Name = ReadDeviceDescription(adapter.InstanceId) ?? adapter.Name });
+        }
+
+        return adapters;
+    }
+
+    private static string[] GetInterfacePaths()
+    {
+        // Sizing the list and reading it are two calls against a device tree
+        // that can change in between, which is what CR_BUFFER_SMALL means
+        // here. Retry rather than truncate.
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            if (CM_Get_Device_Interface_List_Size(
+                    out var size, ref _displayDeviceArrival, null, CmGetDeviceInterfaceListPresent) != CrSuccess)
+            {
+                return [];
+            }
+
+            if (size == 0)
+                return [];
+
+            var buffer = new char[size];
+            var result = CM_Get_Device_Interface_List(
+                ref _displayDeviceArrival, null, buffer, (uint)buffer.Length, CmGetDeviceInterfaceListPresent);
+
+            if (result == CrSuccess)
+                return new string(buffer).Split('\0', StringSplitOptions.RemoveEmptyEntries);
+
+            if (result != CrBufferSmall)
+                return [];
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Pull the vendor and device out of a device interface path.
+    ///
+    /// A real card looks like
+    ///   \\?\PCI#VEN_10DE&amp;DEV_2702&amp;SUBSYS_89641043&amp;REV_A1#4&amp;8fc2ab9&amp;0&amp;0009#{1ca05180-...}
+    /// and Microsoft's software adapter looks like
+    ///   \\?\ROOT#BasicRender#0000#{1ca05180-...}
+    /// which has no VEN_ and is rejected here.
+    ///
+    /// False for anything that is not a PCI device from one of the three
+    /// vendors we can read sensors from.
+    /// </summary>
+    internal static bool TryParseInterfacePath(string interfacePath, out DisplayAdapter adapter)
+    {
+        adapter = default;
+
+        if (string.IsNullOrEmpty(interfacePath))
+            return false;
+
+        var vendorId = ReadHexToken(interfacePath, "VEN_");
+        if (vendorId is null)
+            return false;
+
+        HardwareType type;
+        switch (vendorId)
+        {
+            case VendorNvidia:
+                type = HardwareType.GpuNvidia;
+                break;
+            case VendorAmd:
+                type = HardwareType.GpuAmd;
+                break;
+            case VendorIntel:
+                type = HardwareType.GpuIntel;
+                break;
+            default:
+                return false;
+        }
+
+        var deviceId = ReadHexToken(interfacePath, "DEV_") ?? "";
+
+        adapter = new DisplayAdapter(
+            type,
+            vendorId,
+            deviceId,
+            ToInstanceId(interfacePath),
+            // Only used when the device tree has no description for the node.
+            // Recognisable, and never blank, so the GPU stays selectable.
+            $"{VendorName(type)} Graphics {deviceId}".TrimEnd());
+
+        return true;
+    }
+
+    /// <summary>
+    /// The 4 hex digits following a token, e.g. "VEN_" in "PCI#VEN_10DE&amp;DEV_2702".
+    /// Null when the token is absent or is not followed by 4 hex digits.
+    /// Upper-cased so callers can compare without picking a culture.
+    /// </summary>
+    internal static string? ReadHexToken(string value, string token)
+    {
+        var start = value.IndexOf(token, StringComparison.OrdinalIgnoreCase);
+        if (start < 0)
+            return null;
+
+        start += token.Length;
+        if (start + 4 > value.Length)
+            return null;
+
+        for (var i = start; i < start + 4; i++)
+        {
+            if (!Uri.IsHexDigit(value[i]))
+                return null;
+        }
+
+        return value.Substring(start, 4).ToUpperInvariant();
+    }
+
+    /// <summary>
+    /// Device interface path to device instance ID, which is what
+    /// CM_Locate_DevNode takes:
+    ///   \\?\PCI#VEN_10DE&amp;DEV_2702#4&amp;8fc2ab9&amp;0&amp;0009#{1ca05180-...}
+    /// becomes
+    ///   PCI\VEN_10DE&amp;DEV_2702\4&amp;8fc2ab9&amp;0&amp;0009
+    /// Mirrors LibreHardwareMonitor's D3DDisplayDevice.GetActualDeviceIdentifier.
+    /// </summary>
+    internal static string ToInstanceId(string interfacePath)
+    {
+        var value = interfacePath;
+
+        if (value.StartsWith(@"\\?\", StringComparison.Ordinal))
+            value = value[4..];
+
+        if (value.Length > 0 && value[^1] == '}')
+        {
+            var brace = value.LastIndexOf('{');
+            // The brace is preceded by the '#' separating it from the
+            // instance, so that goes too. brace > 0 keeps a malformed path
+            // from producing a negative length.
+            if (brace > 0)
+                value = value[..(brace - 1)];
+        }
+
+        return value.Replace('#', '\\');
+    }
+
+    /// <summary>
+    /// The device tree's description for a node, e.g. "NVIDIA GeForce RTX 4080
+    /// SUPER". Null when the node cannot be located or has no description, in
+    /// which case the caller keeps its vendor-and-device fallback name.
+    /// </summary>
+    private static string? ReadDeviceDescription(string instanceId)
+    {
+        if (CM_Locate_DevNode(out var devInst, instanceId, CmLocateDevNodeNormal) != CrSuccess)
+            return null;
+
+        uint length = 0;
+        var sized = CM_Get_DevNode_Registry_Property(devInst, CmDrpDeviceDesc, out _, null, ref length, 0);
+
+        if ((sized != CrSuccess && sized != CrBufferSmall) || length == 0)
+            return null;
+
+        var buffer = new byte[length];
+        if (CM_Get_DevNode_Registry_Property(devInst, CmDrpDeviceDesc, out var type, buffer, ref length, 0) != CrSuccess)
+            return null;
+
+        // DeviceDesc is REG_SZ on every device Windows populates it for, but
+        // the property is registry-backed and nothing guarantees the type.
+        // Decoding a REG_BINARY or REG_MULTI_SZ as UTF-16 would put mojibake in
+        // the GPU picker, so anything else falls back to the caller's name.
+        if (type != RegSz)
+            return null;
+
+        return CleanDeviceDescription(Encoding.Unicode.GetString(buffer));
+    }
+
+    /// <summary>
+    /// Device descriptions come back NUL-terminated, and sometimes still in
+    /// the INF's unresolved form:
+    ///   "@oem12.inf,%nvidia_dev.2702%;NVIDIA GeForce RTX 4080 SUPER"
+    /// The readable half is whatever follows the last ';'. Null for an empty
+    /// result, so the caller falls back rather than showing a blank row.
+    /// </summary>
+    internal static string? CleanDeviceDescription(string raw)
+    {
+        var value = raw;
+
+        var nul = value.IndexOf('\0');
+        if (nul >= 0)
+            value = value[..nul];
+
+        var semicolon = value.LastIndexOf(';');
+        if (semicolon >= 0 && semicolon < value.Length - 1)
+            value = value[(semicolon + 1)..];
+
+        value = value.Trim();
+
+        return value.Length == 0 ? null : value;
+    }
+
+    private static string VendorName(HardwareType type)
+    {
+        switch (type)
+        {
+            case HardwareType.GpuNvidia:
+                return "NVIDIA";
+            case HardwareType.GpuAmd:
+                return "AMD";
+            case HardwareType.GpuIntel:
+                return "Intel";
+            default:
+                return "Unknown";
+        }
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/Monitor/GpuReconciler.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/GpuReconciler.cs
@@ -1,0 +1,76 @@
+using LibreHardwareMonitor.Hardware;
+
+namespace HardwareMonitor.Monitor;
+
+/// <summary>
+/// Compares the GPUs the device tree reports against the GPUs
+/// LibreHardwareMonitor actually produced, and says which are unaccounted for.
+///
+/// Deliberately pure: the whole decision is a function of two lists, so it can
+/// be exercised without a machine that has the hardware in question. The
+/// caller owns the side effects (rebuilding LibreHardwareMonitor's GPU groups,
+/// synthesising placeholder entries, logging).
+///
+/// Matching is per vendor, by count, not per device. LibreHardwareMonitor's
+/// IHardware exposes only Name and Identifier, never a PCI device ID, so there
+/// is nothing to join two specific devices on. Counting per vendor is exact
+/// for the case this exists to serve, a laptop with one integrated and one
+/// discrete GPU from different vendors, and degrades to "how many are missing"
+/// rather than "which one" for two cards from the same vendor.
+/// </summary>
+public static class GpuReconciler
+{
+    /// <summary>
+    /// The adapters the device tree sees but LibreHardwareMonitor has not
+    /// produced hardware for. Empty when everything is accounted for, which is
+    /// the case on every single-GPU machine and is the cheap path.
+    ///
+    /// When a vendor is short by N, the trailing N adapters of that vendor are
+    /// reported. Which specific device is missing is unknowable here, so the
+    /// choice is arbitrary but deterministic.
+    /// </summary>
+    public static IReadOnlyList<DisplayAdapters.DisplayAdapter> Missing(
+        IReadOnlyList<DisplayAdapters.DisplayAdapter> adapters,
+        IEnumerable<HardwareType> detectedGpuTypes)
+    {
+        var detected = new Dictionary<HardwareType, int>();
+        foreach (var type in detectedGpuTypes)
+        {
+            if (!IsGpu(type))
+                continue;
+
+            detected[type] = detected.GetValueOrDefault(type) + 1;
+        }
+
+        var missing = new List<DisplayAdapters.DisplayAdapter>();
+        var seen = new Dictionary<HardwareType, int>();
+
+        foreach (var adapter in adapters)
+        {
+            var index = seen.GetValueOrDefault(adapter.Type);
+            seen[adapter.Type] = index + 1;
+
+            // The first N adapters of a vendor are taken to be the N that
+            // LibreHardwareMonitor produced; anything past that is missing.
+            if (index >= detected.GetValueOrDefault(adapter.Type))
+                missing.Add(adapter);
+        }
+
+        return missing;
+    }
+
+    /// <summary>
+    /// A stable, ASCII-only identifier for a GPU the device tree sees but
+    /// LibreHardwareMonitor has no reading for.
+    ///
+    /// Kept clearly distinct from LibreHardwareMonitor's own identifiers
+    /// (/gpu-nvidia/0 and friends) so the two can never collide, and so a
+    /// reader can tell at a glance that an entry carries no sensors. The index
+    /// disambiguates two identical cards.
+    /// </summary>
+    public static string PlaceholderIdentifier(DisplayAdapters.DisplayAdapter adapter, int index) =>
+        $"/gpu-absent/{adapter.VendorId}-{adapter.DeviceId}-{index}";
+
+    public static bool IsGpu(HardwareType type) =>
+        type is HardwareType.GpuNvidia or HardwareType.GpuAmd or HardwareType.GpuIntel;
+}

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -39,6 +39,29 @@ public class MonitorPoller(
     // How many times a change to the active sensor set is worth logging.
     private const int SensorSetChangeLogLimit = 5;
 
+    // How often the device tree is re-checked against LibreHardwareMonitor's
+    // GPU list. The check is a device-tree enumeration and a count compare, so
+    // it is cheap enough to leave running for the life of the sidecar; only a
+    // mismatch costs anything, and a single-GPU machine never has one. Running
+    // it forever rather than as a startup burst is what catches a GPU that
+    // arrives late, e.g. an external GPU or a driver that finished installing.
+    private const int GpuReconcileIntervalMs = 30_000;
+
+    // Rebuilding the GPU groups cannot help a GPU whose vendor SDK will never
+    // answer, so the rebuild is capped. Past the cap the GPU is still listed
+    // from the device tree, just without readings.
+    private const int MaxGpuGroupRebuilds = 5;
+
+    private long _nextGpuReconcileAt;
+    private int _gpuGroupRebuilds;
+
+    /// <summary>
+    /// GPUs the device tree reports as present that LibreHardwareMonitor has
+    /// produced no hardware for. Listed to the app anyway, without sensors, so
+    /// the user can still select the GPU they meant.
+    /// </summary>
+    private IReadOnlyList<DisplayAdapters.DisplayAdapter> _absentGpus = [];
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         logger.LogInformation("Starting monitor");
@@ -64,6 +87,13 @@ public class MonitorPoller(
                 "Continuing with FPS and any sensors that initialized; low-level CPU sensors " +
                 "may be unavailable.");
         }
+
+        // Before anything is logged or mapped, check LibreHardwareMonitor's
+        // GPU list against the device tree. Its GPU groups enumerate once, in
+        // their constructors, so a vendor SDK that was not ready here would
+        // otherwise leave the GPU missing for the whole session.
+        ReconcileGpus();
+        _nextGpuReconcileAt = Environment.TickCount64 + GpuReconcileIntervalMs;
 
         // Log discovered hardware and sensor counts for diagnostics
         int hwCount = 0, sensorCount = 0;
@@ -115,6 +145,28 @@ public class MonitorPoller(
 
         while (!stoppingToken.IsCancellationRequested)
         {
+            // Ahead of the no-clients check on purpose: the GPU list should be
+            // right by the time a client connects, not a poll or two after.
+            // Wall-clock rather than an accumulator because the two waits below
+            // differ (1s with no client, the polling rate with one).
+            if (Environment.TickCount64 >= _nextGpuReconcileAt)
+            {
+                _nextGpuReconcileAt = Environment.TickCount64 + GpuReconcileIntervalMs;
+
+                var reconcile = ReconcileGpus();
+                if (reconcile != GpuReconcileResult.Unchanged)
+                {
+                    // Only a rebuild invalidates the cached IHardware. Doing
+                    // this unconditionally would also clear the StopUpdates()
+                    // suspension MapHardwares exists to preserve.
+                    if (reconcile == GpuReconcileResult.Rebuilt)
+                        ForgetGpuHardware(sharedMemoryData);
+
+                    MapHardwareData(sharedMemoryData);
+                    knownSensorCount = CountActiveSensors();
+                }
+            }
+
             if (!_socketHost.HasConnections())
             {
                 //logger.LogInformation("No clients connected, waiting for connections...");
@@ -298,6 +350,181 @@ public class MonitorPoller(
         }
     }
 
+    /// <summary>
+    /// What a reconcile pass did, which decides how much the caller has to
+    /// throw away. The distinction matters: forgetting the cached GPU entries
+    /// is mandatory after a rebuild, and harmful without one, because it also
+    /// forgets that a GPU was suspended by StopUpdates() after throwing.
+    /// </summary>
+    private enum GpuReconcileResult
+    {
+        /// <summary>Nothing to do.</summary>
+        Unchanged,
+
+        /// <summary>
+        /// The GPUs listed without sensors changed. Existing IHardware
+        /// instances are still live; re-map, but keep them.
+        /// </summary>
+        ListChanged,
+
+        /// <summary>
+        /// LibreHardwareMonitor's GPU groups were re-created, so every GPU
+        /// IHardware the cache holds is now a closed instance.
+        /// </summary>
+        Rebuilt,
+    }
+
+    /// <summary>
+    /// Check the GPUs the device tree reports against the ones
+    /// LibreHardwareMonitor produced, rebuild its GPU groups when it is short,
+    /// and remember whatever is still unaccounted for so MapHardwares can list
+    /// it without sensors.
+    /// </summary>
+    private GpuReconcileResult ReconcileGpus()
+    {
+        IReadOnlyList<DisplayAdapters.DisplayAdapter> adapters;
+
+        try
+        {
+            adapters = DisplayAdapters.Enumerate();
+        }
+        catch (Exception ex)
+        {
+            // A second opinion we cannot obtain is not worth failing over. The
+            // GPU list stays whatever LibreHardwareMonitor reported, which is
+            // exactly the behaviour before this existed.
+            logger.LogWarning(ex, "Could not enumerate display adapters; using LibreHardwareMonitor's GPU list as-is");
+            return GpuReconcileResult.Unchanged;
+        }
+
+        // No adapters at all means the enumeration told us nothing useful
+        // rather than that the machine has no GPU, so nothing is concluded
+        // from it. A machine with a GPU that the device tree cannot see is not
+        // a case this can improve on.
+        if (adapters.Count == 0)
+            return GpuReconcileResult.Unchanged;
+
+        var missing = GpuReconciler.Missing(adapters, DetectedGpuTypes());
+
+        if (missing.Count > 0 && _gpuGroupRebuilds < MaxGpuGroupRebuilds)
+        {
+            _gpuGroupRebuilds++;
+            logger.LogInformation(
+                "Device tree reports {Present} GPU(s), LibreHardwareMonitor produced {Produced} ({Missing}); rebuilding its GPU groups, attempt {Attempt} of {Max}",
+                adapters.Count,
+                adapters.Count - missing.Count,
+                string.Join(", ", missing.Select(m => m.Name)),
+                _gpuGroupRebuilds,
+                MaxGpuGroupRebuilds);
+
+            RebuildGpuGroups();
+            SetAbsentGpus(GpuReconciler.Missing(adapters, DetectedGpuTypes()));
+
+            // A rebuild replaces every GPU IHardware, so the cached entries now
+            // point at closed instances and must be recreated regardless of
+            // whether the shortfall changed.
+            return GpuReconcileResult.Rebuilt;
+        }
+
+        // Compared by identity, not by count. One GPU becoming readable while
+        // another stops leaves the count unchanged, and treating that as "no
+        // change" would keep listing a placeholder for the wrong GPU.
+        if (SameGpus(missing, _absentGpus))
+            return GpuReconcileResult.Unchanged;
+
+        SetAbsentGpus(missing);
+
+        // No rebuild happened, so every surviving IHardware is still live. The
+        // caller re-maps to pick up the changed placeholder list; it must not
+        // forget the existing GPU entries, or a hardware suspended by
+        // StopUpdates() after throwing would be resurrected and throw again.
+        return GpuReconcileResult.ListChanged;
+    }
+
+    private static bool SameGpus(
+        IReadOnlyList<DisplayAdapters.DisplayAdapter> a,
+        IReadOnlyList<DisplayAdapters.DisplayAdapter> b)
+    {
+        if (a.Count != b.Count)
+            return false;
+
+        for (var i = 0; i < a.Count; i++)
+        {
+            if (a[i].InstanceId != b[i].InstanceId)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Record the GPUs left without readings and log the change, once per
+    /// change rather than once per check, so a permanent shortfall does not
+    /// write a line every 30 seconds.
+    /// </summary>
+    private void SetAbsentGpus(IReadOnlyList<DisplayAdapters.DisplayAdapter> missing)
+    {
+        if (SameGpus(missing, _absentGpus))
+            return;
+
+        _absentGpus = missing;
+
+        if (missing.Count == 0)
+        {
+            logger.LogInformation("Every GPU the device tree reports now has readings");
+            return;
+        }
+
+        logger.LogWarning(
+            "{Count} GPU(s) present in the device tree have no readings after {Rebuilds} rebuild(s): {Missing}. They are listed for selection but every value reads 0.",
+            missing.Count,
+            _gpuGroupRebuilds,
+            string.Join(", ", missing.Select(m => m.Name)));
+    }
+
+    /// <summary>
+    /// Re-create LibreHardwareMonitor's three GPU groups. Assigning
+    /// IsGpuEnabled is the only handle it offers for this: the setter drops
+    /// AmdGpuGroup / NvidiaGroup / IntelGpuGroup and constructs them again,
+    /// which re-runs the ADL / NvAPI / IntelGcl enumeration that a constructor
+    /// otherwise does exactly once per process.
+    /// </summary>
+    private void RebuildGpuGroups()
+    {
+        try
+        {
+            _computer.IsGpuEnabled = false;
+            _computer.IsGpuEnabled = true;
+            _computer.Accept(new UpdateVisitor());
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Rebuilding the GPU groups failed; keeping the GPU list as it was");
+        }
+    }
+
+    private IEnumerable<HardwareType> DetectedGpuTypes()
+    {
+        foreach (var hardware in _computer.Hardware)
+        {
+            if (GpuReconciler.IsGpu(hardware.HardwareType))
+                yield return hardware.HardwareType;
+        }
+    }
+
+    /// <summary>
+    /// Drop the cached entries for every GPU so the next re-map recreates them.
+    ///
+    /// Required after a group rebuild. MapHardwares reuses entries by
+    /// identifier, and a rebuilt group hands out new IHardware instances under
+    /// the same identifiers (/gpu-nvidia/0 and friends), so reuse would leave
+    /// every GPU entry pointing at a closed instance that never updates again.
+    /// </summary>
+    private static void ForgetGpuHardware(SharedMemoryData data)
+    {
+        data.Hardwares.RemoveAll(h => GpuReconciler.IsGpu(h.HardwareType));
+    }
+
     private SharedMemoryData QueryHardwareData()
     {
         var sharedMemoryData = new SharedMemoryData();
@@ -350,6 +577,29 @@ public class MonitorPoller(
             {
                 Add(subHardware);
             }
+        }
+
+        // GPUs the device tree reports but LibreHardwareMonitor produced
+        // nothing for. Listed so the user can still pick the GPU they meant
+        // instead of it being absent from the app entirely; they carry no
+        // sensors, so every reading on them is 0.
+        for (var i = 0; i < _absentGpus.Count; i++)
+        {
+            var adapter = _absentGpus[i];
+            var identifier = GpuReconciler.PlaceholderIdentifier(adapter, i);
+
+            hardwareList.Add(known.TryGetValue(identifier, out var existing)
+                ? existing
+                : new SharedMemoryHardware
+                {
+                    // Cleaned like every other name: the wire writes a UTF-16
+                    // character count in front of UTF-8 bytes, so a name with
+                    // non-ASCII in it would misalign every field after it.
+                    Name = RemoveSpecialCharacters(adapter.Name),
+                    Identifier = identifier,
+                    HardwareType = adapter.Type,
+                    Hardware = null,
+                });
         }
 
         sharedMemoryData.Hardwares = hardwareList;

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -417,13 +417,14 @@ public class MonitorPoller(
                 _gpuGroupRebuilds,
                 MaxGpuGroupRebuilds);
 
-            RebuildGpuGroups();
+            var tornDown = RebuildGpuGroups();
             SetAbsentGpus(GpuReconciler.Missing(adapters, DetectedGpuTypes()));
 
-            // A rebuild replaces every GPU IHardware, so the cached entries now
-            // point at closed instances and must be recreated regardless of
-            // whether the shortfall changed.
-            return GpuReconcileResult.Rebuilt;
+            // Only report a rebuild when the old groups were actually closed.
+            // That is what makes the cached entries stale, and forgetting them
+            // when nothing was torn down would needlessly discard the
+            // StopUpdates() suspension MapHardwares keeps them for.
+            return tornDown ? GpuReconcileResult.Rebuilt : GpuReconcileResult.ListChanged;
         }
 
         // Compared by identity, not by count. One GPU becoming readable while
@@ -489,18 +490,46 @@ public class MonitorPoller(
     /// which re-runs the ADL / NvAPI / IntelGcl enumeration that a constructor
     /// otherwise does exactly once per process.
     /// </summary>
-    private void RebuildGpuGroups()
+    /// <summary>
+    /// Returns whether the existing GPU groups were torn down, which is what
+    /// decides if the caller has to forget its cached entries.
+    ///
+    /// The two halves are separated deliberately. Disabling closes the current
+    /// groups, so every cached IHardware becomes a closed instance the moment
+    /// that succeeds, whether or not the rebuild after it does. Failing on the
+    /// way down leaves everything intact and the cache still valid; failing on
+    /// the way back up does not, and pretending otherwise would leave the app
+    /// updating closed handles forever.
+    /// </summary>
+    private bool RebuildGpuGroups()
     {
         try
         {
             _computer.IsGpuEnabled = false;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Could not disable the GPU groups; the GPU list is unchanged");
+            return false;
+        }
+
+        try
+        {
             _computer.IsGpuEnabled = true;
             _computer.Accept(new UpdateVisitor());
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Rebuilding the GPU groups failed; keeping the GPU list as it was");
+            // The old groups are already closed, so there is nothing to fall
+            // back to. GPUs read 0 until a later attempt succeeds, which is
+            // honest; keeping the closed handles would freeze the last values
+            // on screen and look live.
+            logger.LogError(ex,
+                "Rebuilding the GPU groups failed after the old ones were closed; " +
+                "GPU readings are unavailable until a later attempt succeeds");
         }
+
+        return true;
     }
 
     private IEnumerable<HardwareType> DetectedGpuTypes()

--- a/HardwareMonitor/HardwareMonitor/SharedMemory/SharedMemory.cs
+++ b/HardwareMonitor/HardwareMonitor/SharedMemory/SharedMemory.cs
@@ -30,7 +30,13 @@ public static class SharedMemoryConsts
 
 public class SharedMemoryHardware
 {
-    public required IHardware Hardware;
+    /// <summary>
+    /// Null for a GPU the device tree reports as present but that
+    /// LibreHardwareMonitor produced no hardware for. Such an entry exists so
+    /// the GPU is still listed and selectable; it carries no sensors and has
+    /// nothing to update. See HardwareMonitor.Monitor.GpuReconciler.
+    /// </summary>
+    public required IHardware? Hardware;
     public required string Name { get; set; }
     public required string Identifier { get; set; }
     public required HardwareType HardwareType { get; set; }
@@ -41,7 +47,7 @@ public class SharedMemoryHardware
     {
         if (_isActive)
         {
-            Hardware.Update();
+            Hardware?.Update();
         }
     }
 

--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -349,6 +349,13 @@ pub struct OverlaySettings {
     // struct comment above).
     #[serde(rename = "pixelShift", default)]
     pub pixel_shift: bool,
+    // Hardware identifier of the GPU every GPU reading is taken from, e.g.
+    // "/gpu-nvidia/0". Empty means "not chosen yet", which the app resolves on
+    // load. Machines with one GPU never show the control that sets this.
+    // `default` keeps older save files loading, and it must live here or serde
+    // drops it on save (see the struct comment above).
+    #[serde(rename = "selectedGpuId", default)]
+    pub selected_gpu_id: String,
     pub sensors: SensorsConfig,
 }
 
@@ -379,6 +386,7 @@ impl Default for OverlaySettings {
             polling_rate: 500,
             is_logging_enabled: false,
             pixel_shift: false,
+            selected_gpu_id: String::new(),
             sensors: SensorsConfig::default(),
         }
     }
@@ -442,4 +450,49 @@ pub struct MonitorInfo {
     pub x: i32,
     pub y: i32,
     pub primary: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The settings file is written by deserialising the app's JSON into
+    /// OverlaySettings and serialising it straight back out, so any field the
+    /// struct does not model is dropped on the first save. That is silent, and
+    /// it costs the user their setting, so the GPU choice is pinned by a test
+    /// rather than by the comment next to it.
+    #[test]
+    fn the_selected_gpu_survives_a_save_and_load_round_trip() {
+        let settings = OverlaySettings {
+            selected_gpu_id: "/gpu-nvidia/0".to_string(),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&settings).expect("serialise");
+        assert!(
+            json.contains("\"selectedGpuId\":\"/gpu-nvidia/0\""),
+            "the app reads this key name, not the Rust field name: {json}"
+        );
+
+        let restored: OverlaySettings = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(restored.selected_gpu_id, "/gpu-nvidia/0");
+    }
+
+    /// Every settings file written before this field existed lacks the key.
+    /// Without `default` on it, serde rejects the whole file and the user is
+    /// silently reset to defaults on upgrade.
+    #[test]
+    fn a_settings_file_written_before_the_gpu_field_still_loads() {
+        let mut without = serde_json::to_value(OverlaySettings::default()).expect("to value");
+        without
+            .as_object_mut()
+            .expect("object")
+            .remove("selectedGpuId")
+            .expect("the key should have been there to remove");
+
+        let loaded: OverlaySettings =
+            serde_json::from_value(without).expect("an older settings file must still load");
+
+        assert_eq!(loaded.selected_gpu_id, "");
+    }
 }

--- a/tauri-app/src/components/overlay/GpuSection.tsx
+++ b/tauri-app/src/components/overlay/GpuSection.tsx
@@ -44,9 +44,17 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
   const toGigabytes = (s: Sensor | undefined): number =>
     s == null ? 0 : s.sensorType === SensorType.SmallData ? (s.value ?? 0) / 1024 : s.value ?? 0;
 
-  // Anchor VRAM lookups to the GPU of the configured "GPU Memory Used" sensor.
+  // Anchor VRAM lookups to the selected GPU.
+  //
+  // This used to anchor to whichever GPU the configured "GPU Memory Used"
+  // sensor happened to sit on, which let the cluster straddle two GPUs: the
+  // used/total pair came from that sensor's GPU while the load fallback below
+  // came from vramUsage.customReadingId, and nothing tied the two together.
+  // The stored GPU is the one the user actually chose, so it is the honest
+  // anchor. The fallback keeps a settings file written before that field
+  // existed working until the next poll fills it in.
   const vramUsedConfigured = findSensorById(sensors, totalVramUsed.customReadingId);
-  const gpuHwId = vramUsedConfigured?.hardwareIdentifier;
+  const gpuHwId = settings.selectedGpuId || vramUsedConfigured?.hardwareIdentifier;
   const onGpu = (re: RegExp): Sensor | undefined =>
     gpuHwId ? sensors.find((s) => s.hardwareIdentifier === gpuHwId && re.test(s.name)) : undefined;
 

--- a/tauri-app/src/components/settings/stats/GpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/GpuSection.tsx
@@ -1,7 +1,16 @@
 import { useRef } from "react";
 import type { Hardware, Sensor } from "@/lib/types";
-import { HardwareType, SensorType } from "@/lib/types";
+import { SensorType } from "@/lib/types";
+import { listGpus, sensorsOnGpu } from "@/lib/gpu";
 import { useSettingsStore } from "@/stores/settings-store";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/shadcn/select";
+import { InfoIcon } from "../settings/icons";
 import { SectionCard, SubCollapsible } from "./SectionCard";
 import { SensorSelect } from "./SensorSelect";
 import { TempRangeControl } from "./TempRangeControl";
@@ -11,36 +20,31 @@ interface Props {
   hardwares: Hardware[];
 }
 
-const GPU_HW_TYPES = [
-  HardwareType.GpuNvidia,
-  HardwareType.GpuAmd,
-  HardwareType.GpuIntel,
-];
-
 export function GpuSection({ sensors, hardwares }: Props) {
   const settings = useSettingsStore((s) => s.settings);
   const updateSensor = useSettingsStore((s) => s.updateSensor);
   const updateBoundary = useSettingsStore((s) => s.updateBoundary);
+  const selectGpu = useSettingsStore((s) => s.selectGpu);
+  // `.settled` rather than a per-snapshot check: one snapshot cannot tell a
+  // parked GPU from one whose sensors have not activated yet, and the notice
+  // would flash on every launch. See nextGpuSilence.
+  const gpuIsIdle = useSettingsStore((s) => s.gpuSilence.settled);
   const { gpuUsage, gpuTemp, gpuConsumption, vramUsage } = settings.sensors;
 
-  const gpuHwIds = new Set(
-    hardwares.filter((h) => GPU_HW_TYPES.includes(h.hardwareType)).map((h) => h.identifier),
-  );
-  const gpuLoadSensors = sensors.filter(
-    (s) => gpuHwIds.has(s.hardwareIdentifier) && s.sensorType === SensorType.Load,
-  );
-  const gpuTempSensors = sensors.filter(
-    (s) => gpuHwIds.has(s.hardwareIdentifier) && s.sensorType === SensorType.Temperature,
-  );
-  const gpuPowerSensors = sensors.filter(
-    (s) => gpuHwIds.has(s.hardwareIdentifier) && s.sensorType === SensorType.Power,
-  );
+  const gpus = listGpus(hardwares);
+  // Every row below draws from one GPU. Scoping the option lists is what makes
+  // a mixed configuration unreachable rather than merely discouraged: on a
+  // laptop the sensor names collide (both an NVIDIA and an Intel GPU expose a
+  // temperature called "GPU Core"), so an unscoped list offers two identical
+  // rows and no way to tell them apart.
+  const gpuSensors = sensorsOnGpu(sensors, settings.selectedGpuId);
+
+  const gpuLoadSensors = gpuSensors.filter((s) => s.sensorType === SensorType.Load);
+  const gpuTempSensors = gpuSensors.filter((s) => s.sensorType === SensorType.Temperature);
+  const gpuPowerSensors = gpuSensors.filter((s) => s.sensorType === SensorType.Power);
   // VRAM usage is a load-type sensor whose name indicates memory.
-  const vramSensors = sensors.filter(
-    (s) =>
-      gpuHwIds.has(s.hardwareIdentifier) &&
-      s.sensorType === SensorType.Load &&
-      s.name.toLowerCase().includes("memory"),
+  const vramSensors = gpuLoadSensors.filter((s) =>
+    s.name.toLowerCase().includes("memory"),
   );
 
   const anyEnabled =
@@ -84,6 +88,35 @@ export function GpuSection({ sensors, hardwares }: Props) {
   return (
     <SectionCard title="GPU" enabled={anyEnabled} onToggle={handleMaster}>
       <div className="flex flex-col gap-3">
+        {/* Only shown when there is a choice to make. On the overwhelming
+            majority of machines there is exactly one GPU, and a control whose
+            list has a single entry is noise. */}
+        {gpus.length > 1 && (
+          <div className="flex flex-col gap-3">
+            <Select value={settings.selectedGpuId} onValueChange={selectGpu}>
+              <SelectTrigger className="w-full rounded-[8px] border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] font-medium shadow-[0_1px_2px_rgba(16,24,40,0.05)]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {gpus.map((gpu) => (
+                  <SelectItem key={gpu.identifier} value={gpu.identifier}>
+                    {gpu.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {/* Only while the chosen GPU is actually reporting nothing. A GPU
+                that is reading fine needs no explanation, and a notice that is
+                always there stops being read. */}
+            {gpuIsIdle && (
+              <div className="flex items-center gap-2 text-[12px] font-medium text-muted-foreground">
+                <InfoIcon className="size-4 shrink-0" />
+                <span>A GPU that is idle or powered down reports 0.</span>
+              </div>
+            )}
+          </div>
+        )}
+
         <SubCollapsible
           label="GPU Usage"
           checked={gpuUsage.isEnabled}

--- a/tauri-app/src/lib/gpu.test.ts
+++ b/tauri-app/src/lib/gpu.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect } from "vitest";
+import {
+  isGpu,
+  isGpuReportingNothing,
+  listGpus,
+  nextGpuSilence,
+  NO_GPU_SILENCE,
+  pickDefaultGpu,
+  resolveSelectedGpu,
+  sensorsOnGpu,
+  shouldRepickSensor,
+  type GpuSilence,
+} from "./gpu";
+import type { Hardware, Sensor } from "./types";
+import { HardwareType, SensorType } from "./types";
+
+// The machine from issue #48: an RTX 3050 laptop GPU alongside Intel
+// integrated graphics. Sensor names are the ones LibreHardwareMonitor 0.9.6
+// actually produces, which is the point of the fixture: NVIDIA and Intel both
+// expose a temperature called "GPU Core", so nothing but the hardware
+// identifier separates them.
+const NVIDIA: Hardware = {
+  name: "NVIDIA GeForce RTX 3050 Laptop GPU",
+  identifier: "/gpu-nvidia/0",
+  hardwareType: HardwareType.GpuNvidia,
+};
+
+const INTEL: Hardware = {
+  name: "Intel(R) UHD Graphics",
+  identifier: "/gpu-intel/0",
+  hardwareType: HardwareType.GpuIntel,
+};
+
+const CPU: Hardware = {
+  name: "Intel Core i5-11400H",
+  identifier: "/intelcpu/0",
+  hardwareType: HardwareType.Cpu,
+};
+
+function sensor(
+  hardwareIdentifier: string,
+  identifier: string,
+  name: string,
+  sensorType: SensorType,
+  value = 0,
+): Sensor {
+  return { name, identifier, hardwareIdentifier, sensorType, value };
+}
+
+const NVIDIA_SENSORS = [
+  sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/0", "GPU Core", SensorType.Load, 42),
+  sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/1", "GPU Memory Controller", SensorType.Load, 12),
+  sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/0", "GPU Core", SensorType.Temperature, 61),
+  sensor("/gpu-nvidia/0", "/gpu-nvidia/0/power/0", "GPU Package", SensorType.Power, 55),
+  sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/1", "GPU Memory Used", SensorType.SmallData, 2048),
+  sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/2", "GPU Memory Total", SensorType.SmallData, 4096),
+];
+
+// Intel exposes its load through D3D engine nodes and has no memory of its
+// own, so its only "total" is the system memory it may borrow.
+const INTEL_SENSORS = [
+  sensor("/gpu-intel/0", "/gpu-intel/0/load/0", "D3D 3D", SensorType.Load, 7),
+  sensor("/gpu-intel/0", "/gpu-intel/0/temperature/0", "GPU Core", SensorType.Temperature, 45),
+  sensor("/gpu-intel/0", "/gpu-intel/0/power/0", "GPU Power", SensorType.Power, 4),
+  sensor("/gpu-intel/0", "/gpu-intel/0/smalldata/3", "D3D Shared Memory Total", SensorType.SmallData, 16384),
+];
+
+const ALL_SENSORS = [...NVIDIA_SENSORS, ...INTEL_SENSORS];
+
+describe("listGpus", () => {
+  it("keeps GPUs and drops everything else", () => {
+    expect(listGpus([CPU, NVIDIA, INTEL]).map((g) => g.identifier)).toEqual([
+      "/gpu-nvidia/0",
+      "/gpu-intel/0",
+    ]);
+  });
+
+  it("preserves the order the sidecar sent", () => {
+    expect(listGpus([INTEL, NVIDIA])[0].identifier).toBe("/gpu-intel/0");
+  });
+
+  it("recognises all three GPU vendors", () => {
+    const amd = { ...NVIDIA, hardwareType: HardwareType.GpuAmd };
+    expect(isGpu(NVIDIA)).toBe(true);
+    expect(isGpu(INTEL)).toBe(true);
+    expect(isGpu(amd)).toBe(true);
+    expect(isGpu(CPU)).toBe(false);
+  });
+});
+
+describe("sensorsOnGpu", () => {
+  it("returns only that GPU's sensors", () => {
+    const scoped = sensorsOnGpu(ALL_SENSORS, "/gpu-nvidia/0");
+    expect(scoped).toHaveLength(NVIDIA_SENSORS.length);
+    expect(scoped.every((s) => s.hardwareIdentifier === "/gpu-nvidia/0")).toBe(true);
+  });
+
+  it("separates the two identically-named GPU Core temperatures", () => {
+    const nvidia = sensorsOnGpu(ALL_SENSORS, "/gpu-nvidia/0").filter(
+      (s) => s.sensorType === SensorType.Temperature,
+    );
+    const intel = sensorsOnGpu(ALL_SENSORS, "/gpu-intel/0").filter(
+      (s) => s.sensorType === SensorType.Temperature,
+    );
+
+    expect(nvidia).toHaveLength(1);
+    expect(intel).toHaveLength(1);
+    expect(nvidia[0].name).toBe(intel[0].name);
+    expect(nvidia[0].identifier).not.toBe(intel[0].identifier);
+  });
+
+  it("is empty for a GPU with no readings, and for no GPU at all", () => {
+    expect(sensorsOnGpu(ALL_SENSORS, "/gpu-absent/10DE-2507-0")).toEqual([]);
+    expect(sensorsOnGpu(ALL_SENSORS, "")).toEqual([]);
+  });
+});
+
+describe("pickDefaultGpu", () => {
+  it("prefers the discrete GPU over integrated graphics", () => {
+    expect(pickDefaultGpu([NVIDIA, INTEL], ALL_SENSORS)).toBe("/gpu-nvidia/0");
+  });
+
+  it("still prefers it when the integrated GPU is listed first", () => {
+    expect(pickDefaultGpu([INTEL, NVIDIA], ALL_SENSORS)).toBe("/gpu-nvidia/0");
+  });
+
+  it("ignores shared memory, which is system RAM and dwarfs real VRAM", () => {
+    // Intel's shared total is 16384 against the NVIDIA card's dedicated 4096.
+    // Counting it would pick the integrated GPU on every laptop.
+    const intelShared = ALL_SENSORS.find((s) => s.name === "D3D Shared Memory Total");
+    expect(intelShared?.value).toBeGreaterThan(4096);
+    expect(pickDefaultGpu([NVIDIA, INTEL], ALL_SENSORS)).toBe("/gpu-nvidia/0");
+  });
+
+  it("prefers a non-Intel GPU when no memory reading has arrived yet", () => {
+    // First launch: sensors activate over the first few polls rather than all
+    // at once, so the tie-break has to hold with nothing to rank on.
+    expect(pickDefaultGpu([INTEL, NVIDIA], [])).toBe("/gpu-nvidia/0");
+  });
+
+  it("ranks two discrete GPUs by dedicated memory", () => {
+    const second: Hardware = {
+      name: "NVIDIA GeForce RTX 4090",
+      identifier: "/gpu-nvidia/1",
+      hardwareType: HardwareType.GpuNvidia,
+    };
+    const sensors = [
+      ...NVIDIA_SENSORS,
+      sensor("/gpu-nvidia/1", "/gpu-nvidia/1/smalldata/2", "GPU Memory Total", SensorType.SmallData, 24576),
+    ];
+
+    expect(pickDefaultGpu([NVIDIA, second], sensors)).toBe("/gpu-nvidia/1");
+  });
+
+  it("separates an AMD integrated GPU from an AMD card by memory, not by type", () => {
+    // Both report as GpuAmd, so hardware type cannot tell them apart.
+    const apu: Hardware = { name: "AMD Radeon Graphics", identifier: "/gpu-amd/0", hardwareType: HardwareType.GpuAmd };
+    const card: Hardware = { name: "AMD Radeon RX 7900 XT", identifier: "/gpu-amd/1", hardwareType: HardwareType.GpuAmd };
+    const sensors = [
+      sensor("/gpu-amd/0", "/gpu-amd/0/smalldata/2", "GPU Memory Total", SensorType.SmallData, 512),
+      sensor("/gpu-amd/1", "/gpu-amd/1/smalldata/2", "GPU Memory Total", SensorType.SmallData, 20480),
+    ];
+
+    expect(pickDefaultGpu([apu, card], sensors)).toBe("/gpu-amd/1");
+  });
+
+  it("returns the only GPU when there is one, and empty when there are none", () => {
+    expect(pickDefaultGpu([NVIDIA], ALL_SENSORS)).toBe("/gpu-nvidia/0");
+    expect(pickDefaultGpu([], ALL_SENSORS)).toBe("");
+  });
+});
+
+describe("resolveSelectedGpu", () => {
+  it("keeps a stored choice that still resolves", () => {
+    expect(resolveSelectedGpu("/gpu-intel/0", "", [NVIDIA, INTEL], ALL_SENSORS)).toBe("/gpu-intel/0");
+  });
+
+  it("keeps the stored choice even when it disagrees with the default", () => {
+    // Choosing the integrated GPU on purpose has to survive every reload.
+    expect(resolveSelectedGpu("/gpu-intel/0", "/gpu-nvidia/0/load/0", [NVIDIA, INTEL], ALL_SENSORS))
+      .toBe("/gpu-intel/0");
+  });
+
+  it("adopts the GPU behind the saved GPU Usage sensor when nothing is stored", () => {
+    // The upgrade path: settings written before this control existed.
+    expect(resolveSelectedGpu("", "/gpu-intel/0/load/0", [NVIDIA, INTEL], ALL_SENSORS))
+      .toBe("/gpu-intel/0");
+  });
+
+  it("falls back to the default when the stored GPU is gone", () => {
+    expect(resolveSelectedGpu("/gpu-amd/9", "", [NVIDIA, INTEL], ALL_SENSORS)).toBe("/gpu-nvidia/0");
+  });
+
+  it("falls back to the default when the anchor sensor is gone too", () => {
+    expect(resolveSelectedGpu("", "/gpu-amd/9/load/0", [NVIDIA, INTEL], ALL_SENSORS))
+      .toBe("/gpu-nvidia/0");
+  });
+
+  it("leaves the stored value alone when no GPU is reported at all", () => {
+    // A sidecar that has not finished enumerating must not clear a valid
+    // choice, or every restart would reset the user's GPU.
+    expect(resolveSelectedGpu("/gpu-nvidia/0", "", [], [])).toBe("/gpu-nvidia/0");
+  });
+
+  it("selects a GPU that has no readings, so it can still be chosen", () => {
+    const absent: Hardware = {
+      name: "NVIDIA GeForce RTX 3050 Laptop GPU",
+      identifier: "/gpu-absent/10DE-2507-0",
+      hardwareType: HardwareType.GpuNvidia,
+    };
+    expect(resolveSelectedGpu("/gpu-absent/10DE-2507-0", "", [absent, INTEL], INTEL_SENSORS))
+      .toBe("/gpu-absent/10DE-2507-0");
+  });
+});
+
+describe("isGpuReportingNothing", () => {
+  it("is false for a GPU that is reporting", () => {
+    expect(isGpuReportingNothing("/gpu-nvidia/0", ALL_SENSORS)).toBe(false);
+  });
+
+  it("is true for a GPU with no sensors at all", () => {
+    // Parked, or its vendor SDK never answered, so it exists only because the
+    // device tree reported it.
+    expect(isGpuReportingNothing("/gpu-absent/10DE-2507-0", ALL_SENSORS)).toBe(true);
+  });
+
+  it("is true when every sensor on the GPU reads 0", () => {
+    const parked = [
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/0", "GPU Core", SensorType.Load, 0),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/0", "GPU Core", SensorType.Temperature, 0),
+      ...INTEL_SENSORS,
+    ];
+    expect(isGpuReportingNothing("/gpu-nvidia/0", parked)).toBe(true);
+  });
+
+  it("is false for a GPU at 0% load that still reports temperature", () => {
+    // Awake and reporting perfectly well, just not busy. Nothing to explain.
+    const idleButAwake = [
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/0", "GPU Core", SensorType.Load, 0),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/0", "GPU Core", SensorType.Temperature, 45),
+    ];
+    expect(isGpuReportingNothing("/gpu-nvidia/0", idleButAwake)).toBe(false);
+  });
+
+  it("is true before any sensor has arrived, which is why callers must not render off it", () => {
+    // Indistinguishable from a parked GPU in a single snapshot. Separating the
+    // two is nextGpuSilence's job, not this one's.
+    expect(isGpuReportingNothing("/gpu-nvidia/0", [])).toBe(true);
+  });
+
+  it("is false when no GPU is selected", () => {
+    expect(isGpuReportingNothing("", ALL_SENSORS)).toBe(false);
+  });
+});
+
+describe("nextGpuSilence", () => {
+  const quiet: Sensor[] = [];
+  const advance = (
+    state: GpuSilence,
+    gpuId: string,
+    sensors: Sensor[],
+    now: number,
+  ) => nextGpuSilence(state, gpuId, sensors, now, 2000);
+
+  it("does not settle while the GPU is still within the dwell", () => {
+    let state = advance(NO_GPU_SILENCE, "/gpu-nvidia/0", quiet, 1000);
+    expect(state.settled).toBe(false);
+
+    state = advance(state, "/gpu-nvidia/0", quiet, 2500);
+    expect(state.settled).toBe(false);
+  });
+
+  it("settles once the GPU has been quiet for the whole dwell", () => {
+    let state = advance(NO_GPU_SILENCE, "/gpu-nvidia/0", quiet, 1000);
+    state = advance(state, "/gpu-nvidia/0", quiet, 3000);
+    expect(state.settled).toBe(true);
+  });
+
+  it("never settles for a GPU whose sensors merely arrive late", () => {
+    // The case the old snapshot-only check got wrong. CPU and RAM sensors
+    // activate before GPU ones, and an AMD GPU reads through a sampling session
+    // with no sample on the first Update, so a healthy GPU looks silent for a
+    // poll or two. At a 500ms rate that is four polls before the dwell expires.
+    const cpuOnly = [sensor("/amdcpu/0", "/amdcpu/0/load/0", "CPU Total", SensorType.Load, 20)];
+
+    let state = advance(NO_GPU_SILENCE, "/gpu-nvidia/0", cpuOnly, 0);
+    for (const t of [500, 1000, 1500]) {
+      state = advance(state, "/gpu-nvidia/0", cpuOnly, t);
+      expect(state.settled).toBe(false);
+    }
+
+    // Sensors activate before the dwell expires, so nothing is ever shown.
+    state = advance(state, "/gpu-nvidia/0", ALL_SENSORS, 1800);
+    expect(state.settled).toBe(false);
+    expect(state.since).toBeNull();
+  });
+
+  it("forgives instantly on a single reading", () => {
+    let state = advance(NO_GPU_SILENCE, "/gpu-nvidia/0", quiet, 0);
+    state = advance(state, "/gpu-nvidia/0", quiet, 5000);
+    expect(state.settled).toBe(true);
+
+    state = advance(state, "/gpu-nvidia/0", ALL_SENSORS, 5100);
+    expect(state.settled).toBe(false);
+    expect(state.since).toBeNull();
+  });
+
+  it("restarts the clock when the selected GPU changes", () => {
+    // Switching must not inherit an age the new GPU never earned, or a freshly
+    // chosen GPU would be accused the moment it is picked.
+    let state = advance(NO_GPU_SILENCE, "/gpu-nvidia/0", quiet, 0);
+    state = advance(state, "/gpu-nvidia/0", quiet, 5000);
+    expect(state.settled).toBe(true);
+
+    state = advance(state, "/gpu-intel/0", quiet, 5100);
+    expect(state.settled).toBe(false);
+    expect(state.since).toBe(5100);
+  });
+
+  it("keeps timing across polls rather than restarting each one", () => {
+    let state = advance(NO_GPU_SILENCE, "/gpu-nvidia/0", quiet, 0);
+    for (const t of [500, 1000, 1500]) state = advance(state, "/gpu-nvidia/0", quiet, t);
+    expect(state.since).toBe(0);
+    expect(state.settled).toBe(false);
+
+    state = advance(state, "/gpu-nvidia/0", quiet, 2000);
+    expect(state.settled).toBe(true);
+  });
+
+  it("resets when no GPU is selected", () => {
+    let state = advance(NO_GPU_SILENCE, "/gpu-nvidia/0", quiet, 0);
+    state = advance(state, "", quiet, 5000);
+    expect(state).toEqual(NO_GPU_SILENCE);
+  });
+
+  it("settles for a GPU that is present but reporting all zeros", () => {
+    const parked = [
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/0", "GPU Core", SensorType.Load, 0),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/0", "GPU Core", SensorType.Temperature, 0),
+    ];
+
+    let state = advance(NO_GPU_SILENCE, "/gpu-nvidia/0", parked, 0);
+    state = advance(state, "/gpu-nvidia/0", parked, 2000);
+    expect(state.settled).toBe(true);
+  });
+});
+
+describe("shouldRepickSensor", () => {
+  it("leaves a choice already on the selected GPU alone", () => {
+    expect(shouldRepickSensor("/gpu-nvidia/0/load/0", "/gpu-nvidia/0", ALL_SENSORS)).toBe(false);
+  });
+
+  it("replaces a choice that sits on a different GPU", () => {
+    // The repair path: settings written before the GPU was pinned.
+    expect(shouldRepickSensor("/gpu-nvidia/0/load/0", "/gpu-intel/0", ALL_SENSORS)).toBe(true);
+  });
+
+  it("picks something when nothing is chosen", () => {
+    expect(shouldRepickSensor("", "/gpu-nvidia/0", ALL_SENSORS)).toBe(true);
+  });
+
+  it("leaves a choice alone when its sensor is not in this snapshot", () => {
+    // LibreHardwareMonitor only exposes a sensor once it has produced a
+    // reading, and AMD GPUs read through a sampling session with no sample on
+    // the first update. Re-picking here would wipe a deliberate choice on the
+    // strength of a snapshot that had not caught up yet.
+    expect(shouldRepickSensor("/gpu-amd/0/temperature/0", "/gpu-amd/0", [])).toBe(false);
+    expect(shouldRepickSensor("/gpu-nvidia/0/load/99", "/gpu-nvidia/0", ALL_SENSORS)).toBe(false);
+  });
+
+  it("replaces an off-GPU choice even when the selected GPU has no sensors", () => {
+    // Selecting a powered-down GPU must stop the old GPU's numbers being
+    // shown under its name. The row ends up empty, and reads 0.
+    expect(shouldRepickSensor("/gpu-intel/0/load/0", "/gpu-absent/10DE-2507-0", ALL_SENSORS))
+      .toBe(true);
+  });
+});

--- a/tauri-app/src/lib/gpu.ts
+++ b/tauri-app/src/lib/gpu.ts
@@ -1,0 +1,251 @@
+import type { Hardware, Sensor } from "./types";
+import { HardwareType, SensorType } from "./types";
+
+/**
+ * Choosing which GPU the overlay reads from.
+ *
+ * Every GPU reading (usage, temperature, power, VRAM) is pinned to one GPU,
+ * named by `settings.selectedGpuId`. That is a hard constraint rather than a
+ * default: the sensor pickers only ever offer sensors from the selected GPU,
+ * so a machine with an integrated and a discrete GPU cannot end up showing
+ * temperature from one and load from the other.
+ *
+ * The functions here are pure, which is the point. The behaviour that matters
+ * only appears on a machine with two GPUs, and those are exactly the machines
+ * we cannot test on.
+ */
+
+export const GPU_HARDWARE_TYPES = [
+  HardwareType.GpuNvidia,
+  HardwareType.GpuAmd,
+  HardwareType.GpuIntel,
+] as const;
+
+export function isGpu(hardware: Hardware): boolean {
+  return (GPU_HARDWARE_TYPES as readonly HardwareType[]).includes(hardware.hardwareType);
+}
+
+/** Every GPU the sidecar reported, in the order it sent them. */
+export function listGpus(hardwares: Hardware[]): Hardware[] {
+  return hardwares.filter(isGpu);
+}
+
+/** The sensors belonging to one GPU. Empty for a GPU with no readings yet. */
+export function sensorsOnGpu(sensors: Sensor[], gpuId: string): Sensor[] {
+  if (!gpuId) return [];
+  return sensors.filter((s) => s.hardwareIdentifier === gpuId);
+}
+
+/**
+ * Dedicated video memory a GPU reports, in whatever unit the sensor uses.
+ * Only ever compared against another GPU's, so the unit does not matter.
+ *
+ * "Shared" totals are excluded deliberately: an integrated GPU has no memory
+ * of its own and reports system memory it is allowed to borrow, which on a
+ * 32 GB laptop would otherwise outrank a discrete card's 8 GB.
+ */
+function dedicatedMemory(gpuId: string, sensors: Sensor[]): number {
+  let total = 0;
+
+  for (const sensor of sensors) {
+    if (sensor.hardwareIdentifier !== gpuId) continue;
+    if (sensor.sensorType !== SensorType.SmallData && sensor.sensorType !== SensorType.Data) continue;
+
+    const name = sensor.name.toLowerCase();
+    if (!name.includes("memory total") || name.includes("shared")) continue;
+
+    total = Math.max(total, sensor.value ?? 0);
+  }
+
+  return total;
+}
+
+/**
+ * The GPU to use when nobody has chosen one.
+ *
+ * Ranked by dedicated video memory, because that is what actually separates a
+ * discrete card from an integrated one and it comes from a sensor we already
+ * receive. Hardware type cannot do it: an AMD integrated GPU reports as
+ * GpuAmd exactly like a Radeon card does.
+ *
+ * Integrated Intel graphics lose the tie when no memory reading has arrived
+ * yet, which matters at first launch since sensors activate over the first
+ * polls rather than all at once.
+ */
+export function pickDefaultGpu(gpus: Hardware[], sensors: Sensor[]): string {
+  if (gpus.length === 0) return "";
+
+  let best = gpus[0];
+  let bestMemory = dedicatedMemory(best.identifier, sensors);
+
+  for (const candidate of gpus.slice(1)) {
+    const memory = dedicatedMemory(candidate.identifier, sensors);
+
+    if (memory > bestMemory) {
+      best = candidate;
+      bestMemory = memory;
+      continue;
+    }
+
+    // Same memory reading, including the case where neither has one yet.
+    if (
+      memory === bestMemory &&
+      best.hardwareType === HardwareType.GpuIntel &&
+      candidate.hardwareType !== HardwareType.GpuIntel
+    ) {
+      best = candidate;
+      bestMemory = memory;
+    }
+  }
+
+  return best.identifier;
+}
+
+/**
+ * Which GPU to read from, given what is stored and what is present.
+ *
+ * Three cases, in order:
+ *  - a stored choice that still resolves to a present GPU wins outright;
+ *  - otherwise the GPU behind the saved "GPU Usage" sensor is adopted. That is
+ *    the upgrade path for settings written before this control existed, and it
+ *    anchors on GPU Usage because it is the headline reading and so the one a
+ *    user is most likely to have set deliberately;
+ *  - otherwise pick a default.
+ *
+ * The second case is also the repair path for a stored GPU that has gone away,
+ * e.g. a card removed, or a placeholder entry replaced by the real thing once
+ * its vendor SDK started answering.
+ */
+export function resolveSelectedGpu(
+  storedGpuId: string,
+  gpuUsageSensorId: string,
+  gpus: Hardware[],
+  sensors: Sensor[],
+): string {
+  if (gpus.length === 0) return storedGpuId;
+
+  if (storedGpuId && gpus.some((g) => g.identifier === storedGpuId)) {
+    return storedGpuId;
+  }
+
+  const anchor = sensors.find((s) => s.identifier === gpuUsageSensorId);
+  if (anchor && gpus.some((g) => g.identifier === anchor.hardwareIdentifier)) {
+    return anchor.hardwareIdentifier;
+  }
+
+  return pickDefaultGpu(gpus, sensors);
+}
+
+/**
+ * Whether a GPU reports nothing in THIS snapshot: it has no sensors at all, or
+ * has sensors and every one reads 0.
+ *
+ * A GPU sitting at 0% load but 45°C is reporting perfectly well, just not
+ * busy, so this is false for it.
+ *
+ * Deliberately a statement about one snapshot and nothing more. A single
+ * snapshot cannot distinguish "parked" from "has not woken up yet", so callers
+ * must not render anything off this directly. See nextGpuSilence.
+ */
+export function isGpuReportingNothing(gpuId: string, sensors: Sensor[]): boolean {
+  if (!gpuId) return false;
+
+  const own = sensorsOnGpu(sensors, gpuId);
+  if (own.length === 0) return true;
+
+  return own.every((s) => (s.value ?? 0) === 0);
+}
+
+/**
+ * How long a GPU has to stay quiet before the UI says so.
+ *
+ * Sensors do not all arrive at once. LibreHardwareMonitor only exposes a
+ * sensor once it has produced a reading, and an AMD GPU reads temperature,
+ * power and load through an ADL sampling session that has no sample on the
+ * first Update() — so a perfectly healthy GPU reports nothing for the first
+ * poll or two of every launch. Two seconds clears that comfortably at any
+ * polling rate the app offers, and is short enough that a genuinely parked GPU
+ * explains itself before anyone goes looking.
+ */
+export const GPU_SILENCE_DWELL_MS = 2000;
+
+/**
+ * How long the selected GPU has been reporting nothing.
+ *
+ * `gpuId` is carried so a change of GPU restarts the clock rather than
+ * inheriting the previous one's.
+ */
+export interface GpuSilence {
+  gpuId: string;
+  /** When it first went quiet, or null while it is reporting. */
+  since: number | null;
+  /** Quiet for long enough that saying so is safe. This is what the UI reads. */
+  settled: boolean;
+}
+
+export const NO_GPU_SILENCE: GpuSilence = { gpuId: "", since: null, settled: false };
+
+/**
+ * Advance the silence clock by one snapshot.
+ *
+ * "This GPU is reporting nothing" is a steady-state property, and any answer
+ * derived from a single snapshot is a guess during warm-up. So the clock is
+ * asymmetric on purpose: slow to accuse, instant to forgive. One reading
+ * clears it outright, while claiming silence takes GPU_SILENCE_DWELL_MS of it
+ * holding continuously.
+ *
+ * That also stops a laptop GPU parking and waking through normal use from
+ * strobing the notice on and off.
+ *
+ * Pure, so the whole behaviour is testable without a clock or a DOM.
+ */
+export function nextGpuSilence(
+  previous: GpuSilence,
+  gpuId: string,
+  sensors: Sensor[],
+  now: number,
+  dwellMs: number = GPU_SILENCE_DWELL_MS,
+): GpuSilence {
+  if (!gpuId) return NO_GPU_SILENCE;
+
+  if (!isGpuReportingNothing(gpuId, sensors)) {
+    return { gpuId, since: null, settled: false };
+  }
+
+  // A different GPU than the one being timed, so start its clock from now
+  // rather than inheriting an age it never earned.
+  const since = previous.gpuId === gpuId && previous.since !== null ? previous.since : now;
+
+  return { gpuId, since, settled: now - since >= dwellMs };
+}
+
+/**
+ * Whether a saved GPU sensor choice has to be replaced.
+ *
+ * Three cases, and the middle one is the whole reason this is a function
+ * rather than an inline check:
+ *
+ *  - nothing chosen yet, so pick something;
+ *  - chosen, but that sensor is not in this snapshot at all. Left alone. A
+ *    sensor can be missing because it activates late rather than because it is
+ *    wrong: LibreHardwareMonitor only exposes a sensor once it has produced a
+ *    reading, and an AMD GPU reads temperature, power and load through a
+ *    sampling session that has no sample on the first update. Re-picking here
+ *    would destroy a deliberate choice on the strength of a snapshot that had
+ *    simply not caught up, and the user would never know why;
+ *  - chosen, present, and on a different GPU. Replaced. This is the repair
+ *    path for settings written before the GPU was pinned, and the reason a
+ *    configuration cannot stay mixed.
+ */
+export function shouldRepickSensor(
+  sensorId: string,
+  gpuId: string,
+  sensors: Sensor[],
+): boolean {
+  if (!sensorId) return true;
+
+  const sensor = sensors.find((s) => s.identifier === sensorId);
+  if (!sensor) return false;
+
+  return sensor.hardwareIdentifier !== gpuId;
+}

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -109,6 +109,16 @@ export interface OverlaySettings {
   // When true, the overlay is nudged a few pixels on a slow cycle to spread
   // OLED wear (burn-in mitigation). See pixel-shift logic in OverlayApp.
   pixelShift: boolean;
+  /**
+   * Hardware identifier of the GPU every GPU reading is taken from, e.g.
+   * "/gpu-nvidia/0". Empty means "not chosen yet".
+   *
+   * Resolved when hardware first arrives, in setSensorData, not in
+   * loadSettings: which GPUs exist is not known until the sidecar reports
+   * them. See resolveSelectedGpu. Machines with one GPU never see the control
+   * that changes it.
+   */
+  selectedGpuId: string;
   sensors: SensorsConfig;
 }
 
@@ -199,6 +209,7 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   pollingRate: 500,
   isLoggingEnabled: false,
   pixelShift: false,
+  selectedGpuId: "",
   sensors: {
     framerate: { isEnabled: true, customReadingId: "", targetAppName: "" },
     frametime: { isEnabled: true, customReadingId: "" },

--- a/tauri-app/src/stores/settings-store.gpu.test.ts
+++ b/tauri-app/src/stores/settings-store.gpu.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Hardware, HardwareMonitorData, OverlaySettings, Sensor } from "@/lib/types";
+import { DEFAULT_SETTINGS, HardwareType, SensorType } from "@/lib/types";
+
+// The store talks to Tauri on every settings write, and lib/tauri reads
+// `window` at import time, which does not exist in the node test project.
+// Nothing here asserts on those calls; they only need to not throw.
+vi.mock("@/lib/tauri", () => ({
+  isBrowser: true,
+  clearSettings: vi.fn(),
+  getAppVersion: vi.fn(),
+  getPreferences: vi.fn(),
+  getSettings: vi.fn(),
+  getSidecarStatus: vi.fn(),
+  savePreferences: vi.fn(),
+  saveSettings: vi.fn(),
+  selectPresentMonApp: vi.fn(),
+  setOverlayOpacity: vi.fn(),
+  setOverlayVisible: vi.fn(),
+  setPollingRate: vi.fn(),
+}));
+
+const { useSettingsStore } = await import("./settings-store");
+
+/**
+ * The machine from issue #48. Both GPUs expose a temperature called
+ * "GPU Core", which is exactly why the identifier is the only thing that can
+ * separate them.
+ */
+const NVIDIA: Hardware = {
+  name: "NVIDIA GeForce RTX 3050 Laptop GPU",
+  identifier: "/gpu-nvidia/0",
+  hardwareType: HardwareType.GpuNvidia,
+};
+
+const INTEL: Hardware = {
+  name: "Intel(R) UHD Graphics",
+  identifier: "/gpu-intel/0",
+  hardwareType: HardwareType.GpuIntel,
+};
+
+function sensor(
+  hw: string,
+  id: string,
+  name: string,
+  sensorType: SensorType,
+  value = 1,
+): Sensor {
+  return { name, identifier: id, hardwareIdentifier: hw, sensorType, value };
+}
+
+const DATA: HardwareMonitorData = {
+  hardwares: [NVIDIA, INTEL],
+  lastPollTime: 0,
+  sensors: [
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/0", "GPU Core", SensorType.Load, 40),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/3", "GPU Memory", SensorType.Load, 30),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/0", "GPU Core", SensorType.Temperature, 60),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/power/0", "GPU Package", SensorType.Power, 70),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/1", "GPU Memory Used", SensorType.SmallData, 2048),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/2", "GPU Memory Total", SensorType.SmallData, 4096),
+
+    sensor("/gpu-intel/0", "/gpu-intel/0/load/0", "D3D 3D", SensorType.Load, 5),
+    sensor("/gpu-intel/0", "/gpu-intel/0/load/1", "D3D Memory", SensorType.Load, 3),
+    sensor("/gpu-intel/0", "/gpu-intel/0/temperature/0", "GPU Core", SensorType.Temperature, 44),
+    sensor("/gpu-intel/0", "/gpu-intel/0/power/0", "GPU Power", SensorType.Power, 4),
+    sensor("/gpu-intel/0", "/gpu-intel/0/smalldata/0", "D3D Shared Memory Total", SensorType.SmallData, 16384),
+  ],
+};
+
+function seed(settings: Partial<OverlaySettings>) {
+  useSettingsStore.setState({
+    settings: { ...DEFAULT_SETTINGS, ...settings },
+    sensorData: null,
+    overlayVisible: true,
+  });
+}
+
+function gpuRows() {
+  const { sensors, selectedGpuId } = useSettingsStore.getState().settings;
+  return {
+    selectedGpuId,
+    gpuUsage: sensors.gpuUsage.customReadingId,
+    gpuTemp: sensors.gpuTemp.customReadingId,
+    gpuConsumption: sensors.gpuConsumption.customReadingId,
+    vramUsage: sensors.vramUsage.customReadingId,
+    totalVramUsed: sensors.totalVramUsed.customReadingId,
+  };
+}
+
+/** Every GPU row names a sensor on `gpuId`, or names nothing at all. */
+function allRowsOn(gpuId: string) {
+  const rows = gpuRows();
+  return [rows.gpuUsage, rows.gpuTemp, rows.gpuConsumption, rows.vramUsage, rows.totalVramUsed]
+    .filter(Boolean)
+    .every((id) => id.startsWith(gpuId));
+}
+
+beforeEach(() => {
+  seed({});
+});
+
+describe("choosing a GPU on a two-GPU machine", () => {
+  it("picks the discrete GPU on a fresh install", () => {
+    useSettingsStore.getState().setSensorData(DATA);
+
+    expect(gpuRows().selectedGpuId).toBe("/gpu-nvidia/0");
+    expect(allRowsOn("/gpu-nvidia/0")).toBe(true);
+  });
+
+  it("fills every GPU row rather than only some", () => {
+    useSettingsStore.getState().setSensorData(DATA);
+
+    const rows = gpuRows();
+    expect(rows.gpuUsage).toBe("/gpu-nvidia/0/load/0");
+    expect(rows.gpuTemp).toBe("/gpu-nvidia/0/temperature/0");
+    expect(rows.gpuConsumption).toBe("/gpu-nvidia/0/power/0");
+    expect(rows.totalVramUsed).toBe("/gpu-nvidia/0/smalldata/1");
+  });
+});
+
+describe("upgrading an existing install", () => {
+  it("repairs a configuration split across two GPUs", () => {
+    // Reachable today: gpuUsage and gpuTemp match on different keywords over
+    // one unscoped list, so nothing stopped them landing on different GPUs.
+    seed({
+      sensors: {
+        ...DEFAULT_SETTINGS.sensors,
+        gpuUsage: { ...DEFAULT_SETTINGS.sensors.gpuUsage, customReadingId: "/gpu-nvidia/0/load/0" },
+        gpuTemp: { ...DEFAULT_SETTINGS.sensors.gpuTemp, customReadingId: "/gpu-intel/0/temperature/0" },
+      },
+    });
+
+    useSettingsStore.getState().setSensorData(DATA);
+
+    const rows = gpuRows();
+    expect(rows.selectedGpuId).toBe("/gpu-nvidia/0");
+    expect(rows.gpuTemp).toBe("/gpu-nvidia/0/temperature/0");
+    expect(allRowsOn("/gpu-nvidia/0")).toBe(true);
+  });
+
+  it("adopts the GPU behind the saved GPU Usage sensor, even the integrated one", () => {
+    // Someone reading integrated-GPU load before this existed keeps reading it.
+    seed({
+      sensors: {
+        ...DEFAULT_SETTINGS.sensors,
+        gpuUsage: { ...DEFAULT_SETTINGS.sensors.gpuUsage, customReadingId: "/gpu-intel/0/load/0" },
+      },
+    });
+
+    useSettingsStore.getState().setSensorData(DATA);
+
+    expect(gpuRows().selectedGpuId).toBe("/gpu-intel/0");
+    expect(allRowsOn("/gpu-intel/0")).toBe(true);
+  });
+
+  it("keeps a deliberate GPU choice that disagrees with the default", () => {
+    seed({ selectedGpuId: "/gpu-intel/0" });
+
+    useSettingsStore.getState().setSensorData(DATA);
+
+    expect(gpuRows().selectedGpuId).toBe("/gpu-intel/0");
+    expect(allRowsOn("/gpu-intel/0")).toBe(true);
+  });
+
+  it("keeps a hand-picked sensor that is already on the selected GPU", () => {
+    // "GPU Memory" is not what the keyword order would choose for vramUsage,
+    // so this only stays put if a valid on-GPU choice is left alone.
+    seed({
+      selectedGpuId: "/gpu-nvidia/0",
+      sensors: {
+        ...DEFAULT_SETTINGS.sensors,
+        vramUsage: { ...DEFAULT_SETTINGS.sensors.vramUsage, customReadingId: "/gpu-nvidia/0/load/3" },
+      },
+    });
+
+    useSettingsStore.getState().setSensorData(DATA);
+
+    expect(gpuRows().vramUsage).toBe("/gpu-nvidia/0/load/3");
+  });
+
+  it("leaves a choice alone when its sensor has not arrived yet", () => {
+    // AMD activates temperature, power and load a poll or two late. Re-picking
+    // on a snapshot that has not caught up would destroy the saved choice.
+    const late = "/gpu-nvidia/0/temperature/9";
+    seed({
+      selectedGpuId: "/gpu-nvidia/0",
+      sensors: {
+        ...DEFAULT_SETTINGS.sensors,
+        gpuTemp: { ...DEFAULT_SETTINGS.sensors.gpuTemp, customReadingId: late },
+      },
+    });
+
+    useSettingsStore.getState().setSensorData(DATA);
+
+    expect(gpuRows().gpuTemp).toBe(late);
+  });
+});
+
+describe("selectGpu", () => {
+  it("moves every GPU row onto the newly chosen GPU in one update", () => {
+    useSettingsStore.getState().setSensorData(DATA);
+    expect(gpuRows().selectedGpuId).toBe("/gpu-nvidia/0");
+
+    useSettingsStore.getState().selectGpu("/gpu-intel/0");
+
+    const rows = gpuRows();
+    expect(rows.selectedGpuId).toBe("/gpu-intel/0");
+    expect(rows.gpuUsage).toBe("/gpu-intel/0/load/0");
+    expect(rows.gpuTemp).toBe("/gpu-intel/0/temperature/0");
+    expect(rows.gpuConsumption).toBe("/gpu-intel/0/power/0");
+    expect(allRowsOn("/gpu-intel/0")).toBe(true);
+  });
+
+  it("clears the rows when the chosen GPU has no readings, rather than keeping the old GPU's", () => {
+    // A GPU the device tree reports but LibreHardwareMonitor produced nothing
+    // for. Showing 0 under its name is honest; showing the other GPU's numbers
+    // under its name is the bug this whole change removes.
+    const absent: Hardware = {
+      name: "NVIDIA GeForce RTX 3050 Laptop GPU",
+      identifier: "/gpu-absent/10DE-2507-0",
+      hardwareType: HardwareType.GpuNvidia,
+    };
+
+    useSettingsStore.getState().setSensorData({ ...DATA, hardwares: [absent, INTEL] });
+    useSettingsStore.getState().selectGpu("/gpu-absent/10DE-2507-0");
+
+    const rows = gpuRows();
+    expect(rows.selectedGpuId).toBe("/gpu-absent/10DE-2507-0");
+    expect(rows.gpuUsage).toBe("");
+    expect(rows.gpuTemp).toBe("");
+    expect(rows.gpuConsumption).toBe("");
+    expect(rows.totalVramUsed).toBe("");
+  });
+});
+
+/**
+ * The exact payload a two-GPU laptop puts on the wire, transcribed from a
+ * running sidecar rather than invented here: hardware order, sensor names,
+ * identifiers, sensor-type numbers and values all copied from the dump.
+ *
+ * This exists because the other fixtures in this file are what I *believed*
+ * the wire looked like, and a fixture that agrees with the code but not with
+ * the wire cannot catch a mismatch between them.
+ */
+const WIRE: HardwareMonitorData = {
+  lastPollTime: 0,
+  hardwares: [
+    { name: "NVIDIA GeForce RTX 3050 Laptop GPU", identifier: "/gpu-nvidia/0", hardwareType: 4 },
+    { name: "Intel R UHD Graphics", identifier: "/gpu-intel/0", hardwareType: 6 },
+    { name: "Intel Core i5 11400H", identifier: "/intelcpu/0", hardwareType: 2 },
+    { name: "Total Memory", identifier: "/ram", hardwareType: 3 },
+    { name: "Ethernet", identifier: "/nic/0", hardwareType: 8 },
+  ],
+  sensors: [
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/0", "GPU Core", 5, 42),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/1", "GPU Memory Controller", 5, 12),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/3", "GPU Memory", 5, 30),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/0", "GPU Core", 4, 61),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/1", "GPU Hot Spot", 4, 73),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/power/0", "GPU Package", 2, 55),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/1", "GPU Memory Used", 13, 2048),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/2", "GPU Memory Total", 13, 4096),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/9", "D3D Dedicated Memory Used", 13, 2048),
+    sensor("/gpu-intel/0", "/gpu-intel/0/load/0", "D3D 3D", 5, 7),
+    sensor("/gpu-intel/0", "/gpu-intel/0/load/1", "D3D Video Decode", 5, 3),
+    sensor("/gpu-intel/0", "/gpu-intel/0/temperature/0", "GPU Core", 4, 45),
+    sensor("/gpu-intel/0", "/gpu-intel/0/power/0", "GPU Power", 2, 4),
+    sensor("/gpu-intel/0", "/gpu-intel/0/smalldata/0", "D3D Shared Memory Total", 13, 16384),
+    sensor("/gpu-intel/0", "/gpu-intel/0/smalldata/1", "D3D Shared Memory Used", 13, 900),
+    sensor("/intelcpu/0", "/intelcpu/0/load/0", "CPU Total", 5, 33),
+    sensor("/intelcpu/0", "/intelcpu/0/temperature/0", "CPU Package", 4, 52),
+    sensor("/intelcpu/0", "/intelcpu/0/power/0", "CPU Package", 2, 65),
+    sensor("/ram", "/ram/load/0", "Memory Used", 5, 48),
+    sensor("/nic/0", "/nic/0/throughput/7", "Download Speed", 14, 1234),
+    sensor("/nic/0", "/nic/0/throughput/8", "Upload Speed", 14, 567),
+    sensor("/presentmon", "/presentmon/presented", "Presented", 5, 144),
+    sensor("/presentmon", "/presentmon/frametime", "Frametime", 5, 6.94),
+  ],
+};
+
+describe("the payload a real two-GPU sidecar sends", () => {
+  it("lands on the discrete GPU, matching what the running app chose", () => {
+    useSettingsStore.getState().setSensorData(WIRE);
+
+    const rows = gpuRows();
+    expect(rows.selectedGpuId).toBe("/gpu-nvidia/0");
+    expect(rows.gpuUsage).toBe("/gpu-nvidia/0/load/0");
+    expect(rows.gpuTemp).toBe("/gpu-nvidia/0/temperature/0");
+    expect(rows.gpuConsumption).toBe("/gpu-nvidia/0/power/0");
+    expect(rows.totalVramUsed).toBe("/gpu-nvidia/0/smalldata/1");
+  });
+
+  it("does not let the integrated GPU win on borrowed system memory", () => {
+    // Intel's only "memory total" is 16384 MB of shared system RAM against the
+    // discrete card's 4096 MB of its own. Counting shared memory would pick
+    // the integrated GPU on essentially every laptop.
+    useSettingsStore.getState().setSensorData(WIRE);
+    expect(gpuRows().selectedGpuId).toBe("/gpu-nvidia/0");
+  });
+
+  it("leaves every non-GPU reading alone", () => {
+    useSettingsStore.getState().setSensorData(WIRE);
+
+    const { sensors } = useSettingsStore.getState().settings;
+    expect(sensors.cpuUsage.customReadingId).toBe("/intelcpu/0/load/0");
+    expect(sensors.cpuTemp.customReadingId).toBe("/intelcpu/0/temperature/0");
+    expect(sensors.cpuConsumption.customReadingId).toBe("/intelcpu/0/power/0");
+    expect(sensors.ramUsage.customReadingId).toBe("/ram/load/0");
+    expect(sensors.downRate.customReadingId).toBe("/nic/0/throughput/7");
+    expect(sensors.upRate.customReadingId).toBe("/nic/0/throughput/8");
+    expect(sensors.framerate.customReadingId).toBe("/presentmon/presented");
+    expect(sensors.frametime.customReadingId).toBe("/presentmon/frametime");
+  });
+
+  it("moves every GPU row to the integrated GPU when it is chosen", () => {
+    useSettingsStore.getState().setSensorData(WIRE);
+    useSettingsStore.getState().selectGpu("/gpu-intel/0");
+
+    const rows = gpuRows();
+    expect(rows.gpuUsage).toBe("/gpu-intel/0/load/0");
+    expect(rows.gpuTemp).toBe("/gpu-intel/0/temperature/0");
+    expect(rows.gpuConsumption).toBe("/gpu-intel/0/power/0");
+    expect(allRowsOn("/gpu-intel/0")).toBe(true);
+  });
+});
+
+describe("the idle notice", () => {
+  it("does not carry the old GPU's verdict across a switch", () => {
+    // Silence is timed per GPU. If selectGpu left the previous GPU's verdict
+    // in place, switching away from a parked GPU would leave its "reports 0"
+    // notice sitting under a GPU that is reading fine until the next poll.
+    const parkedNvidia: HardwareMonitorData = {
+      ...DATA,
+      sensors: DATA.sensors.filter((s) => s.hardwareIdentifier !== "/gpu-nvidia/0"),
+    };
+
+    useSettingsStore.getState().setSensorData(parkedNvidia);
+    expect(useSettingsStore.getState().gpuSilence.gpuId).toBe("/gpu-nvidia/0");
+
+    useSettingsStore.getState().selectGpu("/gpu-intel/0");
+
+    const silence = useSettingsStore.getState().gpuSilence;
+    expect(silence.gpuId).toBe("/gpu-intel/0");
+    expect(silence.settled).toBe(false);
+    expect(silence.since).toBeNull();
+  });
+
+  it("starts timing immediately when switching to a GPU that reports nothing", () => {
+    const parkedNvidia: HardwareMonitorData = {
+      ...DATA,
+      sensors: DATA.sensors.filter((s) => s.hardwareIdentifier !== "/gpu-nvidia/0"),
+    };
+
+    useSettingsStore.getState().setSensorData(parkedNvidia);
+    useSettingsStore.getState().selectGpu("/gpu-intel/0");
+    useSettingsStore.getState().selectGpu("/gpu-nvidia/0");
+
+    const silence = useSettingsStore.getState().gpuSilence;
+    expect(silence.gpuId).toBe("/gpu-nvidia/0");
+    // Timing has begun, but nothing is claimed yet.
+    expect(silence.since).not.toBeNull();
+    expect(silence.settled).toBe(false);
+  });
+});
+
+describe("single-GPU machines", () => {
+  it("still resolve a GPU, so the overlay anchors VRAM to something", () => {
+    useSettingsStore.getState().setSensorData({ ...DATA, hardwares: [NVIDIA] });
+
+    expect(gpuRows().selectedGpuId).toBe("/gpu-nvidia/0");
+    expect(allRowsOn("/gpu-nvidia/0")).toBe(true);
+  });
+
+  it("leave CPU and RAM rows to the unscoped picker", () => {
+    // The GPU scoping must not touch anything that is not a GPU.
+    const withCpu: HardwareMonitorData = {
+      ...DATA,
+      hardwares: [NVIDIA, { name: "CPU", identifier: "/amdcpu/0", hardwareType: HardwareType.Cpu }],
+      sensors: [
+        ...DATA.sensors,
+        sensor("/amdcpu/0", "/amdcpu/0/load/0", "CPU Total", SensorType.Load, 20),
+      ],
+    };
+
+    useSettingsStore.getState().setSensorData(withCpu);
+
+    expect(useSettingsStore.getState().settings.sensors.cpuUsage.customReadingId)
+      .toBe("/amdcpu/0/load/0");
+  });
+});

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -13,7 +13,32 @@ import type {
   Hardware,
 } from "@/lib/types";
 import { DEFAULT_SETTINGS, HardwareType, SensorType } from "@/lib/types";
+import {
+  listGpus,
+  nextGpuSilence,
+  NO_GPU_SILENCE,
+  resolveSelectedGpu,
+  sensorsOnGpu,
+  shouldRepickSensor,
+  type GpuSilence,
+} from "@/lib/gpu";
 import * as tauri from "@/lib/tauri";
+
+/**
+ * Best sensor of a given type out of an already-narrowed list, by keyword
+ * preference, falling back to the first of that type.
+ */
+function bestOf(candidates: Sensor[], sensorType: SensorType, prefer: string[]): string {
+  const ofType = candidates.filter((s) => s.sensorType === sensorType);
+  if (ofType.length === 0) return "";
+  for (const keyword of prefer) {
+    const match = ofType.find((s) =>
+      s.name.toLowerCase().includes(keyword.toLowerCase())
+    );
+    if (match) return match.identifier;
+  }
+  return ofType[0].identifier;
+}
 
 function findBest(
   sensors: Sensor[],
@@ -25,29 +50,31 @@ function findBest(
   const hwIds = new Set(
     hardwares.filter((h) => hwTypes.includes(h.hardwareType)).map((h) => h.identifier)
   );
-  const candidates = sensors.filter(
-    (s) => hwIds.has(s.hardwareIdentifier) && s.sensorType === sensorType
+  return bestOf(
+    sensors.filter((s) => hwIds.has(s.hardwareIdentifier)),
+    sensorType,
+    prefer
   );
-  if (candidates.length === 0) return "";
-  for (const keyword of prefer) {
-    const match = candidates.find((s) =>
-      s.name.toLowerCase().includes(keyword.toLowerCase())
-    );
-    if (match) return match.identifier;
-  }
-  return candidates[0].identifier;
+}
+
+/**
+ * What autoSelectSensors decided. `selectedGpuId` is separate from `sensors`
+ * because it lives at the top level of the settings shape, not under it.
+ */
+interface AutoSelection {
+  sensors: Partial<OverlaySettings["sensors"]>;
+  selectedGpuId: string;
 }
 
 function autoSelectSensors(
   data: HardwareMonitorData,
   settings: OverlaySettings
-): Partial<OverlaySettings["sensors"]> | null {
+): AutoSelection | null {
   const { sensors, hardwares } = data;
   const patch: Partial<OverlaySettings["sensors"]> = {};
   let changed = false;
 
   const cpuHw = [HardwareType.Cpu];
-  const gpuHw = [HardwareType.GpuNvidia, HardwareType.GpuAmd, HardwareType.GpuIntel];
 
   const tryFill = <K extends SensorKey>(
     key: K,
@@ -65,14 +92,55 @@ function autoSelectSensors(
     }
   };
 
+  // Every GPU reading comes from one GPU, so the GPU is resolved first and the
+  // rows are then filled from its sensors alone.
+  const gpus = listGpus(hardwares);
+  const selectedGpuId = resolveSelectedGpu(
+    settings.selectedGpuId,
+    settings.sensors.gpuUsage.customReadingId,
+    gpus,
+    sensors
+  );
+  const gpuSensors = sensorsOnGpu(sensors, selectedGpuId);
+
+  if (selectedGpuId !== settings.selectedGpuId) changed = true;
+
+  /**
+   * Fill a GPU row, and re-point it when it names a sensor on another GPU.
+   *
+   * Unlike tryFill, an existing choice is not automatically kept, which is
+   * what repairs a configuration written before the GPU was pinned. See
+   * shouldRepickSensor for when a choice is left alone.
+   *
+   * Clearing rather than keeping is deliberate when the selected GPU has no
+   * sensors at all, a card powered down or whose vendor SDK is not answering:
+   * bestOf returns "" and the row reads 0. Showing 0 for the GPU you chose is
+   * honest; quietly showing the other GPU's numbers is the bug this whole
+   * change exists to remove.
+   */
+  const fillOnGpu = <K extends SensorKey>(
+    key: K,
+    sType: SensorType,
+    prefer: string[]
+  ) => {
+    const current = settings.sensors[key];
+    if (!shouldRepickSensor(current.customReadingId, selectedGpuId, sensors)) return;
+
+    const id = bestOf(gpuSensors, sType, prefer);
+    if (id === current.customReadingId) return;
+
+    patch[key] = { ...current, customReadingId: id } as OverlaySettings["sensors"][K];
+    changed = true;
+  };
+
   tryFill("cpuUsage", cpuHw, SensorType.Load, ["CPU Total", "CPU Package", "CPU"]);
   tryFill("cpuTemp", cpuHw, SensorType.Temperature, ["CPU Package", "CPU Core", "CPU"]);
   tryFill("cpuConsumption", cpuHw, SensorType.Power, ["CPU Package", "CPU"]);
-  tryFill("gpuUsage", gpuHw, SensorType.Load, ["GPU Core", "D3D 3D", "GPU"]);
-  tryFill("gpuTemp", gpuHw, SensorType.Temperature, ["GPU Core", "GPU"]);
-  tryFill("vramUsage", gpuHw, SensorType.Load, ["GPU Memory", "Memory"]);
-  tryFill("totalVramUsed", gpuHw, SensorType.SmallData, ["GPU Memory Used", "Memory Used", "VRAM"]);
-  tryFill("gpuConsumption", gpuHw, SensorType.Power, ["GPU Package", "GPU Power", "GPU"]);
+  fillOnGpu("gpuUsage", SensorType.Load, ["GPU Core", "D3D 3D", "GPU"]);
+  fillOnGpu("gpuTemp", SensorType.Temperature, ["GPU Core", "GPU"]);
+  fillOnGpu("vramUsage", SensorType.Load, ["GPU Memory", "Memory"]);
+  fillOnGpu("totalVramUsed", SensorType.SmallData, ["GPU Memory Used", "Memory Used", "VRAM"]);
+  fillOnGpu("gpuConsumption", SensorType.Power, ["GPU Package", "GPU Power", "GPU"]);
   tryFill("ramUsage", [HardwareType.Memory], SensorType.Load, ["Memory Used", "Memory"]);
   // For network, pick the most active non-virtual adapter
   if (!settings.sensors.downRate.customReadingId || !settings.sensors.upRate.customReadingId) {
@@ -143,7 +211,7 @@ function autoSelectSensors(
     }
   }
 
-  return changed ? patch : null;
+  return changed ? { sensors: patch, selectedGpuId } : null;
 }
 
 /** Set once the sidecar-status event channel has delivered anything. See
@@ -168,10 +236,21 @@ interface SettingsStore {
   sidecarStatus: SidecarStatus;
   overlayVisible: boolean;
   appVersion: string;
+  /**
+   * How long the selected GPU has been reporting nothing. Read `.settled`;
+   * a single snapshot cannot tell a parked GPU from one still warming up.
+   */
+  gpuSilence: GpuSilence;
 
   // Settings actions
   loadSettings: () => Promise<void>;
   updateSettings: (patch: Partial<OverlaySettings>) => void;
+  /**
+   * Pin every GPU reading to one GPU. Not updateSettings({ selectedGpuId }),
+   * because changing the GPU has to re-point every GPU sensor row onto it in
+   * the same update, or they keep naming sensors on the old GPU.
+   */
+  selectGpu: (gpuId: string) => void;
   // Generic over SensorKey so framerate's extra targetAppName field is
   // accepted, while non-framerate keys still see only the base SensorConfig
   // shape.
@@ -222,6 +301,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Nothing has gone wrong until the supervisor says so, so a launch reads as
   // "still starting" rather than as a failure.
   sidecarStatus: { exits: 0, spawnError: null },
+  gpuSilence: NO_GPU_SILENCE,
   overlayVisible: false,
   // Empty until loadAppVersion() resolves the real version — better a brief
   // blank than a misleading hardcoded number.
@@ -313,6 +393,42 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     }
   },
 
+  selectGpu: (gpuId) => {
+    const state = get();
+    const withGpu = { ...state.settings, selectedGpuId: gpuId };
+
+    // Re-point every GPU row in the same tick rather than waiting for the
+    // next poll to do it. Same code path either way, so the two cannot drift;
+    // doing it here only means the sensor pickers never briefly read "Select"
+    // while showing sensors from a GPU that is no longer chosen.
+    const selection = state.sensorData
+      ? autoSelectSensors(state.sensorData, withGpu)
+      : null;
+
+    const newSettings = selection
+      ? {
+          ...withGpu,
+          selectedGpuId: selection.selectedGpuId,
+          sensors: { ...withGpu.sensors, ...selection.sensors },
+        }
+      : withGpu;
+
+    set({ settings: newSettings });
+    debouncedSave(newSettings);
+
+    // Re-time the silence clock against the GPU that was just chosen. Without
+    // this the old GPU's verdict survives until the next poll, so switching
+    // away from a parked GPU leaves its "reports 0" notice sitting under a GPU
+    // that is reading fine for up to a polling interval.
+    set({
+      gpuSilence: nextGpuSilence(
+        NO_GPU_SILENCE,
+        newSettings.selectedGpuId,
+        state.sensorData?.sensors ?? [],
+        Date.now(),
+      ),
+    });
+  },
   updateSettings: (patch) => {
     const newSettings = { ...get().settings, ...patch };
     set({ settings: newSettings });
@@ -391,14 +507,31 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     const state = get();
     const wasNull = state.sensorData === null;
     set({ sensorData: data });
-    // Auto-select sensor IDs the first time data arrives (if any are still empty)
-    const patch = autoSelectSensors(data, state.settings);
-    if (patch) {
-      const newSensors = { ...state.settings.sensors, ...patch };
-      const newSettings = { ...state.settings, sensors: newSensors };
+    // Fill in any sensor still unset, and re-point the GPU rows if they name
+    // a sensor on a GPU other than the selected one.
+    const selection = autoSelectSensors(data, state.settings);
+    if (selection) {
+      const newSensors = { ...state.settings.sensors, ...selection.sensors };
+      const newSettings = {
+        ...state.settings,
+        selectedGpuId: selection.selectedGpuId,
+        sensors: newSensors,
+      };
       set({ settings: newSettings });
       debouncedSave(newSettings);
     }
+    // Advance the "this GPU is reporting nothing" clock. Here rather than in a
+    // component timer because this already runs once per poll, so it needs no
+    // timer of its own and stays a pure function of the previous state, the
+    // snapshot, and the time.
+    set({
+      gpuSilence: nextGpuSilence(
+        state.gpuSilence,
+        selection?.selectedGpuId ?? state.settings.selectedGpuId,
+        data.sensors,
+        Date.now(),
+      ),
+    });
     // Auto-show overlay on first data arrival
     if (wasNull && !state.overlayVisible) {
       set({ overlayVisible: true });


### PR DESCRIPTION
Closes the multi-GPU half of #48.

## The problem

On a machine with more than one GPU there was no way to say which one the overlay should read. Each GPU row auto-selected a sensor independently, so usage could come from the discrete card while temperature came from integrated graphics, and nothing tied them together. The sensor pickers could not tell the two apart either: an NVIDIA GPU and an Intel GPU both expose a temperature sensor named `GPU Core`, so the list rendered two identical rows with no way to choose between them.

The reporter put it as "I installed this app for my RTX3050 but the app only supports iGPU".

## The fix

A GPU picker appears in the GPU section whenever a machine reports more than one GPU, using the same `Select` as the polling-rate control. It is a hard scope rather than a default: each sensor list only offers sensors belonging to the selected GPU, so a mixed configuration is unreachable rather than merely discouraged.

The overlay's VRAM cluster anchors to the same GPU. It previously anchored to whichever GPU the configured "GPU Memory Used" sensor happened to sit on, while the load fallback came from `vramUsage.customReadingId` independently, so the used/total pair and the fallback could describe different cards.

Machines with one GPU see no new control.

## Choosing the default

Ranked by dedicated video memory, because that is what actually separates a discrete card from an integrated one. Hardware type cannot: an AMD integrated GPU reports as `GpuAmd` exactly like a Radeon card does. Shared memory is excluded deliberately, since an integrated GPU reports the system RAM it may borrow, which on a 32 GB laptop would outrank an 8 GB discrete card. Integrated Intel graphics lose the tie when no memory reading has arrived yet, which matters at first launch because sensors activate over the first few polls rather than all at once.

## Upgrading an existing install

The GPU behind the saved "GPU Usage" sensor is adopted and the remaining rows move onto it, which repairs a configuration written before the GPU was pinned. A deliberate choice within the selected GPU is left alone.

A saved sensor that is simply absent from the current snapshot is also left alone. LibreHardwareMonitor only exposes a sensor once it has produced a reading, and AMD GPUs read temperature, power and load through an ADL sampling session that has no sample on the first `Update()`, so re-picking there would discard a deliberate choice on the strength of a snapshot that had not caught up.

## Knowing what is installed

The sidecar no longer relies on LibreHardwareMonitor alone. Its GPU groups enumerate exactly once, in the constructors of `AmdGpuGroup` / `NvidiaGroup` / `IntelGpuGroup`, from ADL, NvAPI and IntelGcl. A vendor SDK that is not answering at that moment produces an empty group that is never retried, so a GPU can be missing for an entire session.

`DisplayAdapters` reads the PnP device tree through CfgMgr32 (`GUID_DISPLAY_DEVICE_ARRIVAL`, present devices only), filtered to the three GPU vendor IDs so software adapters like `ROOT\BasicRender` are not offered as dead choices. It sees a card whether or not its vendor SDK is up, and whether or not the card is currently powered.

When the two lists disagree the GPU groups are rebuilt by toggling `IsGpuEnabled`, capped at five attempts since a rebuild cannot help a GPU whose vendor SDK will never answer. Anything still unaccounted for is reported to the app without sensors, so it stays listed and selectable and reads 0 rather than vanishing. The check runs every 30 seconds and is a device-tree enumeration plus a count compare, so a single-GPU machine never pays for more than that.

Only a rebuild invalidates the cached hardware entries. Clearing them on any other change would also clear the `StopUpdates()` suspension that `MapHardwares` reuses entries to preserve.

## The idle notice

A GPU reporting nothing is explained in the settings, but only after it has stayed silent for two seconds. A single snapshot cannot distinguish a parked GPU from one whose sensors have not activated yet, so the check is asymmetric: two seconds of continuous silence to claim it, one reading to clear it. That also stops a laptop GPU parking and waking during normal use from flashing the notice on and off. It is not shown for a GPU sitting at 0% load that still reports temperature, which is reporting perfectly well.

## Settings shape

`selectedGpuId` is added to the Rust `OverlaySettings` struct as well as the app's. Settings are persisted by deserialising the app's JSON into that struct and serialising it straight back out, so a field the struct does not model is silently dropped on the first save. Two Rust tests pin the round trip and the older-file-without-the-key case.

No wire protocol change. A GPU with no readings rides as an ordinary hardware entry with no sensors, so the known UTF-16-count against UTF-8-bytes framing mismatch is not extended.

## Verification

- 99 frontend tests, up from 39. `dotnet build` 0 warnings, `cargo test --lib` 20/20, clippy unchanged at its five pre-existing style warnings, eslint clean, `tsc` reporting the same five long-standing errors, and vite, sidecar and Tauri release builds all clean.
- The rebuild mechanism was proven against real hardware rather than argued: opening LibreHardwareMonitor with `IsGpuEnabled=false` reproduces the reported situation exactly, with the device tree reporting a GPU that LibreHardwareMonitor does not. The reconciler flags it, and the toggle rebuilds it with all 39 sensors reporting live values.
- Driven end to end on a two-GPU machine simulated by a sidecar speaking the real pipe protocol, so the Rust client, the store, the settings UI and the overlay are all the shipping code path. Confirmed: the discrete GPU is chosen by default, switching moves every GPU reading together, the temperature picker lists one `GPU Core` rather than two, and CPU, RAM, network and FPS readings are unaffected.

## Known gaps

The reconcile-and-rebuild path has never fired for a real cause. It was only ever triggered artificially, since no machine here has two physical GPUs, so vendor-SDK behaviour on a real hybrid laptop is unexercised. If the reporter's log shows their GPU was enumerated all along, the picker alone resolves their report and the reconcile remains insurance.

The placeholder identifier for a GPU with no readings is not stable once that GPU becomes readable, so explicitly selecting one and then having its vendor SDK start answering falls back to the default rather than following it across. It lands on the intended GPU in the common case.

No component test covers the picker or the notice. This project has no DOM test dependencies and its Storybook browser project cannot run locally; the logic behind both is covered by unit tests instead.
