### PR TITLE
Stop synthesising an Alt keystroke to win the foreground

### DIFF
--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -207,8 +207,7 @@ fn foreground_is_ours() -> bool {
 pub fn bring_to_front(window: &tauri::WebviewWindow) {
     use windows::Win32::Foundation::HWND;
     use windows::Win32::UI::WindowsAndMessaging::{
-        FlashWindowEx, GetForegroundWindow, IsIconic, SetForegroundWindow, FLASHWINFO,
-        FLASHWINFO_FLAGS, FLASHW_ALL, FLASHW_TIMERNOFG,
+        FlashWindowEx, GetForegroundWindow, IsIconic, SetForegroundWindow, FLASHWINFO, FLASHW_TRAY,
     };
 
     // tauri's HWND comes from its own (newer) windows crate; both are a newtype over
@@ -231,14 +230,22 @@ pub fn bring_to_front(window: &tauri::WebviewWindow) {
             return;
         }
 
-        // Refused. Signal instead of forcing. FLASHW_TIMERNOFG stops the flashing by
-        // itself once the window is brought forward, so nothing has to clear it.
+        // Refused. Signal instead of forcing: three flashes of the taskbar button,
+        // which then stop on their own.
+        //
+        // FLASHW_TRAY rather than FLASHW_ALL because this window is created with
+        // decorations: false, so there is no caption for FLASHW_CAPTION to flash.
+        //
+        // Deliberately no FLASHW_TIMERNOFG. That flag means "flash continuously until
+        // the window comes to the foreground", which contradicts a uCount and would
+        // leave the button flashing until clicked on exactly the paths where the user
+        // never asked for the window: autostart at logon above all.
         let info = FLASHWINFO {
             cbSize: std::mem::size_of::<FLASHWINFO>() as u32,
             hwnd,
-            dwFlags: FLASHWINFO_FLAGS(FLASHW_ALL.0 | FLASHW_TIMERNOFG.0),
+            dwFlags: FLASHW_TRAY,
             uCount: 3,
-            dwTimeout: 0,
+            dwTimeout: 0, // 0 means the default caret blink rate
         };
         let _ = FlashWindowEx(&info);
     }

--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -182,6 +182,75 @@ fn foreground_is_ours() -> bool {
     false
 }
 
+/// Bring a window to the front without letting tao fabricate a keystroke.
+///
+/// Use this instead of `WebviewWindow::set_focus()`. That call routes to tao's
+/// `force_window_active`, which tries `SetForegroundWindow` and, when Windows refuses
+/// it, synthesises a left-Alt press and release through `SendInput` to break the
+/// foreground lock. The injection is system-wide, not scoped to our window: the
+/// Alt-down is delivered to whoever is in front, and the Alt-up arrives after the
+/// foreground has already moved to us, so the window that was in front can be left
+/// believing Alt is still held. Every later keystroke there becomes Alt+key. For a HUD
+/// that exists to sit next to games, with keys physically held down, that is not a
+/// risk worth carrying for a focus nicety.
+///
+/// Windows refuses `SetForegroundWindow` exactly when we are not the foreground
+/// process and did not receive the last input event, which is the normal state while
+/// someone is playing. So the injecting branch is the in-game branch.
+///
+/// This mirrors tao's decision tree and its `SetForegroundWindow` attempt, so every
+/// case that already worked behaves identically. Only the refused branch differs:
+/// flash the taskbar button rather than forge input. The caller has already called
+/// `show()`, so a refusal still leaves the window up, just not in front, which is the
+/// same outcome the user gets today whenever the Alt hack fails to win the race.
+#[cfg(windows)]
+pub fn bring_to_front(window: &tauri::WebviewWindow) {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        FlashWindowEx, GetForegroundWindow, IsIconic, SetForegroundWindow, FLASHWINFO,
+        FLASHWINFO_FLAGS, FLASHW_ALL, FLASHW_TIMERNOFG,
+    };
+
+    // tauri's HWND comes from its own (newer) windows crate; both are a newtype over
+    // *mut c_void, so the pointer carries across.
+    let Ok(raw) = window.hwnd() else {
+        return;
+    };
+    let hwnd = HWND(raw.0 as _);
+
+    unsafe {
+        // Mirrors tao: a minimized window is left alone. Read through IsIconic rather
+        // than Tauri's is_minimized() so this cannot race a queued window message.
+        if IsIconic(hwnd).as_bool() {
+            return;
+        }
+        if hwnd == GetForegroundWindow() {
+            return;
+        }
+        if SetForegroundWindow(hwnd).as_bool() {
+            return;
+        }
+
+        // Refused. Signal instead of forcing. FLASHW_TIMERNOFG stops the flashing by
+        // itself once the window is brought forward, so nothing has to clear it.
+        let info = FLASHWINFO {
+            cbSize: std::mem::size_of::<FLASHWINFO>() as u32,
+            hwnd,
+            dwFlags: FLASHWINFO_FLAGS(FLASHW_ALL.0 | FLASHW_TIMERNOFG.0),
+            uCount: 3,
+            dwTimeout: 0,
+        };
+        let _ = FlashWindowEx(&info);
+    }
+}
+
+/// Non-Windows stub. `set_focus` only injects input in tao's Windows backend, so
+/// everywhere else the plain call is already the right one.
+#[cfg(not(windows))]
+pub fn bring_to_front(window: &tauri::WebviewWindow) {
+    let _ = window.set_focus();
+}
+
 /// Recompute the gate from live window state and apply it.
 ///
 /// The overlay accepts mouse input only while the settings window is visible *and*

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -266,7 +266,7 @@ pub fn run() {
             // Focus the existing settings window when a second instance launches
             if let Some(window) = app.get_webview_window("settings") {
                 let _ = window.show();
-                let _ = window.set_focus();
+                commands::bring_to_front(&window);
             }
         }))
         .setup(|app| {
@@ -346,7 +346,7 @@ pub fn run() {
                 // hidden (config is visible:false) so the app starts to tray.
                 if !start_minimized {
                     let _ = window.show();
-                    let _ = window.set_focus();
+                    commands::bring_to_front(&window);
                 }
             }
 

--- a/tauri-app/src-tauri/src/tray.rs
+++ b/tauri-app/src-tauri/src/tray.rs
@@ -30,7 +30,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
             let app = tray.app_handle();
             if let Some(window) = app.get_webview_window("settings") {
                 let _ = window.show();
-                let _ = window.set_focus();
+                crate::commands::bring_to_front(&window);
             }
         }
     });
@@ -39,7 +39,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         "show_settings" => {
             if let Some(window) = app.get_webview_window("settings") {
                 let _ = window.show();
-                let _ = window.set_focus();
+                crate::commands::bring_to_front(&window);
             }
         }
         "toggle_overlay" => {


### PR DESCRIPTION
## What

Showing the settings window went through `WebviewWindow::set_focus()`, which routes to tao's `force_window_active`. That tries `SetForegroundWindow` and, when Windows refuses it, fabricates a left-Alt press and release through `SendInput` to break the foreground lock.

All four call sites now go through `commands::bring_to_front`, which makes the same `SetForegroundWindow` attempt and flashes the taskbar button instead of forging input when it is refused.

## Why

The injection is system-wide rather than scoped to our own window. The Alt-down is delivered to whatever is in front, and the Alt-up arrives after the foreground has already moved to us, so the window that was in front can be left believing Alt is still held, turning every later keystroke there into Alt+key.

Windows refuses `SetForegroundWindow` precisely when we are not the foreground process and did not receive the last input event, which is the normal state while someone is playing. The injecting branch was therefore the in-game branch, with keys physically held down. A performance HUD should not fabricate modifier keys to win a focus race.

## How

`bring_to_front` mirrors tao's decision tree:

```
IsIconic                       -> return   (tao skips minimized windows too)
already the foreground window  -> return
SetForegroundWindow succeeded  -> return
refused                        -> FlashWindowEx
```

Every case that already worked behaves identically. Only the refused branch differs. Minimized state is read through `IsIconic` rather than Tauri's `is_minimized()` so the check cannot race a queued window message. The HWND crosses the two windows-crate versions in the lockfile cleanly, since both declare `HWND` as a newtype over `*mut c_void`.

## Behaviour change

When Windows refuses the foreground change, the settings window comes up visible and centred but possibly not in front, with its taskbar button flashing, where the old path would sometimes have forced it forward. That applies to three cases: immediately after the UAC elevation, autostart at logon, and launching while a game holds the foreground. The window is still shown in all of them.

## Test plan

- [x] `cargo clippy --target x86_64-pc-windows-msvc --all-targets`: no errors. Warning count unchanged at 5, all pre-existing and in untouched code.
- [x] `cargo test --lib --target x86_64-pc-windows-msvc`: 20 passed, 0 failed.
- [ ] Manual smoke test, not yet run: tray left-click, the Show Settings menu item, a cold launch, and a second launch while the app is already running. The `requireAdministrator` manifest means this needs an interactive UAC prompt.

## Not included

`tray.rs` matches `TrayIconEvent::Click { button: Left, .. }` and ignores `button_state`, and `tray-icon` emits `Click` for both `Down` and `Up`, so one tray click runs the handler twice. Harmless now that nothing is injected, and a separate concern from this diff.
