### PR TITLE
Match the settings window and update pill to the design

### DIFF
--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -281,7 +281,7 @@ impl Default for SensorsConfig {
 }
 
 fn default_pill_opacity() -> f32 { 0.3 }
-fn default_font_size_value() -> f32 { 12.0 }
+fn default_font_size_value() -> f32 { 18.0 }
 fn default_font_size_label() -> f32 { 12.0 }
 fn default_number_font_size() -> f32 { 14.0 }
 fn default_number_label_font_size() -> f32 { 10.0 }
@@ -377,7 +377,7 @@ impl Default for OverlaySettings {
             position_y: 0,
             opacity: 1.0,
             pill_opacity: 0.3,
-            font_size_value: 12.0,
+            font_size_value: 18.0,
             font_size_label: 12.0,
             number_font_size: 14.0,
             number_label_font_size: 10.0,

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -144,13 +144,18 @@ export default function App() {
     }
   }, [settings.isDarkTheme]);
 
+  // The window edge is an outline rather than a border: Figma strokes this
+  // frame OUTSIDE, so its stroke costs no layout and 651 is the content box.
+  // A 1px border ate 2 of that and left every card 601 instead of 603.
   return (
-    <div className="relative mx-auto flex h-screen w-full max-w-[651px] flex-col overflow-hidden rounded-[12px] border border-foreground/10 bg-background text-foreground shadow-sm">
+    <div className="relative mx-auto flex h-screen w-full max-w-[651px] flex-col overflow-hidden rounded-[12px] outline outline-1 -outline-offset-1 outline-foreground/10 bg-background text-foreground shadow-sm">
       {showSplash && <SplashScreen onDone={handleSplashDone} />}
       <TopBar />
       <MonitoringBanner />
       <UpdateBanner />
-      <div className="flex min-h-0 flex-1 flex-col gap-5 px-6 pb-6 pt-6">
+      {/* Figma's window: 651 wide, 24 of padding around a 603 content column,
+          20 between the tabs and the content. */}
+      <div className="flex min-h-0 flex-1 flex-col gap-[var(--spacingL)] p-[var(--spacingXl)]">
         <TabNav activeTab={activeTab} onTabChange={setActiveTab} />
         <div className="min-h-0 flex-1 overflow-y-auto">
           {/* Tabs stay mounted and hide via CSS so local UI state (expanded

--- a/tauri-app/src/app/components/Button.tsx
+++ b/tauri-app/src/app/components/Button.tsx
@@ -12,16 +12,13 @@ const buttonVariants = cva(
           "rounded-[var(--cornerRound)] bg-[var(--bgSurfaceRaised)] text-[var(--textHeading)] hover:bg-[var(--bgSurfaceSunken)] active:bg-[var(--bgSurfaceRaised)]",
         "filled-dark":
           "rounded-[var(--cornerRound)] bg-[var(--bgBrand)] text-[var(--textInverse)] hover:bg-[var(--bgBrandHover)] active:bg-[var(--bgBrand)]",
-        link: "text-[var(--textInverse)] hover:text-[var(--textParagraph1)] active:text-[var(--textInverse)]",
+        link: "rounded-[var(--cornerRound)] text-[var(--textInverse)] hover:text-[var(--textParagraph1)] active:text-[var(--textInverse)]",
       },
       size: {
         sm: "px-[var(--spacingL)] py-[var(--spacingS)] text-body-sm-medium",
         md: "h-[54px] px-[var(--spacingXxl)] py-[var(--spacingS)] text-body-md-medium",
       },
     },
-    compoundVariants: [
-      { variant: "link", size: "sm", className: "px-0 py-0" },
-    ],
     defaultVariants: {
       variant: "filled-white",
       size: "sm",

--- a/tauri-app/src/app/components/ToastBanner.tsx
+++ b/tauri-app/src/app/components/ToastBanner.tsx
@@ -2,22 +2,49 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@/lib/utils";
 
-function ToastBanner({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+/**
+ * The update pill, matched to Figma 2759:11138 / 11446 / 11750 (available,
+ * downloading, ready to install).
+ *
+ * Every value below is read off those nodes: 64 tall from py 12 around a 40
+ * chip, padding 12 left and 16 right, gap 12, radius 100 (cornerRound), fill
+ * Bg/Brand, and a 0 4 24 #0000003d drop shadow which is exactly --shadow-large.
+ *
+ * The two text rows set size, weight and leading directly instead of using
+ * text-body-sm-medium / text-label-sm-medium. Figma leaves both nodes on AUTO
+ * leading, which measures 17 and 15, while those classes apply 16; and because
+ * they are plain CSS rather than Tailwind utilities they sit outside the
+ * utilities layer, so a leading-[17px] alongside one of them is simply ignored.
+ */
+function ToastBanner({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       role="status"
       className={cn(
-        "flex items-center gap-[var(--spacingS)] rounded-[var(--cornerRound)] bg-[var(--bgBrand)] px-[var(--spacingM)] py-[14px] shadow-[var(--shadow-large)]",
-        className
+        "flex items-center gap-[var(--spacingS)] rounded-[var(--cornerRound)] bg-[var(--bgBrand)]",
+        "py-[var(--spacingS)] pl-[var(--spacingS)] pr-[var(--spacingM)]",
+        "shadow-[var(--shadow-large)]",
+        className,
       )}
       {...props}
     />
   );
 }
 
+/**
+ * The 40x40 leading chip.
+ *
+ * Fill is --bgBrandSubtle rather than Figma's literal value. Figma binds this
+ * fill to Gray/800, which lives in the Primitives collection and has one mode,
+ * while the pill around it is Bg/Brand from Colors, which has Light and Dark.
+ * In dark mode the pill flips to #fafafa and Gray/800 does not move, so the
+ * chip stays #1f242f and the icon (Icon/Inverse, which does flip, to #0c111d)
+ * disappears into it. That is a slip in the design file, not a look to copy.
+ *
+ * --bgBrandSubtle is the semantic pair for Bg/Brand: #161b26 on the dark pill,
+ * #ececed on the light one. In light mode it is one shade off the #1f242f Figma
+ * shows, which is the cost of the chip surviving a theme switch.
+ */
 function ToastBannerIcon({
   className,
   asChild = false,
@@ -27,24 +54,19 @@ function ToastBannerIcon({
   return (
     <Comp
       className={cn(
-        "flex shrink-0 items-center justify-center rounded-[var(--cornerRound)] bg-[var(--bgBrandSubtle)] p-[var(--spacingSx)] text-[var(--textInverse)]",
-        className
+        "flex size-[40px] shrink-0 items-center justify-center rounded-[var(--cornerRound)]",
+        "bg-[var(--bgBrandSubtle)] text-[var(--iconInverse)]",
+        className,
       )}
       {...props}
     />
   );
 }
 
-function ToastBannerContent({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function ToastBannerContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn(
-        "flex min-w-0 flex-1 flex-col gap-[var(--spacingXxs)]",
-        className
-      )}
+      className={cn("flex min-w-0 flex-1 flex-col gap-[var(--spacingXxs)]", className)}
       {...props}
     />
   );
@@ -59,8 +81,8 @@ function ToastBannerTitle({
   return (
     <Comp
       className={cn(
-        "truncate text-body-sm-medium text-[var(--textInverse)]",
-        className
+        "truncate text-[14px] font-medium leading-[17px] text-[var(--textInverse)]",
+        className,
       )}
       {...props}
     />
@@ -76,21 +98,19 @@ function ToastBannerDescription({
   return (
     <Comp
       className={cn(
-        "truncate text-label-sm-medium text-[var(--textDisabled)]",
-        className
+        "truncate text-[12px] font-medium leading-[15px] text-[var(--textDisabled)]",
+        className,
       )}
       {...props}
     />
   );
 }
 
-function ToastBannerActions({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+/** Gap 16 between the button group and the close control, per Figma. */
+function ToastBannerActions({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex shrink-0 items-center gap-[var(--spacingL)]", className)}
+      className={cn("flex shrink-0 items-center gap-[var(--spacingM)]", className)}
       {...props}
     />
   );

--- a/tauri-app/src/components/settings/UpdateBanner.tsx
+++ b/tauri-app/src/components/settings/UpdateBanner.tsx
@@ -142,6 +142,7 @@ const PILL_WIDTH_DOWNLOADING = "max-w-[394px]";
 export function UpdateBanner() {
   const status = useUpdaterStore((s) => s.status);
   const version = useUpdaterStore((s) => s.availableVersion);
+  const error = useUpdaterStore((s) => s.error);
   const progress = useUpdaterStore((s) => s.progress);
   const dismissed = useUpdaterStore((s) => s.dismissed);
   const download = useUpdaterStore((s) => s.download);
@@ -163,6 +164,13 @@ export function UpdateBanner() {
   // share one branch.
   const downloaded = status === "ready" || installing;
 
+  // An install only fails after prepare_for_update has stopped the sidecar
+  // supervisor, and nothing restarts it: the flag it clears is never set back,
+  // and the supervisor thread has already returned. So a failed install leaves
+  // the app with no sensor readings until it is restarted, and saying "ready to
+  // install" again would hide that. Same slot, same buttons, truthful title.
+  const installFailed = status === "ready" && !!error;
+
   // Figma has no installing state, so it reuses the ready one and drops the
   // buttons. It is on screen for the moment between the installer starting and
   // the app relaunching.
@@ -170,9 +178,11 @@ export function UpdateBanner() {
     ? "Downloading update..."
     : installing
       ? "Installing update..."
-      : status === "ready"
-        ? "Update ready to install"
-        : "New update is available";
+      : installFailed
+        ? "Install failed, restart Cleanmeter"
+        : status === "ready"
+          ? "Update ready to install"
+          : "New update is available";
 
   // Inset 24 on all three sides, matching the window's own padding, so the
   // pill lines up with the cards above it at every width and not only where it

--- a/tauri-app/src/components/settings/UpdateBanner.tsx
+++ b/tauri-app/src/components/settings/UpdateBanner.tsx
@@ -7,82 +7,257 @@ import {
   ToastBannerActions,
 } from "@/app/components/ToastBanner";
 import { Button } from "@/app/components/Button";
+import { cn } from "@/lib/utils";
 import { useUpdaterStore } from "@/stores/updater-store";
 
-// Matches the CloudDownloadIcon used in the ToastBanner design (Storybook).
+// Where "What's new" goes: the changelog page on the marketing site, which
+// lists the GitHub releases.
+//
+// The www is required. The apex cleanmeter.app has no A/AAAA/CNAME record at
+// all, so a bare-domain link does not resolve; only www is CNAMEd to the host.
+const CHANGELOG_URL = "https://www.cleanmeter.app/changelog";
+
+/* ------------------------------------------------------------------ */
+/*  Icons, exported from Figma. Not redrawn.                           */
+/* ------------------------------------------------------------------ */
+
+// Figma 2759:11139 (cloud_download), 20x20 box, glyph 18.33x13.25.
 function CloudDownloadIcon() {
   return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-    >
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
       <path
-        d="M5.833 16.667a4.02 4.02 0 0 1-2.948-1.219A4.02 4.02 0 0 1 1.667 12.5c0-1.028.347-1.93 1.041-2.708.695-.778 1.57-1.236 2.625-1.375a5.197 5.197 0 0 1 1.896-3.063A5.143 5.143 0 0 1 10.417 4.17c1.444 0 2.687.5 3.729 1.5 1.041 1 1.618 2.222 1.729 3.667a4.078 4.078 0 0 1 2.458 1.396c.667.805 1 1.725 1 2.76 0 1.138-.395 2.106-1.187 2.906-.792.791-1.76 1.19-2.896 1.198v-.063H5.833Zm4.167-3l3-3h-2.083V7.5H9.083v3.167H7l3 3Z"
+        d="M9.16659 10.1243V5.08268C8.11103 5.27713 7.29159 5.78754 6.70825 6.61393C6.12492 7.44032 5.83325 8.29102 5.83325 9.16602H5.41659C4.61103 9.16602 3.92353 9.45074 3.35409 10.0202C2.78464 10.5896 2.49992 11.2771 2.49992 12.0827C2.49992 12.8882 2.78464 13.5757 3.35409 14.1452C3.92353 14.7146 4.61103 14.9993 5.41659 14.9993H15.4166C15.9999 14.9993 16.493 14.798 16.8958 14.3952C17.2985 13.9924 17.4999 13.4993 17.4999 12.916C17.4999 12.3327 17.2985 11.8396 16.8958 11.4368C16.493 11.0341 15.9999 10.8327 15.4166 10.8327H14.1666V9.16602C14.1666 8.49935 14.0138 7.87782 13.7083 7.30143C13.4027 6.72504 12.9999 6.23546 12.4999 5.83268V3.89518C13.5277 4.38129 14.3402 5.10004 14.9374 6.05143C15.5346 7.00282 15.8333 8.04102 15.8333 9.16602C16.7916 9.27713 17.5867 9.69032 18.2187 10.4056C18.8506 11.1209 19.1666 11.9577 19.1666 12.916C19.1666 13.9577 18.802 14.8431 18.0728 15.5723C17.3437 16.3014 16.4583 16.666 15.4166 16.666H5.41659C4.1527 16.666 3.07284 16.2285 2.177 15.3535C1.28117 14.4785 0.833252 13.4091 0.833252 12.1452C0.833252 11.0618 1.15964 10.0966 1.81242 9.24935C2.4652 8.40213 3.31936 7.86046 4.37492 7.62435C4.61103 6.62435 5.20131 5.67296 6.14575 4.77018C7.0902 3.8674 8.09714 3.41602 9.16659 3.41602C9.62492 3.41602 10.0173 3.57921 10.3437 3.9056C10.6701 4.23199 10.8333 4.62435 10.8333 5.08268V10.1243L11.5833 9.39518C11.736 9.2424 11.927 9.16602 12.1562 9.16602C12.3853 9.16602 12.5833 9.24935 12.7499 9.41602C12.9027 9.56879 12.9791 9.76324 12.9791 9.99935C12.9791 10.2355 12.9027 10.4299 12.7499 10.5827L10.5833 12.7493C10.4166 12.916 10.2221 12.9993 9.99992 12.9993C9.7777 12.9993 9.58325 12.916 9.41659 12.7493L7.24992 10.5827C7.09714 10.4299 7.01728 10.2389 7.01034 10.0098C7.00339 9.7806 7.08325 9.58268 7.24992 9.41602C7.4027 9.26324 7.59367 9.18338 7.82284 9.17643C8.052 9.16949 8.24992 9.2424 8.41659 9.39518L9.16659 10.1243Z"
         fill="currentColor"
       />
     </svg>
   );
 }
 
-// Floating update badge. Renders only while an update is available or being
-// installed; otherwise nothing. Lives in the settings window (mounted in App).
+// Figma 2759:11751 (download_done), 20x20 box, glyph 12.87x13.
+function DownloadDoneIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <path
+        d="M7.95834 10.9596L15 3.91797C15.1667 3.7513 15.3646 3.66797 15.5938 3.66797C15.8229 3.66797 16.0208 3.7513 16.1875 3.91797C16.3542 4.08464 16.4375 4.28255 16.4375 4.51172C16.4375 4.74089 16.3542 4.9388 16.1875 5.10547L8.54168 12.7513C8.37501 12.918 8.18057 13.0013 7.95834 13.0013C7.73612 13.0013 7.54168 12.918 7.37501 12.7513L3.81251 9.1888C3.64584 9.02214 3.56598 8.82422 3.57293 8.59505C3.57987 8.36589 3.66668 8.16797 3.83334 8.0013C4.00001 7.83464 4.19793 7.7513 4.42709 7.7513C4.65626 7.7513 4.85418 7.83464 5.02084 8.0013L7.95834 10.9596ZM5.00001 16.668C4.7639 16.668 4.56598 16.5881 4.40626 16.4284C4.24654 16.2687 4.16668 16.0707 4.16668 15.8346C4.16668 15.5985 4.24654 15.4006 4.40626 15.2409C4.56598 15.0812 4.7639 15.0013 5.00001 15.0013H15C15.2361 15.0013 15.434 15.0812 15.5938 15.2409C15.7535 15.4006 15.8333 15.5985 15.8333 15.8346C15.8333 16.0707 15.7535 16.2687 15.5938 16.4284C15.434 16.5881 15.2361 16.668 15 16.668H5.00001Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+// Figma 2759:12536 (close), 20x20 box, glyph 10.96x10.96.
+function CloseIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <path
+        d="M9.99992 11.1673L5.91659 15.2507C5.76381 15.4034 5.56936 15.4798 5.33325 15.4798C5.09714 15.4798 4.9027 15.4034 4.74992 15.2507C4.59714 15.0979 4.52075 14.9034 4.52075 14.6673C4.52075 14.4312 4.59714 14.2368 4.74992 14.084L8.83325 10.0007L4.74992 5.91732C4.59714 5.76454 4.52075 5.5701 4.52075 5.33398C4.52075 5.09787 4.59714 4.90343 4.74992 4.75065C4.9027 4.59787 5.09714 4.52148 5.33325 4.52148C5.56936 4.52148 5.76381 4.59787 5.91659 4.75065L9.99992 8.83398L14.0833 4.75065C14.236 4.59787 14.4305 4.52148 14.6666 4.52148C14.9027 4.52148 15.0971 4.59787 15.2499 4.75065C15.4027 4.90343 15.4791 5.09787 15.4791 5.33398C15.4791 5.5701 15.4027 5.76454 15.2499 5.91732L11.1666 10.0007L15.2499 14.084C15.4027 14.2368 15.4791 14.4312 15.4791 14.6673C15.4791 14.9034 15.4027 15.0979 15.2499 15.2507C15.0971 15.4034 14.9027 15.4798 14.6666 15.4798C14.4305 15.4798 14.236 15.4034 14.0833 15.2507L9.99992 11.1673Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Download progress ring                                             */
+/* ------------------------------------------------------------------ */
+
+// Geometry taken from the two arcs in Figma 2759:11453: a 24 box with
+// innerRadius 0.74, which is a 3.12 stroke on a 10.44 radius. The track is
+// white at 10%, the arc is Bg/Success Hover, and Figma starts it at twelve
+// o'clock (arcData startingAngle 4.712 rad) running clockwise.
+const RING_RADIUS = 10.44;
+const RING_STROKE = 3.12;
+const RING_LENGTH = 2 * Math.PI * RING_RADIUS;
+
+// Figma draws the arc at a 3.414 rad sweep, which is 54.3% of the circle. That
+// is the frame the indeterminate case spins, so a download with no known length
+// still shows the design's arc rather than an invented one.
+const RING_INDETERMINATE_SWEEP = 3.414385 / (2 * Math.PI);
+
+function ProgressRing({ progress }: { progress: number }) {
+  const indeterminate = progress < 0;
+  const fraction = indeterminate
+    ? RING_INDETERMINATE_SWEEP
+    : Math.min(1, Math.max(0, progress / 100));
+
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={cn(indeterminate && "animate-spin motion-reduce:animate-none")}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={indeterminate ? undefined : progress}
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r={RING_RADIUS}
+        stroke="var(--textInverse)"
+        strokeOpacity={0.1}
+        strokeWidth={RING_STROKE}
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r={RING_RADIUS}
+        stroke="var(--bgSuccessHover)"
+        strokeWidth={RING_STROKE}
+        strokeDasharray={RING_LENGTH}
+        strokeDashoffset={RING_LENGTH * (1 - fraction)}
+        transform="rotate(-90 12 12)"
+        // Linear, and shorter than the gap between two progress events, so the
+        // arc keeps moving between updates without ever lagging behind them.
+        className="transition-[stroke-dashoffset] duration-200 ease-linear motion-reduce:transition-none"
+      />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  The pill                                                           */
+/* ------------------------------------------------------------------ */
+
+// Widths are Figma's: 603 for the offer and the ready states, 394 while
+// downloading. 603 is also the settings window's content column, so the pill
+// lines up with the cards above it, and the 394 one centres.
+//
+// The pill's own right padding is 16. Figma's ready state says 20 while the
+// other two say 16, and a padding that changed with the state would jump the
+// close button mid-transition.
+const PILL_WIDTH = "max-w-[603px]";
+const PILL_WIDTH_DOWNLOADING = "max-w-[394px]";
+
+/**
+ * Floating update pill. Renders while an update is available, downloading or
+ * waiting to install; otherwise nothing. Lives in the settings window (mounted
+ * in App).
+ *
+ * Matched to Figma 2759:11138 (available), 2759:11446 (downloading) and
+ * 2759:11750 (ready to install).
+ */
 export function UpdateBanner() {
   const status = useUpdaterStore((s) => s.status);
   const version = useUpdaterStore((s) => s.availableVersion);
   const progress = useUpdaterStore((s) => s.progress);
   const dismissed = useUpdaterStore((s) => s.dismissed);
-  const downloadAndInstall = useUpdaterStore((s) => s.downloadAndInstall);
+  const download = useUpdaterStore((s) => s.download);
+  const install = useUpdaterStore((s) => s.install);
+  const cancel = useUpdaterStore((s) => s.cancel);
   const dismiss = useUpdaterStore((s) => s.dismiss);
 
   const visible =
     !dismissed &&
     (status === "available" ||
       status === "downloading" ||
+      status === "ready" ||
       status === "installing");
   if (!visible) return null;
 
-  const title =
-    status === "downloading"
-      ? "Downloading update…"
-      : status === "installing"
-        ? "Installing — the app will restart"
-        : "New update available";
+  const downloading = status === "downloading";
+  const installing = status === "installing";
+  // Installing shows the ready layout with its buttons disabled, so the two
+  // share one branch.
+  const downloaded = status === "ready" || installing;
 
-  const description =
-    status === "downloading"
-      ? progress >= 0
-        ? `${progress}%`
-        : "Downloading…"
-      : version
-        ? `v${version}`
-        : undefined;
+  // Figma has no installing state, so it reuses the ready one and drops the
+  // buttons. It is on screen for the moment between the installer starting and
+  // the app relaunching.
+  const title = downloading
+    ? "Downloading update..."
+    : installing
+      ? "Installing update..."
+      : status === "ready"
+        ? "Update ready to install"
+        : "New update is available";
 
-  const busy = status === "downloading" || status === "installing";
-
+  // Inset 24 on all three sides, matching the window's own padding, so the
+  // pill lines up with the cards above it at every width and not only where it
+  // happens to hit its 603 cap.
+  //
+  // Figma has three instances of this pill in one frame: 24 from the bottom on
+  // two of them and 23 on the third, and 24 from each side on all of them. The
+  // 23 is a nudge, so 24 is the number.
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-[var(--spacingL)] z-50 flex justify-center px-[var(--spacingL)]">
-      <ToastBanner className="pointer-events-auto w-full max-w-[499px]">
+    <div className="pointer-events-none fixed inset-x-0 bottom-[var(--spacingXl)] z-50 flex justify-center px-[var(--spacingXl)]">
+      <ToastBanner
+        className={cn(
+          "pointer-events-auto w-full",
+          // The pill's own travel between 603 and 394. max-width rather than
+          // width so both ends resolve to px and interpolate; the easing is the
+          // one the collapsibles use, over a little longer because this moves
+          // roughly 200px rather than rotating an icon.
+          "transition-[max-width] duration-300 ease-[cubic-bezier(0.165,0.84,0.44,1)] motion-reduce:transition-none",
+          downloading ? PILL_WIDTH_DOWNLOADING : PILL_WIDTH,
+        )}
+      >
         <ToastBannerIcon>
-          <CloudDownloadIcon />
+          {downloading ? (
+            <ProgressRing progress={progress} />
+          ) : downloaded ? (
+            <DownloadDoneIcon />
+          ) : (
+            <CloudDownloadIcon />
+          )}
         </ToastBannerIcon>
+
         <ToastBannerContent>
           <ToastBannerTitle>{title}</ToastBannerTitle>
-          {description && (
-            <ToastBannerDescription>{description}</ToastBannerDescription>
-          )}
+          {version && <ToastBannerDescription>v{version}</ToastBannerDescription>}
         </ToastBannerContent>
-        {!busy && (
-          <ToastBannerActions>
-            <Button variant="link" onClick={dismiss}>
-              Later
-            </Button>
-            <Button variant="filled-white" onClick={downloadAndInstall}>
-              Update now
-            </Button>
+
+        {downloading ? (
+          <Button
+            variant="link"
+            size="sm"
+            onClick={cancel}
+            // Figma pads Cancel 12 all round, where the other buttons get 20
+            // on the sides.
+            className="shrink-0 px-[var(--spacingS)] animate-in fade-in-0 duration-200 motion-reduce:animate-none"
+          >
+            Cancel
+          </Button>
+        ) : (
+          <ToastBannerActions className="animate-in fade-in-0 duration-200 motion-reduce:animate-none">
+            {/* The two buttons touch: Figma puts them in a frame with gap 0. */}
+            <div className="flex items-center">
+              {downloaded ? (
+                <Button variant="link" size="sm" onClick={dismiss} disabled={installing}>
+                  Later
+                </Button>
+              ) : (
+                <Button variant="link" size="sm" asChild>
+                  <a href={CHANGELOG_URL} target="_blank" rel="noreferrer">
+                    What&rsquo;s new
+                  </a>
+                </Button>
+              )}
+              {downloaded ? (
+                <Button
+                  variant="filled-white"
+                  size="sm"
+                  onClick={install}
+                  disabled={installing}
+                >
+                  Install now
+                </Button>
+              ) : (
+                <Button variant="filled-white" size="sm" onClick={download}>
+                  Update now
+                </Button>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={dismiss}
+              aria-label="Dismiss"
+              className="flex size-[20px] shrink-0 cursor-pointer items-center justify-center text-[var(--iconSubtle)] transition-colors duration-150 hover:text-[var(--iconSubtleHover)]"
+            >
+              <CloseIcon />
+            </button>
           </ToastBannerActions>
         )}
       </ToastBanner>

--- a/tauri-app/src/components/settings/help/AboutSection.tsx
+++ b/tauri-app/src/components/settings/help/AboutSection.tsx
@@ -1,9 +1,15 @@
 import { CollapsibleCard } from "../style/CollapsibleCard";
 
-// Copy transcribed verbatim from Figma node 2664:2793 (curly quotes and all).
-// Line breaks are pinned to match the Figma layout exactly: this is a
-// fixed-width (563px) panel, so each line is an explicit break; blank lines
-// between paragraphs are the double newline.
+// Copy transcribed verbatim from Figma node 2664:2793 (curly quotes and all),
+// with the closing paragraph carrying two corrections Saad made after that
+// node was drawn: "feature requests" rather than "feature request", and "an
+// overlay that gamers" rather than "an overlay gamers".
+//
+// Line breaks are pinned to match the Figma layout: this is a fixed-width
+// (563px) panel, so each line is an explicit break and blank lines between
+// paragraphs are the double newline. The two added words push the closing
+// paragraph past its old break points, so its last two lines are re-flowed to
+// keep every line inside the panel; nothing else moves.
 const ABOUT_PARAGRAPHS: string[][] = [
   [
     "“Most performance monitoring overlays are cluttered, difficult to configure, and",
@@ -23,15 +29,15 @@ const ABOUT_PARAGRAPHS: string[][] = [
   ],
   [
     "We’re building Cleanmeter alongside the PC community, taking in all the feedback,",
-    "feature request, and issues to create an overlay gamers, creators, and PC",
-    "enthusiasts actually enjoy using. :) ”",
+    "feature requests, and issues to create an overlay that gamers, creators,",
+    "and PC enthusiasts actually enjoy using. :) ”",
   ],
 ];
 const ABOUT_BODY = ABOUT_PARAGRAPHS.map((lines) => lines.join("\n")).join("\n\n");
 
 export function AboutSection() {
   return (
-    <CollapsibleCard title="About">
+    <CollapsibleCard title="About" defaultOpen={false}>
       <div className="flex flex-col gap-5">
         <p className="whitespace-pre-line text-[14px] font-medium leading-[1.5] text-foreground">
           {ABOUT_BODY}

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -7,9 +7,9 @@ import {
   Select,
   SelectContent,
   SelectItem,
-  SelectTrigger,
   SelectValue,
 } from "@/components/shadcn/select";
+import { SelectFieldTrigger } from "@/components/ui/SelectField";
 import { cn } from "@/lib/utils";
 import { getAutoStart, setAutoStart } from "@/lib/tauri";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -35,8 +35,8 @@ function SectionCard({
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex w-full flex-col gap-5 rounded-[12px] bg-[var(--bgSurfaceRaised)] p-5">
-      <h2 className="text-[13px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+    <section className="flex w-full flex-col gap-[var(--spacingL)] rounded-[var(--cornerXl)] bg-[var(--bgSurfaceRaised)] p-[var(--spacingL)]">
+      <h2 className="text-[13px] font-semibold uppercase leading-[16px] tracking-[0.1em] text-muted-foreground">
         {title}
       </h2>
       {children}
@@ -73,48 +73,48 @@ function GeneralSection() {
 
   return (
     <SectionCard title="General">
-      <div className="flex flex-col gap-5">
-        <div className="flex flex-col gap-3">
-          <label className="flex cursor-pointer items-center gap-2 text-[14px] font-medium text-foreground">
+      {/* Three blocks, laid out by the card's own 20 gap rather than a wrapper
+          of its own: Figma 2526:6755 puts the checkboxes, the divider and the
+          Pixel Shift row 20 apart. */}
+      <div className="flex flex-col gap-[var(--spacingS)]">
+        <label className="flex cursor-pointer items-center gap-[var(--spacingXs)] text-[14px] font-medium text-foreground">
             <Checkbox
               checked={startWithWindows}
               disabled={autoStartPending}
               onCheckedChange={(v) => handleStartWithWindows(v === true)}
             />
-            Start with windows
-          </label>
-          <label className="flex cursor-pointer items-center gap-2 text-[14px] font-medium text-foreground">
-            <Checkbox
-              checked={startMinimized}
-              onCheckedChange={(v) =>
-                updatePreferences({ startMinimized: v === true })
-              }
-            />
-            Start minimized
-          </label>
-        </div>
-        <div className="h-px w-full bg-[var(--borderSubtle)]" />
-        <div className="flex items-center gap-3">
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-[var(--cornerRound)] border border-[var(--borderBold)] bg-[var(--bgSurfaceRaised)]">
-            {/* The glyph is geometrically centered but top-heavy (solid
-                monitor body over thin legs), which reads as sitting high in
-                the circle — nudge down 1px for optical center. */}
-            <ComputerIcon className="size-5 translate-y-[1px] text-[var(--textParagraph1)]" />
-          </div>
-          <div className="flex min-w-0 flex-1 flex-col gap-[6px]">
-            <span className="text-[14px] font-medium text-[var(--textHeading)]">
-              Pixel Shift
-            </span>
-            <span className="text-[14px] font-normal text-[var(--textParagraph1)]">
-              Shifts the overlay periodically to avoid OLED burn-in.
-            </span>
-          </div>
-          <Switch
-            checked={pixelShift}
-            onCheckedChange={(v) => updateSettings({ pixelShift: v })}
-            aria-label="Pixel Shift"
+          Start with windows
+        </label>
+        <label className="flex cursor-pointer items-center gap-[var(--spacingXs)] text-[14px] font-medium text-foreground">
+          <Checkbox
+            checked={startMinimized}
+            onCheckedChange={(v) =>
+              updatePreferences({ startMinimized: v === true })
+            }
           />
+          Start minimized
+        </label>
+      </div>
+      <div className="h-px w-full shrink-0 bg-[var(--borderSubtle)]" />
+      <div className="flex items-center gap-[var(--spacingS)]">
+        <div className="flex size-[40px] shrink-0 items-center justify-center rounded-[var(--cornerRound)] border border-[var(--borderBold)] bg-[var(--bgSurfaceRaised)]">
+          {/* No optical nudge: the exported glyph carries Figma's own 1.67
+              inset inside a 20 box, so centring the box centres the glyph. */}
+          <ComputerIcon className="size-[20px] text-[var(--textParagraph1)]" />
         </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-[6px]">
+          <span className="text-[14px] font-medium leading-[17px] text-[var(--textHeading)]">
+            Pixel Shift
+          </span>
+          <span className="text-[14px] font-normal leading-[17px] text-[var(--textParagraph1)]">
+            Shifts the overlay periodically to avoid OLED burn-in.
+          </span>
+        </div>
+        <Switch
+          checked={pixelShift}
+          onCheckedChange={(v) => updateSettings({ pixelShift: v })}
+          aria-label="Pixel Shift"
+        />
       </div>
     </SectionCard>
   );
@@ -178,16 +178,16 @@ function PollingRateSection() {
 
   return (
     <SectionCard title="Polling rate">
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-[var(--spacingS)]">
         <Select
           value={String(pollingRate)}
           onValueChange={(v) =>
             updateSettings({ pollingRate: parseInt(v, 10) })
           }
         >
-          <SelectTrigger className="w-full rounded-[8px] border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] font-medium shadow-[0_1px_2px_rgba(16,24,40,0.05)]">
+          <SelectFieldTrigger label="Polling rate:">
             <SelectValue />
-          </SelectTrigger>
+          </SelectFieldTrigger>
           <SelectContent>
             {POLLING_RATES.map((rate) => (
               <SelectItem key={rate} value={String(rate)}>
@@ -196,8 +196,8 @@ function PollingRateSection() {
             ))}
           </SelectContent>
         </Select>
-        <div className="flex items-center gap-2 text-[12px] font-medium text-muted-foreground">
-          <InfoIcon className="size-4 shrink-0" />
+        <div className="flex items-center gap-[var(--spacingXxxs)] text-[12px] font-medium leading-[15px] text-[var(--textParagraph1)]">
+          <InfoIcon className="size-[16px] shrink-0" />
           <span>The interval in milliseconds the app will update data</span>
         </div>
       </div>
@@ -252,7 +252,10 @@ function AppearanceSection() {
 
   return (
     <SectionCard title="Appearance">
-      <div className="flex gap-3">
+      {/* Figma 2526:6791: three cards 12 apart, each a 104 preview over a 49
+          label row. The border is an inset shadow rather than a real border so
+          the 2 of a selected card does not resize the content. */}
+      <div className="flex gap-[var(--spacingS)]">
         {THEME_OPTIONS.map(({ value, label, Preview }) => {
           const selected = themeMode === value;
           return (
@@ -267,13 +270,17 @@ function AppearanceSection() {
               style={{
                 boxShadow: selected
                   ? "inset 0 0 0 2px var(--borderBrand), 0 4px 8px 0 rgba(0,0,0,0.02)"
-                  : "inset 0 0 0 1px var(--borderBold), 0 4px 8px 0 rgba(0,0,0,0.02)",
+                  // Border/Bold already carries alpha, and Figma halves it
+                  // again with a 50% stroke opacity on the layer. Mixing the
+                  // token toward transparent reproduces that in both themes
+                  // instead of hardcoding one theme's result.
+                  : "inset 0 0 0 1px color-mix(in srgb, var(--borderBold) 50%, transparent), 0 4px 8px 0 rgba(0,0,0,0.02)",
               }}
             >
-              <div className="h-[104px] w-full pb-0 pl-1 pr-1 pt-1">
+              <div className="h-[104px] w-full pb-0 pl-[4px] pr-[4px] pt-[4px]">
                 <Preview />
               </div>
-              <div className="flex h-[49px] items-center px-4 text-[14px] font-medium text-foreground">
+              <div className="flex h-[49px] items-center px-[var(--spacingM)] text-[14px] font-medium leading-[17px] text-[var(--textHeading)]">
                 {label}
               </div>
             </button>
@@ -348,6 +355,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/SCgXtTMNvJ";
 // The actual "download & install" happens from the floating UpdateBanner.
 function UpdatesButton() {
   const status = useUpdaterStore((s) => s.status);
+  const dismissed = useUpdaterStore((s) => s.dismissed);
   const check = useUpdaterStore((s) => s.check);
 
   const busy =
@@ -355,18 +363,29 @@ function UpdatesButton() {
     status === "downloading" ||
     status === "installing";
 
+  // "ready" is deliberately not busy: a downloaded update whose pill was
+  // dismissed is brought back by pressing this, which is what check() does
+  // when it sees that status.
+  //
+  // The two labels that point at the pill only apply while the pill is on
+  // screen. Once it has been dismissed they would be pointing at nothing, so
+  // the button goes back to inviting the press that brings it back.
+  const pending = (status === "available" || status === "ready") && !dismissed;
+
   const label =
     status === "checking"
       ? "Checking for updates…"
-      : status === "available"
-        ? "Update available — see banner"
-        : status === "downloading" || status === "installing"
-          ? "Updating…"
-          : status === "uptodate"
-            ? "You're on the latest version"
-            : status === "error"
-              ? "Couldn't check — try again"
-              : "Check for latest updates";
+      : pending && status === "available"
+        ? "Update available!"
+        : pending
+          ? "Update ready to install"
+          : status === "downloading" || status === "installing"
+            ? "Updating…"
+            : status === "uptodate"
+              ? "You're on the latest version"
+              : status === "error"
+                ? "Couldn't check, try again"
+                : "Check for latest updates";
 
   return (
     <FooterLinkButton
@@ -383,8 +402,8 @@ export function SettingsTab() {
   const appVersion = useSettingsStore((s) => s.appVersion);
 
   return (
-    <div className="flex h-full w-full flex-col gap-5">
-      <div className="flex w-full flex-col gap-4">
+    <div className="flex h-full w-full flex-col gap-[var(--spacingL)]">
+      <div className="flex w-full flex-col gap-[var(--spacingM)]">
         <GeneralSection />
         <TemperatureUnitsSection />
         <PollingRateSection />

--- a/tauri-app/src/components/settings/settings/icons.tsx
+++ b/tauri-app/src/components/settings/settings/icons.tsx
@@ -94,50 +94,56 @@ export function BrowserUpdatedIcon({ className }: IconProps) {
 // Computer / monitor icon — Figma node 2524:5178 (Pixel Shift row). 20px,
 // 1.5 stroke in currentColor. Geometry copied verbatim from the Figma export
 // (viewBox kept at the source 18.1667 units so paths stay exact).
+// Computer glyph, exported from Figma 2524:5178. A 20 box holding a 16.67
+// glyph, so it is centred by its own 1.67 inset and needs no nudging. The
+// previous version drew the same paths into an 18.1667 viewBox, which scaled
+// the glyph up by 1.1 and lost that inset.
 export function ComputerIcon({ className }: IconProps) {
   return (
     <svg
       width="20"
       height="20"
-      viewBox="0 0 18.1667 18.1667"
+      viewBox="0 0 20 20"
       fill="none"
       className={className}
       aria-hidden
     >
       <g stroke="currentColor" strokeWidth="1.5">
         <path
-          d="M10.75 0.75H7.41667C4.68398 0.75 3.31763 0.75 2.34909 1.42818C1.99076 1.67909 1.67909 1.99076 1.42818 2.34909C0.75 3.31763 0.75 4.68398 0.75 7.41667C0.75 10.1494 0.75 11.5157 1.42818 12.4842C1.67909 12.8426 1.99076 13.1542 2.34909 13.4052C3.31763 14.0833 4.68398 14.0833 7.41667 14.0833H10.75C13.4827 14.0833 14.849 14.0833 15.8176 13.4052C16.1759 13.1542 16.4876 12.8426 16.7385 12.4842C17.4167 11.5157 17.4167 10.1494 17.4167 7.41667C17.4167 4.68398 17.4167 3.31763 16.7385 2.34909C16.4876 1.99076 16.1759 1.67909 15.8176 1.42818C14.849 0.75 13.4827 0.75 10.75 0.75Z"
+          d="M11.666 1.66663H8.33268C5.59999 1.66663 4.23365 1.66663 3.2651 2.34481C2.90677 2.59571 2.5951 2.90738 2.3442 3.26571C1.66602 4.23426 1.66602 5.6006 1.66602 8.33329C1.66602 11.066 1.66602 12.4323 2.3442 13.4009C2.5951 13.7592 2.90677 14.0709 3.2651 14.3218C4.23365 15 5.59999 15 8.33268 15H11.666C14.3987 15 15.7651 15 16.7336 14.3218C17.0919 14.0709 17.4036 13.7592 17.6545 13.4009C18.3327 12.4323 18.3327 11.066 18.3327 8.33329C18.3327 5.6006 18.3327 4.23426 17.6545 3.26571C17.4036 2.90738 17.0919 2.59571 16.7336 2.34481C15.7651 1.66663 14.3987 1.66663 11.666 1.66663Z"
           strokeLinecap="round"
         />
         <path
-          d="M8.25 11.5833H9.91667"
+          d="M9.16602 12.5H10.8327"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
         <path
-          d="M11.1667 17.4167L10.9038 17.0676C10.3111 16.2807 10.1641 15.0787 10.539 14.0833M7 17.4167L7.26292 17.0676C7.85561 16.2807 8.00255 15.0787 7.62769 14.0833"
+          d="M12.0827 18.3333L11.8198 17.9843C11.2271 17.1974 11.0801 15.9953 11.455 15M7.91602 18.3333L8.17893 17.9843C8.77163 17.1974 8.91856 15.9953 8.54371 15"
           strokeLinecap="round"
         />
-        <path d="M4.91667 17.4167H13.25" strokeLinecap="round" />
+        <path d="M5.83398 18.3334H14.1673" strokeLinecap="round" />
       </g>
     </svg>
   );
 }
 
-// Info icon — Figma node 2075:8803 (Material Symbols rounded filled, 16px).
+// Info glyph, exported from Figma 2759:12474. A 13.33 glyph inside a 16 box,
+// which is the whole point: the previous version drew the circle edge to edge,
+// so it rendered a fifth larger than every info row in the design.
 export function InfoIcon({ className }: IconProps) {
   return (
     <svg
       width="16"
       height="16"
-      viewBox="0 0 27 27"
+      viewBox="0 0 16 16"
       fill="none"
       className={className}
       aria-hidden
     >
       <path
         fill="currentColor"
-        d="M13.5 20.25c.3825 0 .7031-.1293.9618-.3881.2588-.2587.3882-.5793.3882-.9618V13.5c0-.3825-.1294-.7032-.3882-.9619-.2587-.2588-.5793-.3881-.9618-.3881-.3825 0-.7032.1293-.9619.3881-.2588.2587-.3881.5794-.3881.9619v5.3999c0 .3825.1293.7031.3881.9618.2587.2588.5794.3881.9619.3881zm0-10.8c.3825 0 .7031-.1294.9618-.3881.2588-.2588.3882-.5794.3882-.9619 0-.3825-.1294-.7031-.3882-.9619-.2587-.2588-.5793-.3881-.9618-.3881-.3825 0-.7032.1293-.9619.3881-.2588.2588-.3881.5794-.3881.9619 0 .3825.1293.7031.3881.9619.2587.2587.5794.3881.9619.3881zM13.5 27c-1.8675 0-3.6225-.3544-5.265-1.0631C6.5925 25.228 5.1637 24.2662 3.9487 23.0512 2.7337 21.8362 1.7719 20.4074 1.0631 18.7649.3544 17.1224 0 15.3675 0 13.5c0-1.8675.3544-3.6225 1.0631-5.265C1.7719 6.5925 2.7337 5.1637 3.9487 3.9487 5.1637 2.7337 6.5925 1.7719 8.235 1.0631 9.8775.3544 11.6325 0 13.5 0c1.8675 0 3.6224.3544 5.2649 1.0631C20.4074 1.7719 21.8362 2.7337 23.0512 3.9487 24.2662 5.1637 25.228 6.5925 25.9368 8.235 26.6455 9.8775 26.9999 11.6325 26.9999 13.5c0 1.8675-.3544 3.6224-1.0631 5.2649-.7088 1.6425-1.6706 3.0713-2.8856 4.2863-1.215 1.215-2.6438 2.1768-4.2863 2.8856C17.1224 26.6455 15.3675 26.9999 13.5 26.9999zm0-2.7c3.0149 0 5.5687-1.0462 7.6612-3.1387 2.0925-2.0925 3.1387-4.6463 3.1387-7.6612 0-3.015-1.0462-5.5687-3.1387-7.6612C19.0687 3.7462 16.5149 2.7 13.5 2.7c-3.015 0-5.5687 1.0462-7.6612 3.1387C3.7462 7.9312 2.7 10.485 2.7 13.5c0 3.0149 1.0462 5.5687 3.1388 7.6612C7.9313 23.2537 10.485 24.2999 13.5 24.2999z"
+        d="M8.00114 11.332C8.19003 11.332 8.34836 11.2681 8.47614 11.1404C8.60392 11.0126 8.66781 10.8543 8.66781 10.6654V7.9987C8.66781 7.80981 8.60392 7.65148 8.47614 7.5237C8.34836 7.39592 8.19003 7.33203 8.00114 7.33203C7.81225 7.33203 7.65392 7.39592 7.52614 7.5237C7.39836 7.65148 7.33447 7.80981 7.33447 7.9987V10.6654C7.33447 10.8543 7.39836 11.0126 7.52614 11.1404C7.65392 11.2681 7.81225 11.332 8.00114 11.332ZM8.00114 5.9987C8.19003 5.9987 8.34836 5.93481 8.47614 5.80703C8.60392 5.67925 8.66781 5.52092 8.66781 5.33203C8.66781 5.14314 8.60392 4.98481 8.47614 4.85703C8.34836 4.72925 8.19003 4.66536 8.00114 4.66536C7.81225 4.66536 7.65392 4.72925 7.52614 4.85703C7.39836 4.98481 7.33447 5.14314 7.33447 5.33203C7.33447 5.52092 7.39836 5.67925 7.52614 5.80703C7.65392 5.93481 7.81225 5.9987 8.00114 5.9987ZM8.00114 14.6654C7.07892 14.6654 6.21225 14.4904 5.40114 14.1404C4.59003 13.7904 3.88447 13.3154 3.28447 12.7154C2.68447 12.1154 2.20947 11.4098 1.85947 10.5987C1.50947 9.78759 1.33447 8.92092 1.33447 7.9987C1.33447 7.07648 1.50947 6.20981 1.85947 5.3987C2.20947 4.58759 2.68447 3.88203 3.28447 3.28203C3.88447 2.68203 4.59003 2.20703 5.40114 1.85703C6.21225 1.50703 7.07892 1.33203 8.00114 1.33203C8.92336 1.33203 9.79003 1.50703 10.6011 1.85703C11.4123 2.20703 12.1178 2.68203 12.7178 3.28203C13.3178 3.88203 13.7928 4.58759 14.1428 5.3987C14.4928 6.20981 14.6678 7.07648 14.6678 7.9987C14.6678 8.92092 14.4928 9.78759 14.1428 10.5987C13.7928 11.4098 13.3178 12.1154 12.7178 12.7154C12.1178 13.3154 11.4123 13.7904 10.6011 14.1404C9.79003 14.4904 8.92336 14.6654 8.00114 14.6654ZM8.00114 13.332C9.49003 13.332 10.7511 12.8154 11.7845 11.782C12.8178 10.7487 13.3345 9.48759 13.3345 7.9987C13.3345 6.50981 12.8178 5.2487 11.7845 4.21536C10.7511 3.18203 9.49003 2.66536 8.00114 2.66536C6.51225 2.66536 5.25114 3.18203 4.21781 4.21536C3.18447 5.2487 2.66781 6.50981 2.66781 7.9987C2.66781 9.48759 3.18447 10.7487 4.21781 11.782C5.25114 12.8154 6.51225 13.332 8.00114 13.332Z"
       />
     </svg>
   );
@@ -187,17 +193,41 @@ export function ChevronRightIcon({ className }: IconProps) {
 // "Visual" mock-window with 8px padding, holding three 120×26 bars (gap 6,
 // rounded-4) filled #F0F1F1. The Visual is 6px taller than the parent so the
 // bottom bar reads as slightly clipped. On the dark variant Figma applies
-// 10% layer opacity to the bars — they render as a subtle dark stripe on
-// the #161B26 inner, not as bright white.
+/**
+ * The mock app window inside a theme preview. Figma 2526:6791: 136 wide, 8 of
+ * padding, radius 8, pinned 16 in and 16 down, holding three 26-tall bars 6
+ * apart. It is 106 tall against a 100 tall preview, so the last bar is cut off
+ * by the preview's own clip, which is what the design shows.
+ *
+ * The bars are Bg/Surface at full strength on a light window and at 10% layer
+ * opacity on a dark one, so they read as a subtle stripe rather than white.
+ */
+function ThemeWindow({
+  inner,
+  barOpacity = 1,
+}: {
+  inner: string;
+  barOpacity?: number;
+}) {
+  return (
+    <div
+      className="absolute left-[16px] top-[16px] flex w-[136px] flex-col gap-[6px] rounded-[8px] p-[8px]"
+      style={{ backgroundColor: inner }}
+    >
+      <div className="h-[26px] rounded-[4px] bg-[#F0F1F1]" style={{ opacity: barOpacity }} />
+      <div className="h-[26px] rounded-[4px] bg-[#F0F1F1]" style={{ opacity: barOpacity }} />
+      <div className="h-[26px] rounded-[4px] bg-[#F0F1F1]" style={{ opacity: barOpacity }} />
+    </div>
+  );
+}
+
 function ThemePreviewBars({
   bg,
   inner,
-  bar,
   barOpacity = 1,
 }: {
   bg: string;
   inner: string;
-  bar: string;
   barOpacity?: number;
 }) {
   return (
@@ -205,69 +235,34 @@ function ThemePreviewBars({
       className="relative h-full w-full overflow-hidden rounded-[4px]"
       style={{ backgroundColor: bg }}
     >
-      <div
-        className="absolute left-1/2 top-[6px] flex w-[136px] -translate-x-1/2 flex-col gap-[6px] rounded-[8px] p-2"
-        style={{ backgroundColor: inner }}
-      >
-        <div
-          className="h-[26px] rounded-[4px]"
-          style={{ backgroundColor: bar, opacity: barOpacity }}
-        />
-        <div
-          className="h-[26px] rounded-[4px]"
-          style={{ backgroundColor: bar, opacity: barOpacity }}
-        />
-        <div
-          className="h-[26px] rounded-[4px]"
-          style={{ backgroundColor: bar, opacity: barOpacity }}
-        />
-      </div>
+      <ThemeWindow inner={inner} barOpacity={barOpacity} />
     </div>
   );
 }
 
 export function ThemePreviewLight() {
-  return <ThemePreviewBars bg="#F5F5F6" inner="#FFFFFF" bar="#F0F1F1" />;
+  return <ThemePreviewBars bg="#F5F5F6" inner="#FFFFFF" />;
 }
 
 export function ThemePreviewDark() {
-  return (
-    <ThemePreviewBars
-      bg="#0C111D"
-      inner="#161B26"
-      bar="#F0F1F1"
-      barOpacity={0.1}
-    />
-  );
+  return <ThemePreviewBars bg="#0C111D" inner="#161B26" barOpacity={0.1} />;
 }
 
-// System preview (Figma 2075:8832): outer preview has a light bg with a
-// dark overlay covering the LEFT half — base bg is #F5F5F6, left 50% is
-// #0C111D. A single centered Visual spans both halves; its inner bg and
-// each bar are split-coloured at the same 50% seam so the rounded corners
-// and bar shapes look continuous across the dark/light divide.
-const SYSTEM_INNER_BG =
-  "linear-gradient(to right, #161B26 50%, #FFFFFF 50%)";
-const SYSTEM_BAR_BG =
-  "linear-gradient(to right, rgba(240,241,241,0.1) 50%, #F0F1F1 50%)";
-
+/**
+ * System: the light preview with a clipped dark half laid over its left side,
+ * carrying its own copy of the window at the same 16 offset.
+ *
+ * That is how Figma builds it, and it is also why the seam stays exact. The
+ * previous version painted a gradient at 50% of the window instead, which only
+ * lines up with the half's edge when the window happens to be centred, and the
+ * card is a flex child whose width is not fixed.
+ */
 export function ThemePreviewSystem() {
   return (
-    <div
-      className="relative h-full w-full overflow-hidden rounded-[4px]"
-      style={{ backgroundColor: "#F5F5F6" }}
-    >
-      <div
-        className="absolute inset-y-0 left-0 w-1/2"
-        style={{ backgroundColor: "#0C111D" }}
-      />
-      <div
-        className="absolute left-1/2 top-[6px] flex w-[136px] -translate-x-1/2 flex-col gap-[6px] rounded-[8px] p-2"
-        style={{ background: SYSTEM_INNER_BG }}
-      >
-        <div className="h-[26px] rounded-[4px]" style={{ background: SYSTEM_BAR_BG }} />
-        <div className="h-[26px] rounded-[4px]" style={{ background: SYSTEM_BAR_BG }} />
-        <div className="h-[26px] rounded-[4px]" style={{ background: SYSTEM_BAR_BG }} />
+    <div className="relative h-full w-full overflow-hidden rounded-[4px] bg-[#F5F5F6]">
+      <ThemeWindow inner="#FFFFFF" />
+      <div className="absolute inset-y-0 left-0 w-1/2 overflow-hidden rounded-l-[4px] bg-[#0C111D]">
+        <ThemeWindow inner="#161B26" barOpacity={0.1} />
       </div>
     </div>
   );

--- a/tauri-app/src/components/settings/stats/CpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/CpuSection.tsx
@@ -65,20 +65,18 @@ export function CpuSection({ sensors, hardwares }: Props) {
           onCheckedChange={(v) => updateSensor("cpuUsage", { isEnabled: v })}
           defaultOpen
         >
-          <div className="flex flex-col gap-4">
-            {cpuLoadSensors.length > 0 && (
-              <SensorSelect
-                label="CPU Usage"
-                value={cpuUsage.customReadingId}
-                options={cpuLoadSensors}
-                onChange={(v) => updateSensor("cpuUsage", { customReadingId: v })}
-              />
-            )}
-            <TempRangeControl
-              boundaries={cpuUsage.boundaries}
-              onChange={(b) => updateBoundary("cpuUsage", b)}
+          {cpuLoadSensors.length > 0 && (
+            <SensorSelect
+              label="CPU Usage"
+              value={cpuUsage.customReadingId}
+              options={cpuLoadSensors}
+              onChange={(v) => updateSensor("cpuUsage", { customReadingId: v })}
             />
-          </div>
+          )}
+          <TempRangeControl
+            boundaries={cpuUsage.boundaries}
+            onChange={(b) => updateBoundary("cpuUsage", b)}
+          />
         </SubCollapsible>
 
         <SubCollapsible
@@ -86,22 +84,20 @@ export function CpuSection({ sensors, hardwares }: Props) {
           checked={cpuTemp.isEnabled}
           onCheckedChange={(v) => updateSensor("cpuTemp", { isEnabled: v })}
         >
-          <div className="flex flex-col gap-4">
-            {cpuTempSensors.length > 0 && (
-              <SensorSelect
-                label="CPU Temperature"
-                value={cpuTemp.customReadingId}
-                options={cpuTempSensors}
-                onChange={(v) => updateSensor("cpuTemp", { customReadingId: v })}
-              />
-            )}
-            <TempRangeControl
-              boundaries={cpuTemp.boundaries}
-              onChange={(b) => updateBoundary("cpuTemp", b)}
-              isTemperature
-              max={120}
+          {cpuTempSensors.length > 0 && (
+            <SensorSelect
+              label="CPU Temperature"
+              value={cpuTemp.customReadingId}
+              options={cpuTempSensors}
+              onChange={(v) => updateSensor("cpuTemp", { customReadingId: v })}
             />
-          </div>
+          )}
+          <TempRangeControl
+            boundaries={cpuTemp.boundaries}
+            onChange={(b) => updateBoundary("cpuTemp", b)}
+            isTemperature
+            max={120}
+          />
         </SubCollapsible>
 
         <SubCollapsible
@@ -109,18 +105,16 @@ export function CpuSection({ sensors, hardwares }: Props) {
           checked={cpuConsumption.isEnabled}
           onCheckedChange={(v) => updateSensor("cpuConsumption", { isEnabled: v })}
         >
-          <div className="flex flex-col gap-4">
-            {cpuPowerSensors.length > 0 && (
-              <SensorSelect
-                label="CPU Power"
-                value={cpuConsumption.customReadingId}
-                options={cpuPowerSensors}
-                onChange={(v) =>
-                  updateSensor("cpuConsumption", { customReadingId: v })
-                }
-              />
-            )}
-          </div>
+          {cpuPowerSensors.length > 0 && (
+            <SensorSelect
+              label="CPU Power"
+              value={cpuConsumption.customReadingId}
+              options={cpuPowerSensors}
+              onChange={(v) =>
+                updateSensor("cpuConsumption", { customReadingId: v })
+              }
+            />
+          )}
         </SubCollapsible>
       </div>
     </SectionCard>

--- a/tauri-app/src/components/settings/stats/FpsSection.tsx
+++ b/tauri-app/src/components/settings/stats/FpsSection.tsx
@@ -1,13 +1,13 @@
 import { useRef } from "react";
-import { Info } from "lucide-react";
 import { Checkbox } from "@/components/shadcn/checkbox";
 import {
   Select,
   SelectContent,
   SelectItem,
-  SelectTrigger,
   SelectValue,
 } from "@/components/shadcn/select";
+import { SelectFieldTrigger } from "@/components/ui/SelectField";
+import { InfoIcon } from "../settings/icons";
 import { useSettingsStore } from "@/stores/settings-store";
 import { AUTO_OPTION, monitorAppOptions } from "@/lib/fps-apps";
 import { SectionCard } from "./SectionCard";
@@ -64,19 +64,16 @@ export function FpsSection() {
           recently, so the control disappeared at the desktop and whenever a
           fullscreen game stopped presenting, taking Auto (and any pick the
           user wanted to undo) with it. See monitorAppOptions. */}
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-[var(--spacingS)]">
         <Select
           value={selectedApp}
           onValueChange={(v) =>
             updateSensor("framerate", { targetAppName: v === AUTO_OPTION ? "" : v })
           }
         >
-          <SelectTrigger className="h-10 rounded-[8px] text-[14px]">
-            <span className="flex items-center gap-2">
-              <span className="text-[14px] font-normal text-muted-foreground">Monitor app:</span>
-              <SelectValue placeholder="Auto" />
-            </span>
-          </SelectTrigger>
+          <SelectFieldTrigger label="Monitor app:">
+            <SelectValue placeholder="Auto" />
+          </SelectFieldTrigger>
           <SelectContent>
             <SelectItem value={AUTO_OPTION}>Auto</SelectItem>
             {appOptions.map((app) => (
@@ -86,9 +83,9 @@ export function FpsSection() {
             ))}
           </SelectContent>
         </Select>
-        <div className="flex items-center gap-1">
-          <Info className="size-4 text-muted-foreground" strokeWidth={2} />
-          <span className="text-[12px] font-medium text-muted-foreground">
+        <div className="flex items-center gap-[var(--spacingXxxs)] text-[12px] font-medium leading-[15px] text-[var(--textParagraph1)]">
+          <InfoIcon className="size-[16px] shrink-0" />
+          <span>
             {presentMonApps.length > 0
               ? "Apps are auto updated every 10 seconds."
               : "No apps detected yet. Auto follows the app in focus."}

--- a/tauri-app/src/components/settings/stats/GpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/GpuSection.tsx
@@ -7,9 +7,9 @@ import {
   Select,
   SelectContent,
   SelectItem,
-  SelectTrigger,
   SelectValue,
 } from "@/components/shadcn/select";
+import { SelectFieldTrigger } from "@/components/ui/SelectField";
 import { InfoIcon } from "../settings/icons";
 import { SectionCard, SubCollapsible } from "./SectionCard";
 import { SensorSelect } from "./SensorSelect";
@@ -25,10 +25,6 @@ export function GpuSection({ sensors, hardwares }: Props) {
   const updateSensor = useSettingsStore((s) => s.updateSensor);
   const updateBoundary = useSettingsStore((s) => s.updateBoundary);
   const selectGpu = useSettingsStore((s) => s.selectGpu);
-  // `.settled` rather than a per-snapshot check: one snapshot cannot tell a
-  // parked GPU from one whose sensors have not activated yet, and the notice
-  // would flash on every launch. See nextGpuSilence.
-  const gpuIsIdle = useSettingsStore((s) => s.gpuSilence.settled);
   const { gpuUsage, gpuTemp, gpuConsumption, vramUsage } = settings.sensors;
 
   const gpus = listGpus(hardwares);
@@ -87,16 +83,20 @@ export function GpuSection({ sensors, hardwares }: Props) {
 
   return (
     <SectionCard title="GPU" enabled={anyEnabled} onToggle={handleMaster}>
-      <div className="flex flex-col gap-3">
-        {/* Only shown when there is a choice to make. On the overwhelming
-            majority of machines there is exactly one GPU, and a control whose
-            list has a single entry is noise. */}
-        {gpus.length > 1 && (
-          <div className="flex flex-col gap-3">
+      {/* Two blocks, not one: the card lays its children out 20 apart, which is
+          the gap Figma puts between the GPU picker and the sensor rows, while
+          the rows themselves sit 12 apart inside their own block. */}
+      {/* The picker is only shown when there is a choice to make. On the
+          overwhelming majority of machines there is exactly one GPU, and a
+          control whose list has a single entry is noise; that machine sees the
+          card exactly as it was before the picker existed. */}
+      {gpus.length > 1 && (
+        <>
+          <div className="flex flex-col gap-[var(--spacingS)]">
             <Select value={settings.selectedGpuId} onValueChange={selectGpu}>
-              <SelectTrigger className="w-full rounded-[8px] border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] font-medium shadow-[0_1px_2px_rgba(16,24,40,0.05)]">
+              <SelectFieldTrigger label="Selected GPU:">
                 <SelectValue />
-              </SelectTrigger>
+              </SelectFieldTrigger>
               <SelectContent>
                 {gpus.map((gpu) => (
                   <SelectItem key={gpu.identifier} value={gpu.identifier}>
@@ -105,38 +105,37 @@ export function GpuSection({ sensors, hardwares }: Props) {
                 ))}
               </SelectContent>
             </Select>
-            {/* Only while the chosen GPU is actually reporting nothing. A GPU
-                that is reading fine needs no explanation, and a notice that is
-                always there stops being read. */}
-            {gpuIsIdle && (
-              <div className="flex items-center gap-2 text-[12px] font-medium text-muted-foreground">
-                <InfoIcon className="size-4 shrink-0" />
-                <span>A GPU that is idle or powered down reports 0.</span>
-              </div>
-            )}
+            {/* Shown for as long as the picker is, per Figma. It explains what
+                a 0 reading means rather than reporting one, so it is a standing
+                note about the control and not a state of the GPU. */}
+            <div className="flex items-center gap-[var(--spacingXxxs)] text-[12px] font-medium leading-[15px] text-[var(--textParagraph1)]">
+              <InfoIcon className="size-[16px] shrink-0" />
+              <span>A GPU will report stats only when it’s being used.</span>
+            </div>
           </div>
-        )}
+          <div className="h-px w-full shrink-0 bg-[var(--borderSubtle)]" />
+        </>
+      )}
 
+      <div className="flex flex-col gap-[var(--spacingS)]">
         <SubCollapsible
           label="GPU Usage"
           checked={gpuUsage.isEnabled}
           onCheckedChange={(v) => updateSensor("gpuUsage", { isEnabled: v })}
           defaultOpen
         >
-          <div className="flex flex-col gap-4">
-            {gpuLoadSensors.length > 0 && (
-              <SensorSelect
-                label="GPU Usage"
-                value={gpuUsage.customReadingId}
-                options={gpuLoadSensors}
-                onChange={(v) => updateSensor("gpuUsage", { customReadingId: v })}
-              />
-            )}
-            <TempRangeControl
-              boundaries={gpuUsage.boundaries}
-              onChange={(b) => updateBoundary("gpuUsage", b)}
+          {gpuLoadSensors.length > 0 && (
+            <SensorSelect
+              label="GPU Usage"
+              value={gpuUsage.customReadingId}
+              options={gpuLoadSensors}
+              onChange={(v) => updateSensor("gpuUsage", { customReadingId: v })}
             />
-          </div>
+          )}
+          <TempRangeControl
+            boundaries={gpuUsage.boundaries}
+            onChange={(b) => updateBoundary("gpuUsage", b)}
+          />
         </SubCollapsible>
 
         <SubCollapsible
@@ -144,22 +143,20 @@ export function GpuSection({ sensors, hardwares }: Props) {
           checked={gpuTemp.isEnabled}
           onCheckedChange={(v) => updateSensor("gpuTemp", { isEnabled: v })}
         >
-          <div className="flex flex-col gap-4">
-            {gpuTempSensors.length > 0 && (
-              <SensorSelect
-                label="GPU Temperature"
-                value={gpuTemp.customReadingId}
-                options={gpuTempSensors}
-                onChange={(v) => updateSensor("gpuTemp", { customReadingId: v })}
-              />
-            )}
-            <TempRangeControl
-              boundaries={gpuTemp.boundaries}
-              onChange={(b) => updateBoundary("gpuTemp", b)}
-              isTemperature
-              max={120}
+          {gpuTempSensors.length > 0 && (
+            <SensorSelect
+              label="GPU Temperature"
+              value={gpuTemp.customReadingId}
+              options={gpuTempSensors}
+              onChange={(v) => updateSensor("gpuTemp", { customReadingId: v })}
             />
-          </div>
+          )}
+          <TempRangeControl
+            boundaries={gpuTemp.boundaries}
+            onChange={(b) => updateBoundary("gpuTemp", b)}
+            isTemperature
+            max={120}
+          />
         </SubCollapsible>
 
         <SubCollapsible
@@ -167,16 +164,14 @@ export function GpuSection({ sensors, hardwares }: Props) {
           checked={gpuConsumption.isEnabled}
           onCheckedChange={(v) => updateSensor("gpuConsumption", { isEnabled: v })}
         >
-          <div className="flex flex-col gap-4">
-            {gpuPowerSensors.length > 0 && (
-              <SensorSelect
-                label="GPU Power"
-                value={gpuConsumption.customReadingId}
-                options={gpuPowerSensors}
-                onChange={(v) => updateSensor("gpuConsumption", { customReadingId: v })}
-              />
-            )}
-          </div>
+          {gpuPowerSensors.length > 0 && (
+            <SensorSelect
+              label="GPU Power"
+              value={gpuConsumption.customReadingId}
+              options={gpuPowerSensors}
+              onChange={(v) => updateSensor("gpuConsumption", { customReadingId: v })}
+            />
+          )}
         </SubCollapsible>
 
         <SubCollapsible
@@ -187,20 +182,18 @@ export function GpuSection({ sensors, hardwares }: Props) {
             updateSensor("totalVramUsed", { isEnabled: v });
           }}
         >
-          <div className="flex flex-col gap-4">
-            {vramSensors.length > 0 && (
-              <SensorSelect
-                label="VRAM Usage"
-                value={vramUsage.customReadingId}
-                options={vramSensors}
-                onChange={(v) => updateSensor("vramUsage", { customReadingId: v })}
-              />
-            )}
-            <TempRangeControl
-              boundaries={vramUsage.boundaries}
-              onChange={(b) => updateBoundary("vramUsage", b)}
+          {vramSensors.length > 0 && (
+            <SensorSelect
+              label="VRAM Usage"
+              value={vramUsage.customReadingId}
+              options={vramSensors}
+              onChange={(v) => updateSensor("vramUsage", { customReadingId: v })}
             />
-          </div>
+          )}
+          <TempRangeControl
+            boundaries={vramUsage.boundaries}
+            onChange={(b) => updateBoundary("vramUsage", b)}
+          />
         </SubCollapsible>
       </div>
     </SectionCard>

--- a/tauri-app/src/components/settings/stats/SectionCard.tsx
+++ b/tauri-app/src/components/settings/stats/SectionCard.tsx
@@ -12,6 +12,10 @@ import {
 /**
  * White section card with an uppercase label + optional right-side switch.
  * Matches Figma cards 2075:5766 (FPS), 2075:5793 (GPU), etc.
+ *
+ * Padding, gap and radius are px tokens rather than p-5 / gap-5 / rounded-xl:
+ * :root sets font-size 14px, so a rem utility lands at 87.5% of its nominal
+ * value and the 20 Figma redlines were rendering as 17.5.
  */
 export function SectionCard({
   title,
@@ -29,12 +33,12 @@ export function SectionCard({
   return (
     <section
       className={cn(
-        "flex w-full flex-col gap-5 rounded-[12px] bg-[var(--bgSurfaceRaised)] p-5",
+        "flex w-full flex-col gap-[var(--spacingL)] rounded-[var(--cornerXl)] bg-[var(--bgSurfaceRaised)] p-[var(--spacingL)]",
         className,
       )}
     >
       <div className="flex items-center justify-between">
-        <span className="text-[13px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <span className="text-[13px] font-semibold uppercase leading-[16px] tracking-wide text-muted-foreground">
           {title}
         </span>
         {onToggle !== undefined && (
@@ -97,7 +101,7 @@ export function SubCollapsible({
   }
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen} className="flex flex-col gap-2">
+    <Collapsible open={open} onOpenChange={setOpen} className="flex flex-col gap-[var(--spacingXs)]">
       <div className="flex items-center gap-2">
         <Checkbox
           checked={checked}
@@ -118,14 +122,37 @@ export function SubCollapsible({
       </div>
       {children && (
         <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
-          <div className="flex gap-5 pl-3">
-            <div className="w-[2px] shrink-0 rounded-full bg-divider" />
-            <div className="flex-1 rounded-[8px] bg-sub-card p-4">
-              {children}
+          {/* Figma 2759:12229: a 2px rail 12 in from the left, then the blocks
+              20 across from it, stacked 12 apart. */}
+          <div className="flex gap-[var(--spacingL)] pl-[var(--spacingS)]">
+            <div className="w-[2px] shrink-0 rounded-[var(--cornerRound)] bg-[var(--borderSubtle)]" />
+            <div className="flex min-w-0 flex-1 flex-col gap-[var(--spacingS)]">
+              {/* One card per block, not one card around all of them: the
+                  design separates the sensor picker from the threshold row.
+                  toArray drops the falsy children a `cond && <X/>` leaves
+                  behind, so a hidden block does not leave an empty card. */}
+              {React.Children.toArray(children).map((child, i) => (
+                <SubCard key={i}>{child}</SubCard>
+              ))}
             </div>
           </div>
         </CollapsibleContent>
       )}
     </Collapsible>
+  );
+}
+
+/**
+ * One block inside an expanded SubCollapsible.
+ *
+ * Figma 2759:12490 / 2759:12231: radius 8, 16 all round, Bg/Surface Sunken
+ * Subtler. Gap 16 is the threshold row's; the picker card holds a single child
+ * so its own 6 never shows.
+ */
+function SubCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-[var(--spacingM)] rounded-[var(--cornerL)] bg-[var(--bgSurfaceSunkenSubtler)] p-[var(--spacingM)]">
+      {children}
+    </div>
   );
 }

--- a/tauri-app/src/components/settings/stats/SensorSelect.tsx
+++ b/tauri-app/src/components/settings/stats/SensorSelect.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { Sensor } from "@/lib/types";
 import { SensorPickerModal } from "./SensorPickerModal";
+import { SelectFieldButton } from "@/components/ui/SelectField";
 
 interface Props {
   value: string;
@@ -10,28 +11,11 @@ interface Props {
   label: string;
 }
 
-// Chevron exported from Figma 2353:616 — 20×20, currentColor fill.
-function ChevronIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
-      fill="none"
-      className={className}
-      aria-hidden
-    >
-      <path
-        d="M10.0007 11L13.2507 7.75C13.4034 7.59722 13.5979 7.52083 13.834 7.52083C14.0701 7.52083 14.2645 7.59722 14.4173 7.75C14.5701 7.90278 14.6465 8.09722 14.6465 8.33333C14.6465 8.56944 14.5701 8.76389 14.4173 8.91667L10.584 12.75C10.4173 12.9167 10.2229 13 10.0007 13C9.77843 13 9.58398 12.9167 9.41732 12.75L5.58398 8.91667C5.43121 8.76389 5.35482 8.56944 5.35482 8.33333C5.35482 8.09722 5.43121 7.90278 5.58398 7.75C5.73676 7.59722 5.93121 7.52083 6.16732 7.52083C6.40343 7.52083 6.59787 7.59722 6.75065 7.75L10.0007 11Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
-
 /**
- * Sensor picker trigger pill matched 1:1 to Figma 2353:612.
- * Clicking opens SensorPickerModal — replaces the previous Radix Select dropdown.
+ * Sensor picker trigger pill matched 1:1 to Figma 2353:612, the same field as
+ * the GPU picker, so the pill itself lives in components/ui/SelectField.
+ * Clicking opens SensorPickerModal, which replaced the previous Radix Select
+ * dropdown.
  */
 export function SensorSelect({ value, options, onChange, label }: Props) {
   const [open, setOpen] = useState(false);
@@ -40,19 +24,9 @@ export function SensorSelect({ value, options, onChange, label }: Props) {
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="flex h-10 w-full items-center gap-2 rounded-[8px] border border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)] px-3 py-2 text-left shadow-[0_1px_2px_rgba(16,24,40,0.05)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-      >
-        <span className="shrink-0 text-[14px] font-normal text-[var(--textParagraph1)]">
-          Sensor:
-        </span>
-        <span className="flex-1 truncate text-[14px] font-medium text-[var(--textHeading)]">
-          {currentName}
-        </span>
-        <ChevronIcon className="size-5 shrink-0 text-[var(--iconBolderActive)]" />
-      </button>
+      <SelectFieldButton label="Sensor:" onClick={() => setOpen(true)}>
+        {currentName}
+      </SelectFieldButton>
       <SensorPickerModal
         open={open}
         onOpenChange={setOpen}

--- a/tauri-app/src/components/settings/stats/StatsTab.tsx
+++ b/tauri-app/src/components/settings/stats/StatsTab.tsx
@@ -32,7 +32,7 @@ export function StatsTab() {
   }, [updateStatus]);
 
   return (
-    <div className="flex h-full w-full flex-col gap-4">
+    <div className="flex h-full w-full flex-col gap-[var(--spacingM)]">
       <HotkeyBar />
       <FpsSection />
       <GpuSection sensors={sensors} hardwares={hardwares} />

--- a/tauri-app/src/components/settings/stats/TempRangeControl.tsx
+++ b/tauri-app/src/components/settings/stats/TempRangeControl.tsx
@@ -9,7 +9,8 @@ import {
 } from "@/lib/boundaries";
 
 /**
- * 3-segment range control from Figma. Defaults to a 0-100% scale (GPU/CPU
+ * 3-segment range control from Figma 2759:12231. Each segment is 65 tall: a 17
+ * label row, 8, then a 40 pair of cells. Defaults to a 0-100% scale (GPU/CPU
  * usage); pass `isTemperature` + `max` (in °C) to reuse for temperatures.
  * Boundaries.low / .medium are the upper bounds of the Low / Medium segments.
  * Boundaries.high is the absolute max.
@@ -75,7 +76,7 @@ export function TempRangeControl({
   });
 
   return (
-    <div className="flex gap-4">
+    <div className="flex gap-[var(--spacingM)]">
       <RangeSegment color="#17B26A" label="Low" min={lowMin} max={lowMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin editor={editor("low")} />
       <RangeSegment color="#FEC84B" label="Medium" min={medMin} max={medMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin editor={editor("medium")} />
       <RangeSegment color="#F04438" label="High" min={highMin} max={highMax} unit={displayUnit} inputMax={displayInputMax} readOnlyMin editor={editor("high")} />
@@ -114,10 +115,10 @@ function RangeSegment({
   editor: SegmentEditor;
 }) {
   return (
-    <div className="flex flex-1 flex-col gap-2">
-      <div className="flex items-center gap-1.5">
-        <span className="size-1.5 rounded-full" style={{ background: color }} />
-        <span className="text-[14px] font-medium text-foreground">{label}</span>
+    <div className="flex flex-1 flex-col gap-[var(--spacingXs)]">
+      <div className="flex items-center gap-[var(--spacingXxs)]">
+        <span className="size-[6px] shrink-0 rounded-[var(--cornerRound)]" style={{ background: color }} />
+        <span className="text-[14px] font-medium leading-[17px] text-foreground">{label}</span>
       </div>
       <div className="flex">
         <ValueInput value={min} unit={unit} inputMax={inputMax} readOnly={readOnlyMin} muted className="rounded-l-[8px]" />
@@ -180,7 +181,7 @@ function ValueInput({
 
   return (
     <div
-      className={`flex h-10 flex-1 items-center border border-[var(--borderBolder)] px-3 ${muted ? "bg-sub-card" : "bg-[var(--bgSurfaceRaised)]"} ${className ?? ""}`}
+      className={`flex h-[40px] flex-1 items-center border border-[var(--borderBolder)] px-[var(--spacingS)] ${muted ? "bg-sub-card" : "bg-[var(--bgSurfaceRaised)]"} ${className ?? ""}`}
     >
       <input
         type="number"

--- a/tauri-app/src/components/shadcn/checkbox.tsx
+++ b/tauri-app/src/components/shadcn/checkbox.tsx
@@ -34,17 +34,30 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer size-[18px] shrink-0 rounded-[4px] border border-[var(--bgSurfaceSunken)] bg-[var(--bgSurfaceRaised)]",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+        // 24 box, 19.2 visual: Figma's Checkbox [1.0] instance is 24 square
+        // and that is what sets the height of every row it sits in.
+        "group flex size-[24px] shrink-0 items-center justify-center outline-none",
         "disabled:cursor-not-allowed disabled:opacity-50",
-        "data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-primary-foreground",
         className,
       )}
       {...props}
     >
-      <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
-        <CheckmarkIcon />
-      </CheckboxPrimitive.Indicator>
+      <span
+        className={cn(
+          "relative flex size-[19.2px] items-center justify-center rounded-[4px]",
+          "bg-[var(--bgSurfaceSunken)] group-data-[state=checked]:bg-[var(--bgBrand)]",
+          "transition-colors duration-150 motion-reduce:transition-none",
+          "group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-1",
+        )}
+      >
+        {/* Unchecked is a 15.6 raised square inside the 19.2 sunken one, which
+            is what leaves Figma's 1.8 ring rather than a 1px border. It gives
+            way to the check. */}
+        <span className="absolute size-[15.6px] rounded-[2.6px] bg-[var(--bgSurfaceRaised)] group-data-[state=checked]:hidden" />
+        <CheckboxPrimitive.Indicator className="relative flex items-center justify-center text-[var(--bgSurfaceRaised)]">
+          <CheckmarkIcon />
+        </CheckboxPrimitive.Indicator>
+      </span>
     </CheckboxPrimitive.Root>
   );
 }

--- a/tauri-app/src/components/shadcn/switch.tsx
+++ b/tauri-app/src/components/shadcn/switch.tsx
@@ -2,6 +2,9 @@ import * as React from "react";
 import * as SwitchPrimitive from "@radix-ui/react-switch";
 import { cn } from "@/lib/utils";
 
+// 36x20 track with a 16 knob and 2 of padding, per Figma. The travel is
+// 36 - 2 - 2 - 16 = 16.
+
 function Switch({
   className,
   ...props
@@ -10,7 +13,7 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer inline-flex h-[18px] w-[32px] shrink-0 items-center rounded-full p-[2px] outline-none transition-colors",
+        "peer inline-flex h-[20px] w-[36px] shrink-0 items-center rounded-full p-[2px] outline-none transition-colors",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
         "data-[state=checked]:bg-success data-[state=unchecked]:bg-[var(--bgSurfaceSunken)]",
         className,
@@ -20,8 +23,8 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "pointer-events-none block size-[14px] rounded-full bg-white shadow-sm transition-transform",
-          "data-[state=checked]:translate-x-[14px] data-[state=unchecked]:translate-x-0",
+          "pointer-events-none block size-[16px] rounded-full bg-white shadow-sm transition-transform",
+          "data-[state=checked]:translate-x-[16px] data-[state=unchecked]:translate-x-0",
         )}
       />
     </SwitchPrimitive.Root>

--- a/tauri-app/src/components/ui/SelectField.tsx
+++ b/tauri-app/src/components/ui/SelectField.tsx
@@ -1,0 +1,109 @@
+import * as SelectPrimitive from "@radix-ui/react-select";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The "Input" field from Figma: a 40px pill holding an inline label, a value
+ * that truncates rather than wraps, and a chevron.
+ *
+ * One field in the design, so one component here. It appears as the sensor
+ * picker (Figma 2353:612) and as the GPU picker (Figma 2759:12466), and those
+ * two nodes are identical apart from the label. Their triggers are not the same
+ * element, though: the sensor picker is a button that opens a modal, while the
+ * GPU picker is a Radix Select trigger. Hence two exports over one body.
+ *
+ * Values are tokens rather than literals, per the repo's design-system
+ * conventions: padding 12/8 = spacing-lg/md, gap 8 = spacing-md, radius 8 =
+ * radius-md, border Border/Bolder, fill Bg/Surface Raised, shadow-xs.
+ *
+ * The height and the chevron box are px, not Tailwind's h-10 / size-5. :root
+ * sets font-size 14px, so a rem utility lands at 87.5% of its nominal value
+ * (h-10 measures 35px, not 40) while the design is specified in px.
+ */
+const pillClass = [
+  "flex h-[40px] w-full items-center gap-[var(--spacingXs)]",
+  "rounded-[var(--cornerL)] border border-[var(--borderBolder)] bg-[var(--bgSurfaceRaised)]",
+  "px-[var(--spacingS)] py-[var(--spacingXs)] text-left",
+  "shadow-[0_1px_2px_rgba(16,24,40,0.05)]",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+].join(" ");
+
+/**
+ * Exported from Figma 2759:12472: the same `keyboard_arrow_up` vector the
+ * sensor field uses, rotated to point down. 9.29x5.48 inside a 20x20 box, so
+ * the box is what gets sized and the path carries its own inset.
+ */
+function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      className={className}
+      aria-hidden
+    >
+      <path
+        d="M10.0007 11L13.2507 7.75C13.4034 7.59722 13.5979 7.52083 13.834 7.52083C14.0701 7.52083 14.2645 7.59722 14.4173 7.75C14.5701 7.90278 14.6465 8.09722 14.6465 8.33333C14.6465 8.56944 14.5701 8.76389 14.4173 8.91667L10.584 12.75C10.4173 12.9167 10.2229 13 10.0007 13C9.77843 13 9.58398 12.9167 9.41732 12.75L5.58398 8.91667C5.43121 8.76389 5.35482 8.56944 5.35482 8.33333C5.35482 8.09722 5.43121 7.90278 5.58398 7.75C5.73676 7.59722 5.93121 7.52083 6.16732 7.52083C6.40343 7.52083 6.59787 7.59722 6.75065 7.75L10.0007 11Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function PillBody({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <>
+      <span className="shrink-0 text-[14px] font-normal text-[var(--textParagraph1)]">
+        {label}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-[var(--textHeading)]">
+        {children}
+      </span>
+      <ChevronIcon className="size-[20px] shrink-0 text-[var(--iconBolderActive)]" />
+    </>
+  );
+}
+
+type SelectFieldButtonProps = React.ComponentProps<"button"> & {
+  /** The label inside the field, e.g. "Sensor:". */
+  label: string;
+};
+
+/** The pill as a plain button, for a picker that opens something of its own. */
+export function SelectFieldButton({
+  label,
+  className,
+  children,
+  ...props
+}: SelectFieldButtonProps) {
+  return (
+    <button type="button" className={cn(pillClass, className)} {...props}>
+      <PillBody label={label}>{children}</PillBody>
+    </button>
+  );
+}
+
+type SelectFieldTriggerProps = React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  /** The label inside the field, e.g. "Selected GPU:". */
+  label: string;
+};
+
+/**
+ * The pill as a Radix Select trigger.
+ *
+ * Not built on the shadcn SelectTrigger: that one appends a chevron of its own
+ * and cannot be told not to, which would put two in the field.
+ */
+export function SelectFieldTrigger({
+  label,
+  className,
+  children,
+  ...props
+}: SelectFieldTriggerProps) {
+  return (
+    <SelectPrimitive.Trigger className={cn(pillClass, className)} {...props}>
+      <PillBody label={label}>{children}</PillBody>
+    </SelectPrimitive.Trigger>
+  );
+}

--- a/tauri-app/src/lib/preview-fixture.ts
+++ b/tauri-app/src/lib/preview-fixture.ts
@@ -1,0 +1,172 @@
+import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
+import type { HardwareMonitorData } from "./types";
+import { HardwareType, SensorType } from "./types";
+
+/**
+ * What the browser preview (`npm run dev`) pretends the sidecar is sending.
+ *
+ * The preview has no Tauri runtime and therefore no HardwareMonitor, so every
+ * sensor listener stays silent: the settings UI renders with no readings, no
+ * sensor options in any picker, and a "Monitoring not connected" banner once
+ * the startup grace expires. None of that is the UI we design against.
+ *
+ * This snapshot is a two-GPU laptop (an RTX 3050 alongside Intel integrated
+ * graphics), because the GPU picker in the GPU section only appears when a
+ * machine reports more than one GPU, and that is not a machine we can sit at.
+ * Hardware order, sensor names, identifiers, sensor types and values are
+ * transcribed from a running sidecar's dump on that machine (the same payload
+ * the `stores/settings-store.gpu.test.ts` wire test asserts against), not
+ * invented here. A preview that disagrees with the wire would teach us the
+ * wrong layout.
+ *
+ * Deliberately static: the same numbers on every tick, so a screenshot taken
+ * for a Figma comparison is reproducible.
+ *
+ * Exported as functions rather than constants so nothing here runs at module
+ * load. A top-level call is a possible side effect as far as the bundler is
+ * concerned, and it kept the whole fixture in the production bundle even with
+ * its only caller dead-code-eliminated; a function body is droppable.
+ */
+
+function sensor(
+  hardwareIdentifier: string,
+  identifier: string,
+  name: string,
+  sensorType: SensorType,
+  value: number,
+) {
+  return { name, identifier, hardwareIdentifier, sensorType, value };
+}
+
+export function previewSensorData(): HardwareMonitorData {
+  return {
+    lastPollTime: 0,
+    hardwares: [
+      {
+        name: "NVIDIA GeForce RTX 3050 Laptop GPU",
+        identifier: "/gpu-nvidia/0",
+        hardwareType: HardwareType.GpuNvidia,
+      },
+      {
+        name: "Intel R UHD Graphics",
+        identifier: "/gpu-intel/0",
+        hardwareType: HardwareType.GpuIntel,
+      },
+      { name: "Intel Core i5 11400H", identifier: "/intelcpu/0", hardwareType: HardwareType.Cpu },
+      { name: "Total Memory", identifier: "/ram", hardwareType: HardwareType.Memory },
+      { name: "Ethernet", identifier: "/nic/0", hardwareType: HardwareType.Network },
+    ],
+    sensors: [
+      // Discrete GPU. Note the temperature is named "GPU Core" here and on the
+      // Intel GPU below, and nothing but the hardware identifier separates them,
+      // which is the whole reason the readings are pinned to one GPU.
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/0", "GPU Core", SensorType.Load, 42),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/1", "GPU Memory Controller", SensorType.Load, 12),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/3", "GPU Memory", SensorType.Load, 30),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/0", "GPU Core", SensorType.Temperature, 61),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/1", "GPU Hot Spot", SensorType.Temperature, 73),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/power/0", "GPU Package", SensorType.Power, 55),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/1", "GPU Memory Used", SensorType.SmallData, 2048),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/2", "GPU Memory Total", SensorType.SmallData, 4096),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/9", "D3D Dedicated Memory Used", SensorType.SmallData, 2048),
+
+      // Integrated GPU: load through D3D engine nodes, and its only "memory
+      // total" is system memory it may borrow.
+      sensor("/gpu-intel/0", "/gpu-intel/0/load/0", "D3D 3D", SensorType.Load, 7),
+      sensor("/gpu-intel/0", "/gpu-intel/0/load/1", "D3D Video Decode", SensorType.Load, 3),
+      sensor("/gpu-intel/0", "/gpu-intel/0/temperature/0", "GPU Core", SensorType.Temperature, 45),
+      sensor("/gpu-intel/0", "/gpu-intel/0/power/0", "GPU Power", SensorType.Power, 4),
+      sensor("/gpu-intel/0", "/gpu-intel/0/smalldata/0", "D3D Shared Memory Total", SensorType.SmallData, 16384),
+      sensor("/gpu-intel/0", "/gpu-intel/0/smalldata/1", "D3D Shared Memory Used", SensorType.SmallData, 900),
+
+      sensor("/intelcpu/0", "/intelcpu/0/load/0", "CPU Total", SensorType.Load, 33),
+      sensor("/intelcpu/0", "/intelcpu/0/temperature/0", "CPU Package", SensorType.Temperature, 52),
+      sensor("/intelcpu/0", "/intelcpu/0/power/0", "CPU Package", SensorType.Power, 65),
+
+      sensor("/ram", "/ram/load/0", "Memory Used", SensorType.Load, 48),
+
+      sensor("/nic/0", "/nic/0/throughput/7", "Download Speed", SensorType.Throughput, 1234),
+      sensor("/nic/0", "/nic/0/throughput/8", "Upload Speed", SensorType.Throughput, 567),
+
+      sensor("/presentmon", "/presentmon/presented", "Presented", SensorType.Load, 144),
+      sensor("/presentmon", "/presentmon/frametime", "Frametime", SensorType.Load, 6.94),
+    ],
+  };
+}
+
+/** Something for the FPS app picker to list. */
+export function previewPresentMonApps(): string[] {
+  return ["Cyberpunk2077.exe", "cs2.exe"];
+}
+
+/**
+ * A pending update, so the download banner is reachable in the preview.
+ *
+ * There is no updater in a browser, and the real one only answers when a
+ * release newer than this build exists on the feed, so the banner was
+ * unreachable outside a shipped build going stale.
+ *
+ * Structural, not a real Update: the store reads `version` and calls
+ * `downloadAndInstall`, and nothing else on the instance. The download is
+ * simulated at a visible pace so the available, downloading and installing
+ * states can all be looked at. It ends in "installing" and stays there, since
+ * relaunching is a no-op without a Tauri runtime.
+ */
+const PREVIEW_UPDATE_BYTES = 42 * 1024 * 1024;
+const PREVIEW_UPDATE_CHUNKS = 21;
+const PREVIEW_CHUNK_MS = 90;
+
+// The endpoint the real updater reads is configured in
+// src-tauri/tauri.conf.json, and its manifest is a release asset, which a
+// browser cannot read across origins. The releases API can be read, and it
+// names the same release, so the preview offers the version the packaged app
+// would actually offer rather than a number invented here.
+const PREVIEW_RELEASES_API =
+  "https://api.github.com/repos/SupaStellar/Cleanmeter/releases/latest";
+
+// Deliberately implausible: it only shows when the API cannot be reached
+// (offline, rate limited), and a number that looks real would hide that.
+const PREVIEW_FALLBACK_VERSION = "0.0.0";
+
+let cachedPreviewVersion: string | null = null;
+
+async function latestReleaseVersion(): Promise<string> {
+  if (cachedPreviewVersion) return cachedPreviewVersion;
+  try {
+    const response = await fetch(PREVIEW_RELEASES_API, {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error(`releases API returned ${response.status}`);
+    const body = (await response.json()) as { tag_name?: string };
+    // Tags carry a leading v; the updater manifest and the pill both want it
+    // bare, since the pill renders its own.
+    cachedPreviewVersion =
+      (body.tag_name ?? "").replace(/^v/, "") || PREVIEW_FALLBACK_VERSION;
+  } catch {
+    cachedPreviewVersion = PREVIEW_FALLBACK_VERSION;
+  }
+  return cachedPreviewVersion;
+}
+
+export async function previewUpdate(): Promise<Update> {
+  const download = async (onEvent?: (event: DownloadEvent) => void) => {
+    onEvent?.({ event: "Started", data: { contentLength: PREVIEW_UPDATE_BYTES } });
+    for (let sent = 0; sent < PREVIEW_UPDATE_CHUNKS; sent++) {
+      await new Promise((resolve) => setTimeout(resolve, PREVIEW_CHUNK_MS));
+      onEvent?.({
+        event: "Progress",
+        data: { chunkLength: PREVIEW_UPDATE_BYTES / PREVIEW_UPDATE_CHUNKS },
+      });
+    }
+    onEvent?.({ event: "Finished" });
+  };
+
+  return {
+    version: await latestReleaseVersion(),
+    download,
+    // Nothing to install, but not instant either: the pill shows an installing
+    // state for as long as this takes, and zero would make it unviewable.
+    install: () => new Promise<void>((resolve) => setTimeout(resolve, 1200)),
+    downloadAndInstall: download,
+  } as unknown as Update;
+}

--- a/tauri-app/src/lib/tauri.ts
+++ b/tauri-app/src/lib/tauri.ts
@@ -7,12 +7,48 @@ import type {
   AppPreferences,
   SidecarStatus,
 } from "./types";
+import { previewPresentMonApps, previewSensorData, previewUpdate } from "./preview-fixture";
 
 // ─── Browser detection ──────────────────────────────────────────
 // When running via `npm run dev` in a browser (no Tauri runtime),
 // all invoke/listen calls are no-ops so the UI can be previewed.
 
 export const isBrowser = !("__TAURI_INTERNALS__" in window);
+
+// ─── Browser-preview fixture ────────────────────────────────────
+// The preview has no sidecar, so the sensor listeners below never fire: every
+// picker is empty, no reading has a value, and the monitoring banner appears
+// once the startup grace expires. Replaying a captured snapshot instead is what
+// makes the settings UI reviewable in a browser, including the GPU picker,
+// which only exists on a machine reporting more than one GPU.
+//
+// Gated on import.meta.env.DEV as well as isBrowser: Vite folds that to false
+// in `npm run build`, so neither the replay nor the fixture it imports can
+// reach a shipped bundle. `tauri dev` is unaffected: it has a Tauri runtime,
+// so isBrowser is false there and the real events flow.
+const usePreviewFixture = import.meta.env.DEV && isBrowser;
+
+const PREVIEW_TICK_MS = 1000;
+
+/**
+ * Feed a preview payload to a listener the way the sidecar would.
+ *
+ * Deferred by a macrotask rather than delivered inline: loadSettings() resolves
+ * on a microtask in the preview, and a snapshot landing before it would have
+ * the GPU selection it resolves overwritten by the settings arriving after.
+ */
+function replayPreview<T>(
+  next: () => T,
+  callback: (value: T) => void,
+  everyMs?: number,
+): Promise<UnlistenFn> {
+  const first = setTimeout(() => callback(next()), 0);
+  const repeat = everyMs ? setInterval(() => callback(next()), everyMs) : undefined;
+  return Promise.resolve(() => {
+    clearTimeout(first);
+    if (repeat) clearInterval(repeat);
+  });
+}
 
 async function safeInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   if (isBrowser) return undefined as T;
@@ -95,6 +131,8 @@ export type AppUpdate = import("@tauri-apps/plugin-updater").Update;
 // Returns the pending Update when a newer release exists, or null when the app
 // is current (or running in the browser preview, which has no Tauri runtime).
 export const checkForUpdate = async (): Promise<AppUpdate | null> => {
+  // The preview reports an update so the download banner has a state to be in.
+  if (usePreviewFixture) return previewUpdate();
   if (isBrowser) return null;
   const { check } = await import("@tauri-apps/plugin-updater");
   return check();
@@ -121,19 +159,32 @@ export const prepareForUpdate = async (): Promise<void> => {
 export const onSensorData = (
   callback: (data: HardwareMonitorData) => void
 ): Promise<UnlistenFn> =>
-  safeListen<HardwareMonitorData>("sensor-data", (event) =>
-    callback(event.payload)
-  );
+  usePreviewFixture
+    ? // Re-sent on a tick, like a real poll: the values are identical every
+      // time, but a store that receives one snapshot and never another cannot
+      // show anything that reacts to a reading changing.
+      replayPreview(
+        () => ({ ...previewSensorData(), lastPollTime: Date.now() }),
+        callback,
+        PREVIEW_TICK_MS,
+      )
+    : safeListen<HardwareMonitorData>("sensor-data", (event) =>
+        callback(event.payload)
+      );
 
 export const onPresentMonApps = (
   callback: (apps: string[]) => void
 ): Promise<UnlistenFn> =>
-  safeListen<string[]>("present-mon-apps", (event) => callback(event.payload));
+  usePreviewFixture
+    ? replayPreview(previewPresentMonApps, callback)
+    : safeListen<string[]>("present-mon-apps", (event) => callback(event.payload));
 
 export const onPipeStatus = (
   callback: (status: PipeStatus) => void
 ): Promise<UnlistenFn> =>
-  safeListen<PipeStatus>("pipe-status", (event) => callback(event.payload));
+  usePreviewFixture
+    ? replayPreview(() => ({ connected: true }), callback)
+    : safeListen<PipeStatus>("pipe-status", (event) => callback(event.payload));
 
 export const onSidecarStatus = (
   callback: (status: SidecarStatus) => void

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -200,7 +200,7 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   // Legacy: pill alpha is now driven by `opacity` above. Kept on the settings
   // shape (shared with the Rust struct) but no longer read by the UI.
   pillOpacity: 0.3,
-  fontSizeValue: 12,
+  fontSizeValue: 18,
   fontSizeLabel: 12,
   numberFontSize: 14,
   numberLabelFontSize: 10,

--- a/tauri-app/src/stores/updater-store.test.ts
+++ b/tauri-app/src/stores/updater-store.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// lib/tauri reads `window` at import time, which does not exist in the node
+// test project, and every action here crosses it. checkForUpdate is the only
+// mock a test asserts through; the rest just need to resolve.
+const checkForUpdate = vi.fn();
+const prepareForUpdate = vi.fn(async () => {});
+const relaunchApp = vi.fn(async () => {});
+
+vi.mock("@/lib/tauri", () => ({
+  isBrowser: true,
+  checkForUpdate: (...args: unknown[]) => checkForUpdate(...args),
+  prepareForUpdate: () => prepareForUpdate(),
+  relaunchApp: () => relaunchApp(),
+}));
+
+/**
+ * The store keeps the pending Update in module scope, so every test gets a
+ * fresh module rather than trying to unwind that from the outside.
+ */
+async function freshStore() {
+  vi.resetModules();
+  const { useUpdaterStore } = await import("./updater-store");
+  return useUpdaterStore;
+}
+
+type DownloadEvents = (event: unknown) => void;
+
+/** An Update with only the two methods the store calls. */
+function fakeUpdate(opts: { install?: () => Promise<void>; download?: (onEvent?: DownloadEvents) => Promise<void> } = {}) {
+  return {
+    version: "9.9.9",
+    download:
+      opts.download ??
+      (async (onEvent?: DownloadEvents) => {
+        onEvent?.({ event: "Started", data: { contentLength: 100 } });
+        onEvent?.({ event: "Progress", data: { chunkLength: 50 } });
+        onEvent?.({ event: "Finished" });
+      }),
+    install: opts.install ?? (async () => {}),
+  };
+}
+
+let errorLog: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  checkForUpdate.mockReset();
+  prepareForUpdate.mockClear();
+  relaunchApp.mockClear();
+  // The failure paths log on purpose; keep the test output readable.
+  errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorLog.mockRestore();
+});
+
+describe("check", () => {
+  it("offers an update it finds, and clears a previous dismissal", async () => {
+    const store = await freshStore();
+    checkForUpdate.mockResolvedValue(fakeUpdate());
+    store.setState({ dismissed: true });
+
+    await store.getState().check({ silent: true });
+
+    expect(store.getState().status).toBe("available");
+    expect(store.getState().availableVersion).toBe("9.9.9");
+    expect(store.getState().dismissed).toBe(false);
+  });
+
+  it("stays quiet on a silent check with nothing to offer, and speaks up on a manual one", async () => {
+    const silent = await freshStore();
+    checkForUpdate.mockResolvedValue(null);
+    await silent.getState().check({ silent: true });
+    expect(silent.getState().status).toBe("idle");
+
+    const manual = await freshStore();
+    checkForUpdate.mockResolvedValue(null);
+    await manual.getState().check();
+    expect(manual.getState().status).toBe("uptodate");
+  });
+
+  it("re-surfaces a downloaded update instead of checking again", async () => {
+    const store = await freshStore();
+    checkForUpdate.mockResolvedValue(fakeUpdate());
+    await store.getState().check({ silent: true });
+    await store.getState().download();
+    expect(store.getState().status).toBe("ready");
+
+    store.getState().dismiss();
+    checkForUpdate.mockClear();
+    await store.getState().check();
+
+    // The pill comes back on the update already in hand: no second check, and
+    // the downloaded state is not thrown away.
+    expect(checkForUpdate).not.toHaveBeenCalled();
+    expect(store.getState().status).toBe("ready");
+    expect(store.getState().dismissed).toBe(false);
+  });
+});
+
+describe("download", () => {
+  it("tracks progress and lands on ready", async () => {
+    const store = await freshStore();
+    checkForUpdate.mockResolvedValue(fakeUpdate());
+    await store.getState().check({ silent: true });
+
+    await store.getState().download();
+
+    expect(store.getState().status).toBe("ready");
+    expect(store.getState().progress).toBe(100);
+  });
+
+  it("reports an unknown total as -1 while it runs, then 100 once it finishes", async () => {
+    const store = await freshStore();
+    let finish: () => void = () => {};
+    const settled = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    checkForUpdate.mockResolvedValue(
+      fakeUpdate({
+        download: async (onEvent) => {
+          onEvent?.({ event: "Started", data: { contentLength: null } });
+          await settled;
+        },
+      }),
+    );
+    await store.getState().check({ silent: true });
+    const inFlight = store.getState().download();
+
+    // -1 is the "no total to divide by" marker the pill spins on. It only
+    // means anything mid-download.
+    expect(store.getState().progress).toBe(-1);
+
+    finish();
+    await inFlight;
+    expect(store.getState().progress).toBe(100);
+  });
+
+  it("returns to the offer when the download fails, keeping the pill on screen", async () => {
+    const store = await freshStore();
+    checkForUpdate.mockResolvedValue(
+      fakeUpdate({
+        download: async () => {
+          throw new Error("connection reset");
+        },
+      }),
+    );
+    await store.getState().check({ silent: true });
+    await store.getState().download();
+
+    // Not "error": that status is not one the pill renders, so it would take
+    // the pill off screen and strand the user.
+    expect(store.getState().status).toBe("available");
+    expect(store.getState().progress).toBe(0);
+    expect(store.getState().error).toBe("connection reset");
+  });
+});
+
+describe("cancel", () => {
+  it("orphans the run in flight, so its late finish cannot move the status", async () => {
+    const store = await freshStore();
+    let finish: () => void = () => {};
+    const settled = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    checkForUpdate.mockResolvedValue(
+      fakeUpdate({
+        download: async (onEvent) => {
+          onEvent?.({ event: "Started", data: { contentLength: 100 } });
+          await settled;
+        },
+      }),
+    );
+    await store.getState().check({ silent: true });
+
+    const inFlight = store.getState().download();
+    expect(store.getState().status).toBe("downloading");
+
+    store.getState().cancel();
+    expect(store.getState().status).toBe("available");
+    expect(store.getState().progress).toBe(0);
+
+    finish();
+    await inFlight;
+
+    // The abandoned run resolved after the cancel and must not claim "ready".
+    expect(store.getState().status).toBe("available");
+  });
+
+  it("ignores progress from an abandoned run", async () => {
+    const store = await freshStore();
+    let emit: DownloadEvents = () => {};
+    let finish: () => void = () => {};
+    const settled = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    checkForUpdate.mockResolvedValue(
+      fakeUpdate({
+        download: async (onEvent) => {
+          emit = onEvent ?? (() => {});
+          emit({ event: "Started", data: { contentLength: 100 } });
+          await settled;
+        },
+      }),
+    );
+    await store.getState().check({ silent: true });
+    const inFlight = store.getState().download();
+
+    store.getState().cancel();
+    emit({ event: "Progress", data: { chunkLength: 50 } });
+
+    expect(store.getState().progress).toBe(0);
+    finish();
+    await inFlight;
+  });
+});
+
+describe("install", () => {
+  it("stops the sidecar before installing, then relaunches", async () => {
+    const store = await freshStore();
+    checkForUpdate.mockResolvedValue(fakeUpdate());
+    await store.getState().check({ silent: true });
+    await store.getState().download();
+
+    await store.getState().install();
+
+    expect(prepareForUpdate).toHaveBeenCalledTimes(1);
+    expect(relaunchApp).toHaveBeenCalledTimes(1);
+    expect(store.getState().status).toBe("installing");
+  });
+
+  it("does not stop the sidecar while only downloading", async () => {
+    const store = await freshStore();
+    checkForUpdate.mockResolvedValue(fakeUpdate());
+    await store.getState().check({ silent: true });
+    await store.getState().download();
+
+    expect(prepareForUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns to ready when the install fails, so the downloaded update stays offered", async () => {
+    const store = await freshStore();
+    checkForUpdate.mockResolvedValue(
+      fakeUpdate({
+        install: async () => {
+          throw new Error("installer busy");
+        },
+      }),
+    );
+    await store.getState().check({ silent: true });
+    await store.getState().download();
+    await store.getState().install();
+
+    expect(store.getState().status).toBe("ready");
+    expect(store.getState().error).toBe("installer busy");
+    expect(relaunchApp).not.toHaveBeenCalled();
+  });
+});

--- a/tauri-app/src/stores/updater-store.ts
+++ b/tauri-app/src/stores/updater-store.ts
@@ -9,15 +9,21 @@ import {
 export type UpdaterStatus =
   | "idle" // no check run yet this session
   | "checking" // a check is in flight
-  | "available" // a newer version exists and is waiting to install
+  | "available" // a newer version exists and is waiting to be downloaded
   | "downloading" // user accepted; bytes are streaming
-  | "installing" // download done, installer running / about to relaunch
+  | "ready" // downloaded and waiting for the user to install it
+  | "installing" // installer running / about to relaunch
   | "uptodate" // checked, already on the latest version
-  | "error"; // check or install failed
+  | "error"; // check, download or install failed
 
-// The Update instance is stateful (downloadAndInstall lives on it) and not
+// The Update instance is stateful (download/install live on it) and not
 // serializable, so it's held outside the reactive store.
 let pendingUpdate: AppUpdate | null = null;
+
+// Which download attempt is current. Cancelling bumps it, which orphans the
+// in-flight run: its progress events and its result are both ignored. See
+// cancel() for what this can and cannot do.
+let downloadRun = 0;
 
 interface UpdaterStore {
   status: UpdaterStatus;
@@ -25,13 +31,17 @@ interface UpdaterStore {
   // 0–100 while downloading; -1 when the total size is unknown.
   progress: number;
   error: string | null;
-  // User dismissed the badge with "Later" — stays hidden until the next check.
+  // User dismissed the badge with "Later" or the close button. Stays hidden
+  // until the next check, which is why "Check for latest updates" brings it
+  // back.
   dismissed: boolean;
 
   // `silent` (on-launch) checks never surface "up to date" or errors in the UI;
   // a manual check does. Either way, an available update shows the badge.
   check: (opts?: { silent?: boolean }) => Promise<void>;
-  downloadAndInstall: () => Promise<void>;
+  download: () => Promise<void>;
+  install: () => Promise<void>;
+  cancel: () => void;
   dismiss: () => void;
 }
 
@@ -43,9 +53,17 @@ export const useUpdaterStore = create<UpdaterStore>((set, get) => ({
   dismissed: false,
 
   check: async ({ silent = false } = {}) => {
-    // Don't stack checks or re-check mid-download.
+    // Don't stack checks or re-check mid-update.
     const s = get().status;
     if (s === "checking" || s === "downloading" || s === "installing") return;
+
+    // A download that is already waiting to install must not be thrown away by
+    // a later check: re-surface it instead, which is what "Check for latest
+    // updates" should do after the pill was dismissed.
+    if (s === "ready") {
+      set({ dismissed: false });
+      return;
+    }
 
     set({ status: "checking", error: null });
     try {
@@ -75,22 +93,24 @@ export const useUpdaterStore = create<UpdaterStore>((set, get) => ({
     }
   },
 
-  downloadAndInstall: async () => {
+  // Download only. Installing is a second, deliberate step: the design has a
+  // "ready to install" state with its own button, and an install closes the
+  // app, which should never happen as a side effect of a download finishing.
+  download: async () => {
     if (!pendingUpdate) return;
     // Guard re-entrancy (e.g. a rapid double-tap on "Update now") so two
-    // installs can't race on the same Update instance.
+    // downloads can't race on the same Update instance.
     const s = get().status;
     if (s === "downloading" || s === "installing") return;
+
+    const run = ++downloadRun;
     set({ status: "downloading", progress: 0, error: null });
 
     let downloaded = 0;
     let contentLength = 0;
     try {
-      // Kill the HardwareMonitor sidecar (+ PresentMon) and its supervisor
-      // first — a running sidecar holds its .exe open and the NSIS installer
-      // would fail to overwrite it ("Error opening file for writing").
-      await prepareForUpdate();
-      await pendingUpdate.downloadAndInstall((event) => {
+      await pendingUpdate.download((event) => {
+        if (run !== downloadRun) return; // cancelled
         switch (event.event) {
           case "Started":
             contentLength = event.data.contentLength ?? 0;
@@ -108,20 +128,57 @@ export const useUpdaterStore = create<UpdaterStore>((set, get) => ({
             }
             break;
           case "Finished":
-            set({ status: "installing", progress: 100 });
+            set({ progress: 100 });
             break;
         }
       });
-      // Installer has run (the Finished event already set "installing");
-      // relaunch into the new version. On Windows the NSIS installer may close
+      if (run !== downloadRun) return;
+      set({ status: "ready", progress: 100 });
+    } catch (e) {
+      if (run !== downloadRun) return;
+      // Back to the offer rather than "error". The pill only renders the four
+      // live states, so "error" would take it off screen and leave the row
+      // saying the *check* failed, which is a different thing. The message is
+      // kept for whoever surfaces it, and logged so a failure is diagnosable.
+      const message = e instanceof Error ? e.message : String(e);
+      console.error("Update download failed:", message);
+      set({ status: "available", progress: 0, error: message });
+    }
+  },
+
+  install: async () => {
+    if (!pendingUpdate) return;
+    if (get().status === "installing") return;
+    set({ status: "installing", error: null });
+    try {
+      // Kill the HardwareMonitor sidecar (+ PresentMon) and its supervisor
+      // first: a running sidecar holds its .exe open and the NSIS installer
+      // would fail to overwrite it ("Error opening file for writing"). This
+      // belongs to the install rather than the download, so the sidecar keeps
+      // running (and the overlay keeps reading) while bytes come down.
+      await prepareForUpdate();
+      await pendingUpdate.install();
+      // Relaunch into the new version. On Windows the NSIS installer may close
       // the app itself, so this is best-effort.
       await relaunchApp();
     } catch (e) {
-      set({
-        status: "error",
-        error: e instanceof Error ? e.message : String(e),
-      });
+      // Back to "ready" for the same reason download returns to "available":
+      // the bytes are already here, so the pill has to keep offering to
+      // install them instead of vanishing and stranding a downloaded update.
+      const message = e instanceof Error ? e.message : String(e);
+      console.error("Update install failed:", message);
+      set({ status: "ready", error: message });
     }
+  },
+
+  // Stops tracking the download and returns the pill to its offer.
+  //
+  // It does not abort the transfer: the updater plugin exposes no way to, so
+  // bytes already requested keep arriving and are simply discarded. Cancel is
+  // therefore about the UI getting out of the way, not about saving bandwidth.
+  cancel: () => {
+    downloadRun++;
+    set({ status: "available", progress: 0, error: null });
   },
 
   dismiss: () => set({ dismissed: true }),

--- a/tauri-app/src/stores/updater-store.ts
+++ b/tauri-app/src/stores/updater-store.ts
@@ -156,6 +156,12 @@ export const useUpdaterStore = create<UpdaterStore>((set, get) => ({
       // would fail to overwrite it ("Error opening file for writing"). This
       // belongs to the install rather than the download, so the sidecar keeps
       // running (and the overlay keeps reading) while bytes come down.
+      //
+      // One way only: prepare_for_update clears the supervisor's running flag,
+      // nothing sets it back, and the supervisor thread returns on seeing it
+      // false. If the install then fails, the app has no sensor readings until
+      // it restarts, which is why the pill says so rather than re-offering the
+      // install as though nothing happened.
       await prepareForUpdate();
       await pendingUpdate.install();
       // Relaunch into the new version. On Windows the NSIS installer may close


### PR DESCRIPTION
Brings the settings window in line with the design file, rebuilds the update
pill for the three states it now has, and removes a class of measurement error
that ran through the whole window.

## The measurement problem

Almost every spacing value in this window was 12.5% short. The root font size is
14px, so a rem-based utility resolves to 87.5% of its nominal value: 20 of card
padding rendered as 17.5, a 40 tall field as 35, a 16 icon as 14. The design
specifies px, so the values this window is built from are now px tokens.

Measured after the change: window padding 24 with a 20 gap and a 603 content
column, cards 16 apart, card padding and gap 20, section titles 16 tall,
checkbox rows 24, the threshold block 97 with each segment 65, theme cards 153
over a 104 preview, and the update pill inset 24 on three sides.

The rest of the app still uses rem utilities and is unchanged. Setting the root
size to 16px would correct all of it at once, and only seven rem-based type
utilities exist app-wide, but that is a separate decision.

## Update pill

Downloading and installing are now separate steps, because the design has a
"ready to install" state with its own button and because installing closes the
app. Stopping the sidecar moved from before the download to before the install,
so the overlay keeps reading while bytes come down.

Cancel abandons a download by orphaning its run. It does not abort the transfer:
the updater plugin exposes no way to, so bytes already requested keep arriving
and are discarded. A failed download returns to the offer and a failed install
returns to ready, instead of both landing on a status the pill does not render,
which would take it off screen and strand a downloaded update.

"What's new" opens the changelog on the marketing site. The www is required, as
the apex domain has no DNS record at all.

The pill's leading chip uses a mode-aware token rather than the primitive the
design binds it to. That primitive has a single mode, so in dark mode the pill
inverts to light while the chip stays dark and the icon, which does invert,
disappears into it. In light mode the chip is one shade off the design as a
result.

## Shared field

The design has a single labelled input that appears four times: the sensor
picker, the GPU picker, the monitor-app picker and the polling rate. There were
three separate implementations, none complete. The GPU picker had no label, and
the monitor-app one rendered its label flush against its value because the
wrapper it relied on was not laying out as a flex row. All four now use one
component.

## Behaviour changes worth calling out

- The GPU note is shown for as long as the picker is, rather than only after the
  selected GPU has read zero for two seconds. It explains what a zero reading
  means rather than reporting one. The picker itself still appears only on a
  machine reporting more than one GPU, so a single-GPU machine sees that card
  exactly as before.
- The stats font defaults to 18px on a fresh install, labels stay at 12. An
  existing settings file is merged over the defaults, so a saved size still
  wins. The first-run value comes from the Rust defaults, so both sides moved.
- Checkbox rows are 24 tall rather than 18, and switches are 36 by 20. Both come
  from shared controls, so this is visible on the FPS, Network and sensor rows
  as well.
- The window edge is an outline rather than a border. The design strokes that
  frame outside, so its stroke costs no layout; a 1px border was consuming 2 of
  the content column.
- The About section starts collapsed, and two words in its closing paragraph are
  corrected.

## Icons

Four glyphs are now exports from the design file rather than redrawn: the info
icon, the computer icon, and the pill's cloud-download, download-done and close
icons. The computer one had been drawn into a smaller viewBox, which scaled it
up and lost the inset that centres it, then compensated with a manual nudge.
Measuring the ink centroid shows it needs no nudge.

## Verification

Every measurement in this description was read off the rendered DOM at the real
window width, not estimated. A production build contains none of the dev
preview fixture. 110 unit tests pass, 11 of them new for the updater store,
lint is clean, and cargo check passes for the Rust default.

## Known, not addressed

Cancelling a download and then retrying it starts a second download and orphans
the first one's resource, since the plugin has no abort. The safe fixes all
change behaviour, so it is left as is.
