### PR TITLE
Bump version to 2.2.16

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,8 +5,12 @@ built by the `build.yml` GitHub Actions workflow on a Windows runner.
 
 ## Cut a release
 
-1. Bump the version in `tauri-app/src-tauri/tauri.conf.json` (keep
-   `tauri-app/package.json` in sync), e.g. `2.2.4` → `2.2.5`.
+1. Bump the version in all five places that carry it, e.g. `2.2.4` → `2.2.5`:
+   `tauri-app/src-tauri/tauri.conf.json`, `tauri-app/package.json`,
+   `tauri-app/package-lock.json` (both root entries),
+   `tauri-app/src-tauri/Cargo.toml`, and the `cleanmeter` package entry in
+   `tauri-app/src-tauri/Cargo.lock`. A missed lockfile makes `npm ci` or
+   `cargo build --locked` disagree with its manifest in CI.
 2. Commit, then tag and push:
    ```
    git tag v2.2.5

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cleanmeter",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cleanmeter",
-      "version": "2.2.15",
+      "version": "2.2.16",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@fluentui/react-components": "^9.73.4",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleanmeter",
   "private": true,
-  "version": "2.2.15",
+  "version": "2.2.16",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "cleanmeter"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "byteorder",
  "dirs",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cleanmeter"
-version = "2.2.15"
+version = "2.2.16"
 description = "Gaming performance overlay"
 authors = ["Cleanmeter"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui/toolkits/refs/heads/main/tauri/schema.json",
   "productName": "Cleanmeter",
   "identifier": "com.cleanmeter.desktop",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Cuts the next draft build.

`v2.2.15` was tagged and built as a draft on 14 August and never published.
Main has moved five merges past that tag, so the existing draft no longer
represents what would ship. Per the release flow a superseded draft is replaced
by the next version's rather than re-tagged, so this bumps to 2.2.16.

Once this and #55 are on main, tagging `v2.2.16` triggers the build workflow,
which produces the draft release with the installer, `latest.json` and the
signatures. The draft stays a draft: it is the QA gate, not a leftover step.

Also corrects `RELEASING.md`. It named two files to bump; the version actually
lives in five places, and `tauri-app/package-lock.json` was missing from the
list. A stale lockfile leaves `npm ci` or `cargo build --locked` disagreeing
with its manifest on the runner.
