### PR TITLE
feat: add GPU multi-value readings and game-only overlay visibility

### DIFF
--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -565,13 +565,19 @@ mod tests {
             &[
                 ("CPU Total", "/load/0", "/amdcpu/0"),
                 ("GPU Core", "/temperature/0", "/gpu-nvidia/0"),
+                ("GPU Hot Spot", "/temperature/1", "/gpu-nvidia/0"),
             ],
         );
         let parsed = parse_data_packet(&packet).expect("a well-formed packet must parse");
         assert_eq!(parsed.hardwares.len(), 2);
-        assert_eq!(parsed.sensors.len(), 2);
+        assert_eq!(parsed.sensors.len(), 3);
         assert_eq!(parsed.hardwares[0].name, "CPU");
         assert_eq!(parsed.sensors[1].name, "GPU Core");
+        assert_eq!(parsed.sensors[2].name, "GPU Hot Spot");
+        assert_eq!(
+            parsed.sensors[1].hardware_identifier,
+            parsed.sensors[2].hardware_identifier
+        );
     }
 
     /// An empty snapshot is what the sidecar sends before LibreHardwareMonitor

--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -179,6 +179,8 @@ pub struct SensorConfig {
     pub is_enabled: bool,
     #[serde(rename = "customReadingId")]
     pub custom_reading_id: String,
+    #[serde(rename = "additionalReadingIds", default)]
+    pub additional_reading_ids: Vec<String>,
 }
 
 impl Default for SensorConfig {
@@ -186,6 +188,7 @@ impl Default for SensorConfig {
         SensorConfig {
             is_enabled: true,
             custom_reading_id: String::new(),
+            additional_reading_ids: Vec::new(),
         }
     }
 }
@@ -199,6 +202,8 @@ pub struct FramerateSensorConfig {
     pub is_enabled: bool,
     #[serde(rename = "customReadingId")]
     pub custom_reading_id: String,
+    #[serde(rename = "additionalReadingIds", default)]
+    pub additional_reading_ids: Vec<String>,
     #[serde(rename = "targetAppName", default)]
     pub target_app_name: String,
 }
@@ -208,6 +213,7 @@ impl Default for FramerateSensorConfig {
         FramerateSensorConfig {
             is_enabled: true,
             custom_reading_id: String::new(),
+            additional_reading_ids: Vec::new(),
             target_app_name: String::new(),
         }
     }
@@ -219,6 +225,8 @@ pub struct GraphSensorConfig {
     pub is_enabled: bool,
     #[serde(rename = "customReadingId")]
     pub custom_reading_id: String,
+    #[serde(rename = "additionalReadingIds", default)]
+    pub additional_reading_ids: Vec<String>,
     pub boundaries: Boundaries,
 }
 
@@ -227,6 +235,7 @@ impl Default for GraphSensorConfig {
         GraphSensorConfig {
             is_enabled: true,
             custom_reading_id: String::new(),
+            additional_reading_ids: Vec::new(),
             boundaries: Boundaries::default(),
         }
     }
@@ -478,6 +487,23 @@ mod tests {
         assert_eq!(restored.selected_gpu_id, "/gpu-nvidia/0");
     }
 
+    #[test]
+    fn additional_sensor_readings_survive_a_save_and_load_round_trip() {
+        let mut settings = OverlaySettings::default();
+        settings.sensors.gpu_temp.custom_reading_id =
+            "/gpu-nvidia/0/temperature/0".to_string();
+        settings.sensors.gpu_temp.additional_reading_ids =
+            vec!["/gpu-nvidia/0/temperature/1".to_string()];
+
+        let json = serde_json::to_string(&settings).expect("serialise");
+        let restored: OverlaySettings = serde_json::from_str(&json).expect("deserialise");
+
+        assert_eq!(
+            restored.sensors.gpu_temp.additional_reading_ids,
+            vec!["/gpu-nvidia/0/temperature/1"]
+        );
+    }
+
     /// Every settings file written before this field existed lacks the key.
     /// Without `default` on it, serde rejects the whole file and the user is
     /// silently reset to defaults on upgrade.
@@ -494,5 +520,26 @@ mod tests {
             serde_json::from_value(without).expect("an older settings file must still load");
 
         assert_eq!(loaded.selected_gpu_id, "");
+    }
+
+    #[test]
+    fn a_settings_file_written_before_multi_value_readings_still_loads() {
+        let mut old = serde_json::to_value(OverlaySettings::default()).expect("to value");
+        let sensors = old
+            .get_mut("sensors")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("sensors object");
+        for config in sensors.values_mut() {
+            config
+                .as_object_mut()
+                .expect("sensor config")
+                .remove("additionalReadingIds");
+        }
+
+        let loaded: OverlaySettings =
+            serde_json::from_value(old).expect("an older settings file must still load");
+
+        assert!(loaded.sensors.gpu_temp.additional_reading_ids.is_empty());
+        assert!(loaded.sensors.cpu_temp.additional_reading_ids.is_empty());
     }
 }

--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -352,6 +352,10 @@ pub struct OverlaySettings {
     pub polling_rate: u64,
     #[serde(rename = "isLoggingEnabled")]
     pub is_logging_enabled: bool,
+    // Opt-in visibility policy. Older settings files have no key, so false
+    // preserves the previous always-visible behavior on upgrade.
+    #[serde(rename = "showOverlayOnlyInGames", default)]
+    pub show_overlay_only_in_games: bool,
     // Burn-in mitigation: when true the overlay is nudged a few pixels on a
     // slow cycle (applied entirely on the JS side). `default` keeps older save
     // files loading cleanly. Must live here or serde drops it on save (see the
@@ -394,6 +398,7 @@ impl Default for OverlaySettings {
             label_font_weight: 500,
             polling_rate: 500,
             is_logging_enabled: false,
+            show_overlay_only_in_games: false,
             pixel_shift: false,
             selected_gpu_id: String::new(),
             sensors: SensorsConfig::default(),
@@ -504,6 +509,20 @@ mod tests {
         );
     }
 
+    #[test]
+    fn game_only_visibility_survives_a_save_and_load_round_trip() {
+        let settings = OverlaySettings {
+            show_overlay_only_in_games: true,
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&settings).expect("serialise");
+        assert!(json.contains("\"showOverlayOnlyInGames\":true"));
+
+        let restored: OverlaySettings = serde_json::from_str(&json).expect("deserialise");
+        assert!(restored.show_overlay_only_in_games);
+    }
+
     /// Every settings file written before this field existed lacks the key.
     /// Without `default` on it, serde rejects the whole file and the user is
     /// silently reset to defaults on upgrade.
@@ -541,5 +560,19 @@ mod tests {
 
         assert!(loaded.sensors.gpu_temp.additional_reading_ids.is_empty());
         assert!(loaded.sensors.cpu_temp.additional_reading_ids.is_empty());
+    }
+
+    #[test]
+    fn a_settings_file_written_before_game_only_visibility_still_loads() {
+        let mut old = serde_json::to_value(OverlaySettings::default()).expect("to value");
+        old.as_object_mut()
+            .expect("settings object")
+            .remove("showOverlayOnlyInGames")
+            .expect("the key should exist in current settings");
+
+        let loaded: OverlaySettings =
+            serde_json::from_value(old).expect("an older settings file must still load");
+
+        assert!(!loaded.show_overlay_only_in_games);
     }
 }

--- a/tauri-app/src/components/overlay/GpuSection.tsx
+++ b/tauri-app/src/components/overlay/GpuSection.tsx
@@ -1,6 +1,8 @@
 import { Pill } from "./Pill";
 import { ProgressRing } from "./ProgressRing";
 import { ProgressBar } from "./ProgressBar";
+import { MetricValue } from "./MetricValue";
+import { MultiValueMetric } from "./MultiValueMetric";
 import { useSettingsStore } from "@/stores/settings-store";
 import { SensorType } from "@/lib/types";
 import type { Sensor } from "@/lib/types";
@@ -8,6 +10,14 @@ import { findSensorById, formatValue, formatTemperature } from "@/lib/utils";
 
 interface GpuSectionProps {
   isHorizontal: boolean;
+}
+
+function gpuTemperatureLabel(sensor: Sensor): string {
+  const compact = sensor.name
+    .replace(/^GPU\s+/i, "")
+    .replace(/\s+Temperature$/i, "")
+    .trim();
+  return compact || sensor.name;
 }
 
 export function GpuSection({ isHorizontal }: GpuSectionProps) {
@@ -35,7 +45,6 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
   const Progress = progressType === "bar" ? ProgressBar : ProgressRing;
   const showProgress = progressType !== "none";
 
-  const gpuTempVal = findSensorById(sensors, gpuTemp.customReadingId)?.value ?? 0;
   const gpuUsageVal = findSensorById(sensors, gpuUsage.customReadingId)?.value ?? 0;
   const gpuPowerVal = findSensorById(sensors, gpuConsumption.customReadingId)?.value ?? 0;
 
@@ -78,27 +87,31 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
       ? Math.min((vramUsedVal / vramTotalVal) * 100, 100)
       : vramLoadVal;
 
-  const temp = formatTemperature(gpuTempVal, settings.temperatureUnit);
+  const metricTextProps = {
+    valueFontSize,
+    labelFontSize,
+    valueFontWeight,
+    labelFontWeight,
+  };
 
   return (
     <Pill title="GPU" isHorizontal={isHorizontal}>
       {gpuTemp.isEnabled && (
-        showProgress ? (
-          <Progress
-            value={gpuTempVal}
-            max={100}
-            label={temp.label}
-            unit={temp.symbol}
-            boundaries={gpuTemp.boundaries}
-          />
-        ) : (
-          <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
-              {temp.label}
-            </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{temp.symbol}</span>
-          </div>
-        )
+        <MultiValueMetric
+          sensors={sensors}
+          config={gpuTemp}
+          progressType={progressType}
+          format={(value) => {
+            const temperature = formatTemperature(value, settings.temperatureUnit);
+            return { value: temperature.label, unit: temperature.symbol };
+          }}
+          labelForSensor={gpuTemperatureLabel}
+          boundaries={gpuTemp.boundaries}
+          accepts={(sensor) =>
+            !settings.selectedGpuId || sensor.hardwareIdentifier === settings.selectedGpuId
+          }
+          {...metricTextProps}
+        />
       )}
       {gpuUsage.isEnabled && (
         showProgress ? (
@@ -110,12 +123,7 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
             boundaries={gpuUsage.boundaries}
           />
         ) : (
-          <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
-              {formatValue(gpuUsageVal)}
-            </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>%</span>
-          </div>
+          <MetricValue value={formatValue(gpuUsageVal)} unit="%" {...metricTextProps} />
         )
       )}
       {/* VRAM is gated on vramUsage alone — totalVramUsed is a removed-from-UI
@@ -132,23 +140,17 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
             boundaries={vramUsage.boundaries}
           />
         ) : (
-          <div className="flex items-center gap-1">
-            <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
-              {vramUsedVal > 0 ? formatValue(vramUsedVal, 1) : formatValue(vramUsageVal, 0)}
-            </span>
-            <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>{vramUsedVal > 0 ? "GB" : "%"}</span>
-          </div>
+          <MetricValue
+            value={vramUsedVal > 0 ? formatValue(vramUsedVal, 1) : formatValue(vramUsageVal, 0)}
+            unit={vramUsedVal > 0 ? "GB" : "%"}
+            {...metricTextProps}
+          />
         )
       )}
       {/* Power consumption has no threshold ring in the canonical build —
           always a plain value + unit (matches v2.2.x early build). */}
       {gpuConsumption.isEnabled && (
-        <div className="flex items-center gap-1">
-          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
-            {formatValue(gpuPowerVal)}
-          </span>
-          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>W</span>
-        </div>
+        <MetricValue value={formatValue(gpuPowerVal)} unit="W" {...metricTextProps} />
       )}
     </Pill>
   );

--- a/tauri-app/src/components/overlay/MetricValue.tsx
+++ b/tauri-app/src/components/overlay/MetricValue.tsx
@@ -1,0 +1,63 @@
+interface MetricValueProps {
+  value: string;
+  unit: string;
+  valueFontSize: number;
+  labelFontSize: number;
+  valueFontWeight: number;
+  labelFontWeight: number;
+  label?: string;
+  title?: string;
+}
+
+/** Compact overlay value with an optional label for supplemental readings. */
+export function MetricValue({
+  value,
+  unit,
+  valueFontSize,
+  labelFontSize,
+  valueFontWeight,
+  labelFontWeight,
+  label,
+  title,
+}: MetricValueProps) {
+  return (
+    <div className="flex items-center gap-1" title={title}>
+      {label && (
+        <span
+          style={{
+            fontSize: labelFontSize,
+            fontWeight: labelFontWeight,
+            color: "var(--overlay-text-muted)",
+            fontFamily: "Inter",
+            letterSpacing: "0.04em",
+          }}
+        >
+          {label}
+        </span>
+      )}
+      <span
+        className="tabular-nums"
+        style={{
+          fontSize: valueFontSize,
+          fontWeight: valueFontWeight,
+          color: "var(--overlay-text)",
+          fontFamily: "Inter",
+          letterSpacing: "-0.02em",
+        }}
+      >
+        {value}
+      </span>
+      <span
+        style={{
+          fontSize: labelFontSize,
+          fontWeight: labelFontWeight,
+          color: "var(--overlay-text)",
+          fontFamily: "Inter",
+          letterSpacing: "0.04em",
+        }}
+      >
+        {unit}
+      </span>
+    </div>
+  );
+}

--- a/tauri-app/src/components/overlay/MetricValue.tsx
+++ b/tauri-app/src/components/overlay/MetricValue.tsx
@@ -21,7 +21,7 @@ export function MetricValue({
   title,
 }: MetricValueProps) {
   return (
-    <div className="flex items-center gap-1" title={title}>
+    <div className="flex items-center gap-[var(--spacingXxxs)]" title={title}>
       {label && (
         <span
           style={{

--- a/tauri-app/src/components/overlay/MultiValueMetric.tsx
+++ b/tauri-app/src/components/overlay/MultiValueMetric.tsx
@@ -68,7 +68,10 @@ export function MultiValueMetric({
   return (
     <>
       {showProgress ? (
-        <div className="flex items-center gap-1" title={readings.primary?.name}>
+        <div
+          className="flex items-center gap-[var(--spacingXxxs)]"
+          title={readings.primary?.name}
+        >
           {primaryLabel && (
             <span
               style={{

--- a/tauri-app/src/components/overlay/MultiValueMetric.tsx
+++ b/tauri-app/src/components/overlay/MultiValueMetric.tsx
@@ -1,0 +1,117 @@
+import type {
+  Boundaries,
+  ProgressType,
+  Sensor,
+  SensorConfig,
+} from "@/lib/types";
+import { selectSensorReadings, sensorReadingIds } from "@/lib/sensor-readings";
+import { MetricValue } from "./MetricValue";
+import { ProgressBar } from "./ProgressBar";
+import { ProgressRing } from "./ProgressRing";
+
+interface FormattedReading {
+  value: string;
+  unit: string;
+}
+
+interface MultiValueMetricProps {
+  sensors: Sensor[];
+  config: SensorConfig;
+  progressType: ProgressType;
+  format: (value: number) => FormattedReading;
+  labelForSensor: (sensor: Sensor) => string;
+  valueFontSize: number;
+  labelFontSize: number;
+  valueFontWeight: number;
+  labelFontWeight: number;
+  boundaries?: Boundaries;
+  max?: number;
+  accepts?: (sensor: Sensor) => boolean;
+}
+
+const acceptEverySensor = () => true;
+
+/**
+ * One primary reading plus any supplemental readings selected for the same
+ * metric. The primary retains the existing gauge; supplemental values stay
+ * compact and labeled so their meaning remains clear.
+ */
+export function MultiValueMetric({
+  sensors,
+  config,
+  progressType,
+  format,
+  labelForSensor,
+  valueFontSize,
+  labelFontSize,
+  valueFontWeight,
+  labelFontWeight,
+  boundaries,
+  max = 100,
+  accepts = acceptEverySensor,
+}: MultiValueMetricProps) {
+  const readings = selectSensorReadings(sensors, config, accepts);
+  const primary = format(readings.primary?.value ?? 0);
+  const showProgress = boundaries !== undefined && progressType !== "none";
+  const Progress = progressType === "bar" ? ProgressBar : ProgressRing;
+  const primaryLabel =
+    readings.primary && sensorReadingIds(config).length > 1
+      ? labelForSensor(readings.primary)
+      : undefined;
+  const textProps = {
+    valueFontSize,
+    labelFontSize,
+    valueFontWeight,
+    labelFontWeight,
+  };
+
+  return (
+    <>
+      {showProgress ? (
+        <div className="flex items-center gap-1" title={readings.primary?.name}>
+          {primaryLabel && (
+            <span
+              style={{
+                fontSize: labelFontSize,
+                fontWeight: labelFontWeight,
+                color: "var(--overlay-text-muted)",
+                fontFamily: "Inter",
+                letterSpacing: "0.04em",
+              }}
+            >
+              {primaryLabel}
+            </span>
+          )}
+          <Progress
+            value={readings.primary?.value ?? 0}
+            max={max}
+            label={primary.value}
+            unit={primary.unit}
+            boundaries={boundaries}
+          />
+        </div>
+      ) : (
+        <MetricValue
+          label={primaryLabel}
+          value={primary.value}
+          unit={primary.unit}
+          title={readings.primary?.name}
+          {...textProps}
+        />
+      )}
+      {readings.additional.map((sensor) => {
+        const reading = format(sensor.value);
+        return (
+          <MetricValue
+            key={sensor.identifier}
+            label={labelForSensor(sensor)}
+            value={reading.value}
+            unit={reading.unit}
+            title={sensor.name}
+            {...textProps}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Gamepad2 } from "lucide-react";
 import { Checkbox } from "@/components/shadcn/checkbox";
 import { RadioGroup } from "@/components/shadcn/radio-group";
 import { Switch } from "@/components/shadcn/switch";
@@ -48,6 +49,9 @@ function GeneralSection() {
   const startMinimized = useSettingsStore((s) => s.preferences.startMinimized);
   const updatePreferences = useSettingsStore((s) => s.updatePreferences);
   const pixelShift = useSettingsStore((s) => s.settings.pixelShift);
+  const showOverlayOnlyInGames = useSettingsStore(
+    (s) => s.settings.showOverlayOnlyInGames,
+  );
   const updateSettings = useSettingsStore((s) => s.updateSettings);
   const [startWithWindows, setStartWithWindows] = React.useState(false);
   // Rapid toggles fire concurrent setAutoStart calls that can resolve out
@@ -73,9 +77,7 @@ function GeneralSection() {
 
   return (
     <SectionCard title="General">
-      {/* Three blocks, laid out by the card's own 20 gap rather than a wrapper
-          of its own: Figma 2526:6755 puts the checkboxes, the divider and the
-          Pixel Shift row 20 apart. */}
+      {/* Rows use the card's own 20px gap, matching the existing General card. */}
       <div className="flex flex-col gap-[var(--spacingS)]">
         <label className="flex cursor-pointer items-center gap-[var(--spacingXs)] text-[14px] font-medium text-foreground">
             <Checkbox
@@ -96,7 +98,7 @@ function GeneralSection() {
         </label>
       </div>
       <div className="h-px w-full shrink-0 bg-[var(--borderSubtle)]" />
-      <div className="flex items-center gap-[var(--spacingS)]">
+      <div className="flex min-h-[40px] items-center gap-[var(--spacingS)]">
         <div className="flex size-[40px] shrink-0 items-center justify-center rounded-[var(--cornerRound)] border border-[var(--borderBold)] bg-[var(--bgSurfaceRaised)]">
           {/* No optical nudge: the exported glyph carries Figma's own 1.67
               inset inside a 20 box, so centring the box centres the glyph. */}
@@ -111,9 +113,35 @@ function GeneralSection() {
           </span>
         </div>
         <Switch
+          className="relative before:absolute before:-inset-x-[2px] before:-inset-y-[10px]"
           checked={pixelShift}
           onCheckedChange={(v) => updateSettings({ pixelShift: v })}
           aria-label="Pixel Shift"
+        />
+      </div>
+      <div className="flex min-h-[40px] items-center gap-[var(--spacingS)]">
+        <div className="flex size-[40px] shrink-0 items-center justify-center rounded-[var(--cornerRound)] border border-[var(--borderBold)] bg-[var(--bgSurfaceRaised)]">
+          <Gamepad2
+            aria-hidden
+            className="size-[20px] text-[var(--textParagraph1)]"
+            strokeWidth={1.5}
+          />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-[6px]">
+          <span className="text-[14px] font-medium leading-[17px] text-[var(--textHeading)]">
+            Show only in games
+          </span>
+          <span className="text-pretty text-[14px] font-normal leading-[17px] text-[var(--textParagraph1)]">
+            Shows the overlay while a monitored game is presenting frames.
+          </span>
+        </div>
+        <Switch
+          className="relative before:absolute before:-inset-x-[2px] before:-inset-y-[10px]"
+          checked={showOverlayOnlyInGames}
+          onCheckedChange={(v) =>
+            updateSettings({ showOverlayOnlyInGames: v })
+          }
+          aria-label="Show overlay only in games"
         />
       </div>
     </SectionCard>

--- a/tauri-app/src/components/settings/stats/GpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/GpuSection.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import type { Hardware, Sensor } from "@/lib/types";
 import { SensorType } from "@/lib/types";
 import { listGpus, sensorsOnGpu } from "@/lib/gpu";
+import { sensorReadingIds, sensorReadingPatch } from "@/lib/sensor-readings";
 import { useSettingsStore } from "@/stores/settings-store";
 import {
   Select,
@@ -146,9 +147,10 @@ export function GpuSection({ sensors, hardwares }: Props) {
           {gpuTempSensors.length > 0 && (
             <SensorSelect
               label="GPU Temperature"
-              value={gpuTemp.customReadingId}
+              multiple
+              values={sensorReadingIds(gpuTemp)}
               options={gpuTempSensors}
-              onChange={(v) => updateSensor("gpuTemp", { customReadingId: v })}
+              onChange={(values) => updateSensor("gpuTemp", sensorReadingPatch(values))}
             />
           )}
           <TempRangeControl

--- a/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
+++ b/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
@@ -193,7 +193,7 @@ export function SensorPickerModal({
             "left-1/2 top-[77px] -translate-x-1/2 translate-y-0",
             "grid w-[calc(100%-48px)] max-w-[603px] gap-0 overflow-hidden",
             multiple ? "grid-rows-[auto_1fr_auto]" : "grid-rows-[auto_1fr]",
-            "rounded-[12px] bg-[var(--bgSurfaceRaised)] shadow-lg",
+            "rounded-[var(--cornerXl)] bg-[var(--bgSurfaceRaised)] shadow-lg",
             "data-[state=open]:slide-in-from-top-2 data-[state=closed]:slide-out-to-top-2",
           )}
           onOpenAutoFocus={(e) => {

--- a/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
+++ b/tauri-app/src/components/settings/stats/SensorPickerModal.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogOverlay,
   DialogPortal,
   DialogTitle,
@@ -15,8 +16,11 @@ interface Props {
   onOpenChange: (open: boolean) => void;
   title: string;
   value: string;
+  values?: string[];
+  multiple?: boolean;
   options: Sensor[];
   onChange: (v: string) => void;
+  onValuesChange?: (values: string[]) => void;
 }
 
 // Icons exported from Figma 2353:2207 (close), 2353:2211 (search),
@@ -84,13 +88,18 @@ export function SensorPickerModal({
   onOpenChange,
   title,
   value,
+  values,
+  multiple = false,
   options,
   onChange,
+  onValuesChange,
 }: Props) {
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
+  const [draftValues, setDraftValues] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const selectionKey = (values ?? []).join("\u0000");
 
   // Reset the search field whenever the modal closes. Prop-sync effect, not a
   // render cascade — the setState only fires on the open→closed transition.
@@ -108,10 +117,19 @@ export function SensorPickerModal({
   // Seed the highlight at the currently-selected row on open.
   useEffect(() => {
     if (!open) return;
-    const idx = options.findIndex((s) => s.identifier === value);
+    const selectedValue = multiple ? values?.[0] : value;
+    const idx = options.findIndex((s) => s.identifier === selectedValue);
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveIndex(idx >= 0 ? idx : 0);
-  }, [open, value, options]);
+  }, [open, value, values, options, multiple]);
+
+  useEffect(() => {
+    if (!open) return;
+    // The multi-select is transactional. Closing with the X, Escape, or Cancel
+    // leaves settings untouched; Apply commits this draft in one store update.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setDraftValues(multiple && selectionKey ? selectionKey.split("\u0000") : []);
+  }, [open, multiple, selectionKey]);
 
   // Every keystroke re-narrows the list. Snap to the top match so Enter
   // selects what the user is reading at the top.
@@ -121,7 +139,22 @@ export function SensorPickerModal({
   }, [query]);
 
   const handleSelect = (id: string) => {
+    if (multiple) {
+      setDraftValues((current) =>
+        current.includes(id)
+          ? current.filter((selectedId) => selectedId !== id)
+          : [...current, id],
+      );
+      return;
+    }
+
     onChange(id);
+    onOpenChange(false);
+  };
+
+  const applySelection = () => {
+    if (draftValues.length === 0) return;
+    onValuesChange?.(draftValues);
     onOpenChange(false);
   };
 
@@ -152,13 +185,14 @@ export function SensorPickerModal({
         {/* Overlay sits below the 52px title bar so the bar stays interactive */}
         <DialogOverlay className="top-[52px]" />
         <DialogContent
-          aria-describedby={undefined}
+          {...(multiple ? {} : { "aria-describedby": undefined })}
           // Top-anchored layout matches the existing Figma frame (52px title
           // bar + 25px gap). max-w-[603px] caps width; mx-6 reproduces the
           // 24px gutters by sizing to viewport minus 48px.
           className={cn(
             "left-1/2 top-[77px] -translate-x-1/2 translate-y-0",
-            "grid w-[calc(100%-48px)] max-w-[603px] grid-rows-[auto_1fr] gap-0 overflow-hidden",
+            "grid w-[calc(100%-48px)] max-w-[603px] gap-0 overflow-hidden",
+            multiple ? "grid-rows-[auto_1fr_auto]" : "grid-rows-[auto_1fr]",
             "rounded-[12px] bg-[var(--bgSurfaceRaised)] shadow-lg",
             "data-[state=open]:slide-in-from-top-2 data-[state=closed]:slide-out-to-top-2",
           )}
@@ -174,8 +208,17 @@ export function SensorPickerModal({
           }}
         >
           <div className="flex flex-col gap-4 border-b border-[var(--borderSubtle)] bg-[var(--bgSurfaceRaised)] p-5">
-            <div className="flex items-center justify-between">
-              <DialogTitle>{title}</DialogTitle>
+            <div className="flex items-start justify-between gap-[var(--spacingM)]">
+              <div className="flex min-w-0 flex-col gap-[var(--spacingXxxs)]">
+                <DialogTitle className="text-balance">{title}</DialogTitle>
+                {multiple && (
+                  <DialogDescription
+                    className="text-pretty text-[13px] leading-[18px] text-[var(--textParagraph1)]"
+                  >
+                    Choose one or more readings. The first selected reading uses the gauge.
+                  </DialogDescription>
+                )}
+              </div>
               <DialogClose
                 aria-label="Close"
                 className={cn(
@@ -228,7 +271,9 @@ export function SensorPickerModal({
               </div>
             ) : (
               filtered.map((s, i) => {
-                const selected = s.identifier === value;
+                const selected = multiple
+                  ? draftValues.includes(s.identifier)
+                  : s.identifier === value;
                 const highlighted = selected || i === activeIndex;
                 return (
                   <button
@@ -236,6 +281,7 @@ export function SensorPickerModal({
                     type="button"
                     onClick={() => handleSelect(s.identifier)}
                     onMouseEnter={() => setActiveIndex(i)}
+                    aria-pressed={multiple ? selected : undefined}
                     className={cn(
                       "flex h-10 items-center justify-between gap-2 rounded-[8px] px-3 py-2 text-left",
                       "transition-[background-color,transform] duration-100 ease-out motion-reduce:transition-none",
@@ -245,8 +291,15 @@ export function SensorPickerModal({
                       highlighted && "bg-[var(--bgSurfaceSunkenSubtle)]",
                     )}
                   >
-                    <span className="truncate text-[14px] font-medium text-[var(--textHeading)]">
-                      {s.name}
+                    <span className="flex min-w-0 items-center gap-[var(--spacingXs)]">
+                      <span className="truncate text-[14px] font-medium text-[var(--textHeading)]">
+                        {s.name}
+                      </span>
+                      {multiple && draftValues[0] === s.identifier && draftValues.length > 1 && (
+                        <span className="shrink-0 rounded-[var(--cornerRound)] bg-[var(--bgSurfaceSunken)] px-[var(--spacingXs)] py-[var(--spacingXxxxs)] text-[11px] font-medium leading-[14px] text-[var(--textParagraph1)]">
+                          Gauge
+                        </span>
+                      )}
                     </span>
                     {selected && (
                       <CheckIcon className="size-5 shrink-0 text-[var(--iconBolderActive)]" />
@@ -256,6 +309,32 @@ export function SensorPickerModal({
               })
             )}
           </div>
+          {multiple && (
+            <div className="flex items-center justify-end gap-[var(--spacingXs)] border-t border-[var(--borderSubtle)] bg-[var(--bgSurfaceRaised)] p-[var(--spacingM)]">
+              <DialogClose
+                className={cn(
+                  "h-[40px] rounded-[var(--cornerRound)] px-[var(--spacingL)] text-[14px] font-medium text-[var(--textHeading)]",
+                  "bg-[var(--bgSurfaceSunken)] transition-[background-color,scale] duration-150 hover:bg-[var(--bgSurfaceSunkenSubtle)] active:scale-[0.96]",
+                  "shadow-focus-default focus-visible:outline-none motion-reduce:transition-none",
+                )}
+              >
+                Cancel
+              </DialogClose>
+              <button
+                type="button"
+                disabled={draftValues.length === 0}
+                onClick={applySelection}
+                className={cn(
+                  "h-[40px] rounded-[var(--cornerRound)] px-[var(--spacingL)] text-[14px] font-medium text-[var(--textInverse)]",
+                  "bg-[var(--bgBrand)] transition-[background-color,scale] duration-150 hover:bg-[var(--bgBrandHover)] active:scale-[0.96]",
+                  "shadow-focus-default focus-visible:outline-none motion-reduce:transition-none",
+                  "disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100",
+                )}
+              >
+                Apply {draftValues.length > 0 ? `(${draftValues.length})` : ""}
+              </button>
+            </div>
+          )}
         </DialogContent>
       </DialogPortal>
     </Dialog>

--- a/tauri-app/src/components/settings/stats/SensorSelect.tsx
+++ b/tauri-app/src/components/settings/stats/SensorSelect.tsx
@@ -3,7 +3,8 @@ import type { Sensor } from "@/lib/types";
 import { SensorPickerModal } from "./SensorPickerModal";
 import { SelectFieldButton } from "@/components/ui/SelectField";
 
-interface Props {
+interface SingleSelectProps {
+  multiple?: false;
   value: string;
   options: Sensor[];
   onChange: (v: string) => void;
@@ -11,29 +12,56 @@ interface Props {
   label: string;
 }
 
+interface MultiSelectProps {
+  multiple: true;
+  values: string[];
+  options: Sensor[];
+  onChange: (values: string[]) => void;
+  label: string;
+}
+
+type Props = SingleSelectProps | MultiSelectProps;
+
 /**
  * Sensor picker trigger pill matched 1:1 to Figma 2353:612, the same field as
  * the GPU picker, so the pill itself lives in components/ui/SelectField.
  * Clicking opens SensorPickerModal, which replaced the previous Radix Select
  * dropdown.
  */
-export function SensorSelect({ value, options, onChange, label }: Props) {
+export function SensorSelect(props: Props) {
   const [open, setOpen] = useState(false);
-  const currentName =
-    options.find((o) => o.identifier === value)?.name ?? "Select";
+  const selectedIds = props.multiple ? props.values : [props.value];
+  const primaryName = props.options.find(
+    (option) => option.identifier === selectedIds[0],
+  )?.name;
+  const currentName = primaryName
+    ? `${primaryName}${selectedIds.length > 1 ? ` +${selectedIds.length - 1}` : ""}`
+    : selectedIds.length > 1
+      ? `${selectedIds.length} selected`
+      : "Select";
 
   return (
     <>
-      <SelectFieldButton label="Sensor:" onClick={() => setOpen(true)}>
+      <SelectFieldButton
+        label={props.multiple ? "Sensors:" : "Sensor:"}
+        onClick={() => setOpen(true)}
+      >
         {currentName}
       </SelectFieldButton>
       <SensorPickerModal
         open={open}
         onOpenChange={setOpen}
-        title={`Select ${label} sensor`}
-        value={value}
-        options={options}
-        onChange={onChange}
+        title={`Select ${props.label} ${props.multiple ? "sensors" : "sensor"}`}
+        value={selectedIds[0] ?? ""}
+        values={selectedIds}
+        multiple={props.multiple}
+        options={props.options}
+        onChange={(value) => {
+          if (!props.multiple) props.onChange(value);
+        }}
+        onValuesChange={(values) => {
+          if (props.multiple) props.onChange(values);
+        }}
       />
     </>
   );

--- a/tauri-app/src/lib/game-visibility.test.ts
+++ b/tauri-app/src/lib/game-visibility.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isGamePresenting } from "./game-visibility";
+import { SensorType, type HardwareMonitorData, type Sensor } from "./types";
+
+function snapshot(...sensors: Sensor[]): HardwareMonitorData {
+  return { hardwares: [], sensors, lastPollTime: 0 };
+}
+
+function reading(identifier: string, value: number): Sensor {
+  return {
+    name: "Presented Frames",
+    identifier,
+    hardwareIdentifier: "/presentmon",
+    sensorType: SensorType.Load,
+    value,
+  };
+}
+
+describe("isGamePresenting", () => {
+  it("detects positive PresentMon presented frames", () => {
+    expect(isGamePresenting(snapshot(reading("/presentmon/presented", 144)))).toBe(true);
+  });
+
+  it.each([0, -1, Number.NaN])("treats a non-playing value of %s as inactive", (value) => {
+    expect(isGamePresenting(snapshot(reading("/presentmon/presented", value)))).toBe(false);
+  });
+
+  it("ignores unrelated positive load sensors", () => {
+    expect(isGamePresenting(snapshot(reading("/cpu/0/load/0", 80)))).toBe(false);
+  });
+
+  it("treats a missing snapshot as inactive", () => {
+    expect(isGamePresenting(null)).toBe(false);
+  });
+});

--- a/tauri-app/src/lib/game-visibility.ts
+++ b/tauri-app/src/lib/game-visibility.ts
@@ -1,0 +1,16 @@
+import type { HardwareMonitorData } from "./types";
+
+const PRESENTED_FRAMES_SENSOR_ID = "/presentmon/presented";
+
+/**
+ * PresentMon reports frames only for the monitored foreground application.
+ * Its sensor drops to zero after the existing stale-frame timeout, which makes
+ * it the live game signal without another process scan or polling loop.
+ */
+export function isGamePresenting(data: HardwareMonitorData | null): boolean {
+  const presented = data?.sensors.find(
+    (sensor) => sensor.identifier.toLowerCase() === PRESENTED_FRAMES_SENSOR_ID,
+  );
+
+  return presented !== undefined && Number.isFinite(presented.value) && presented.value > 0;
+}

--- a/tauri-app/src/lib/sensor-readings.test.ts
+++ b/tauri-app/src/lib/sensor-readings.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { SensorType, type Sensor } from "./types";
+import {
+  selectSensorReadings,
+  sensorReadingIds,
+  sensorReadingPatch,
+} from "./sensor-readings";
+
+function reading(identifier: string, hardwareIdentifier = "/gpu-nvidia/0"): Sensor {
+  return {
+    name: identifier.endsWith("/1") ? "GPU Hot Spot" : "GPU Core",
+    identifier,
+    hardwareIdentifier,
+    sensorType: SensorType.Temperature,
+    value: 60,
+  };
+}
+
+describe("sensorReadingIds", () => {
+  it("keeps the primary reading first and removes blanks and duplicates", () => {
+    expect(
+      sensorReadingIds({
+        customReadingId: "/temperature/0",
+        additionalReadingIds: ["", "/temperature/1", "/temperature/0"],
+      }),
+    ).toEqual(["/temperature/0", "/temperature/1"]);
+  });
+
+  it("accepts a settings object from an older build with no additional IDs", () => {
+    expect(
+      sensorReadingIds({
+        customReadingId: "/temperature/0",
+        additionalReadingIds: undefined as unknown as string[],
+      }),
+    ).toEqual(["/temperature/0"]);
+  });
+});
+
+describe("sensorReadingPatch", () => {
+  it("promotes the first selected reading and stores the rest as supplemental", () => {
+    expect(sensorReadingPatch(["/temperature/1", "/temperature/0"])).toEqual({
+      customReadingId: "/temperature/1",
+      additionalReadingIds: ["/temperature/0"],
+    });
+  });
+});
+
+describe("selectSensorReadings", () => {
+  const core = reading("/gpu-nvidia/0/temperature/0");
+  const hotSpot = reading("/gpu-nvidia/0/temperature/1");
+  const otherGpu = reading("/gpu-intel/0/temperature/0", "/gpu-intel/0");
+
+  it("resolves multiple readings in configured order", () => {
+    expect(
+      selectSensorReadings([hotSpot, core], {
+        customReadingId: core.identifier,
+        additionalReadingIds: [hotSpot.identifier],
+      }),
+    ).toEqual({ primary: core, additional: [hotSpot] });
+  });
+
+  it("omits a temporarily unavailable reading without discarding other values", () => {
+    expect(
+      selectSensorReadings([core], {
+        customReadingId: core.identifier,
+        additionalReadingIds: [hotSpot.identifier],
+      }),
+    ).toEqual({ primary: core, additional: [] });
+  });
+
+  it("promotes a live supplemental reading while the configured primary is unavailable", () => {
+    expect(
+      selectSensorReadings([hotSpot], {
+        customReadingId: core.identifier,
+        additionalReadingIds: [hotSpot.identifier],
+      }),
+    ).toEqual({ primary: hotSpot, additional: [] });
+  });
+
+  it("can constrain every reading to the selected source", () => {
+    expect(
+      selectSensorReadings(
+        [core, otherGpu],
+        {
+          customReadingId: core.identifier,
+          additionalReadingIds: [otherGpu.identifier],
+        },
+        (sensor) => sensor.hardwareIdentifier === "/gpu-nvidia/0",
+      ),
+    ).toEqual({ primary: core, additional: [] });
+  });
+});

--- a/tauri-app/src/lib/sensor-readings.ts
+++ b/tauri-app/src/lib/sensor-readings.ts
@@ -1,0 +1,65 @@
+import type { Sensor, SensorConfig } from "./types";
+
+type ReadingSelection = Pick<
+  SensorConfig,
+  "customReadingId" | "additionalReadingIds"
+>;
+
+/**
+ * Ordered, unique sensor identifiers for one metric. The first identifier is
+ * the primary reading and every remaining identifier is supplemental.
+ */
+export function sensorReadingIds(config: ReadingSelection): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+
+  for (const id of [config.customReadingId, ...(config.additionalReadingIds ?? [])]) {
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+
+  return ids;
+}
+
+/** Convert an ordered picker result back to the backward-compatible shape. */
+export function sensorReadingPatch(ids: readonly string[]): ReadingSelection {
+  const normalized = sensorReadingIds({
+    customReadingId: ids[0] ?? "",
+    additionalReadingIds: ids.slice(1),
+  });
+
+  return {
+    customReadingId: normalized[0] ?? "",
+    additionalReadingIds: normalized.slice(1),
+  };
+}
+
+export interface SelectedSensorReadings {
+  primary: Sensor | undefined;
+  additional: Sensor[];
+}
+
+/**
+ * Resolve configured identifiers against one sensor snapshot while preserving
+ * selection order. Missing readings are omitted without changing the saved
+ * selection, because GPU sensors can activate a few polls after startup.
+ */
+export function selectSensorReadings(
+  sensors: Sensor[],
+  config: ReadingSelection,
+  accepts: (sensor: Sensor) => boolean = () => true,
+): SelectedSensorReadings {
+  const byId = new Map(sensors.map((sensor) => [sensor.identifier, sensor]));
+  const available = sensorReadingIds(config)
+    .map((id) => byId.get(id))
+    .filter((sensor): sensor is Sensor => sensor !== undefined && accepts(sensor));
+
+  return {
+    // If the configured primary is late to activate, promote the next live
+    // reading for this render only. The saved order remains untouched, so the
+    // intended primary resumes automatically when it becomes available.
+    primary: available[0],
+    additional: available.slice(1),
+  };
+}

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -47,7 +47,13 @@ export interface Boundaries {
 
 export interface SensorConfig {
   isEnabled: boolean;
+  /**
+   * Primary reading for this metric. Kept as a scalar for compatibility with
+   * settings written before metrics could display more than one reading.
+   */
   customReadingId: string;
+  /** Ordered readings rendered after the primary reading. */
+  additionalReadingIds: string[];
 }
 
 export interface GraphSensorConfig extends SensorConfig {
@@ -211,18 +217,18 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   pixelShift: false,
   selectedGpuId: "",
   sensors: {
-    framerate: { isEnabled: true, customReadingId: "", targetAppName: "" },
-    frametime: { isEnabled: true, customReadingId: "" },
-    cpuTemp: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    cpuUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    cpuConsumption: { isEnabled: true, customReadingId: "" },
-    gpuTemp: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    gpuUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    vramUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    gpuConsumption: { isEnabled: true, customReadingId: "" },
-    totalVramUsed: { isEnabled: true, customReadingId: "" },
-    ramUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
-    upRate: { isEnabled: true, customReadingId: "" },
-    downRate: { isEnabled: true, customReadingId: "" },
+    framerate: { isEnabled: true, customReadingId: "", additionalReadingIds: [], targetAppName: "" },
+    frametime: { isEnabled: true, customReadingId: "", additionalReadingIds: [] },
+    cpuTemp: { isEnabled: true, customReadingId: "", additionalReadingIds: [], boundaries: { low: 60, medium: 80, high: 90 } },
+    cpuUsage: { isEnabled: true, customReadingId: "", additionalReadingIds: [], boundaries: { low: 60, medium: 80, high: 90 } },
+    cpuConsumption: { isEnabled: true, customReadingId: "", additionalReadingIds: [] },
+    gpuTemp: { isEnabled: true, customReadingId: "", additionalReadingIds: [], boundaries: { low: 60, medium: 80, high: 90 } },
+    gpuUsage: { isEnabled: true, customReadingId: "", additionalReadingIds: [], boundaries: { low: 60, medium: 80, high: 90 } },
+    vramUsage: { isEnabled: true, customReadingId: "", additionalReadingIds: [], boundaries: { low: 60, medium: 80, high: 90 } },
+    gpuConsumption: { isEnabled: true, customReadingId: "", additionalReadingIds: [] },
+    totalVramUsed: { isEnabled: true, customReadingId: "", additionalReadingIds: [] },
+    ramUsage: { isEnabled: true, customReadingId: "", additionalReadingIds: [], boundaries: { low: 60, medium: 80, high: 90 } },
+    upRate: { isEnabled: true, customReadingId: "", additionalReadingIds: [] },
+    downRate: { isEnabled: true, customReadingId: "", additionalReadingIds: [] },
   },
 };

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -112,6 +112,8 @@ export interface OverlaySettings {
   labelFontWeight: number;
   pollingRate: number;
   isLoggingEnabled: boolean;
+  /** Hide the overlay unless PresentMon sees the monitored game presenting. */
+  showOverlayOnlyInGames: boolean;
   // When true, the overlay is nudged a few pixels on a slow cycle to spread
   // OLED wear (burn-in mitigation). See pixel-shift logic in OverlayApp.
   pixelShift: boolean;
@@ -214,6 +216,7 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   labelFontWeight: 500,
   pollingRate: 500,
   isLoggingEnabled: false,
+  showOverlayOnlyInGames: false,
   pixelShift: false,
   selectedGpuId: "",
   sensors: {

--- a/tauri-app/src/stores/settings-store.gpu.test.ts
+++ b/tauri-app/src/stores/settings-store.gpu.test.ts
@@ -21,6 +21,7 @@ vi.mock("@/lib/tauri", () => ({
 }));
 
 const { useSettingsStore } = await import("./settings-store");
+const tauri = await import("@/lib/tauri");
 
 /**
  * The machine from issue #48. Both GPUs expose a temperature called
@@ -56,6 +57,7 @@ const DATA: HardwareMonitorData = {
     sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/0", "GPU Core", SensorType.Load, 40),
     sensor("/gpu-nvidia/0", "/gpu-nvidia/0/load/3", "GPU Memory", SensorType.Load, 30),
     sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/0", "GPU Core", SensorType.Temperature, 60),
+    sensor("/gpu-nvidia/0", "/gpu-nvidia/0/temperature/1", "GPU Hot Spot", SensorType.Temperature, 72),
     sensor("/gpu-nvidia/0", "/gpu-nvidia/0/power/0", "GPU Package", SensorType.Power, 70),
     sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/1", "GPU Memory Used", SensorType.SmallData, 2048),
     sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/2", "GPU Memory Total", SensorType.SmallData, 4096),
@@ -82,6 +84,7 @@ function gpuRows() {
     selectedGpuId,
     gpuUsage: sensors.gpuUsage.customReadingId,
     gpuTemp: sensors.gpuTemp.customReadingId,
+    gpuTempAdditional: sensors.gpuTemp.additionalReadingIds,
     gpuConsumption: sensors.gpuConsumption.customReadingId,
     vramUsage: sensors.vramUsage.customReadingId,
     totalVramUsed: sensors.totalVramUsed.customReadingId,
@@ -91,13 +94,44 @@ function gpuRows() {
 /** Every GPU row names a sensor on `gpuId`, or names nothing at all. */
 function allRowsOn(gpuId: string) {
   const rows = gpuRows();
-  return [rows.gpuUsage, rows.gpuTemp, rows.gpuConsumption, rows.vramUsage, rows.totalVramUsed]
+  return [
+    rows.gpuUsage,
+    rows.gpuTemp,
+    ...rows.gpuTempAdditional,
+    rows.gpuConsumption,
+    rows.vramUsage,
+    rows.totalVramUsed,
+  ]
     .filter(Boolean)
     .every((id) => id.startsWith(gpuId));
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   seed({});
+});
+
+describe("loading settings from before multi-value readings", () => {
+  it("hydrates an empty supplemental list without changing the primary reading", async () => {
+    const oldGpuTemp = {
+      isEnabled: true,
+      customReadingId: "/gpu-nvidia/0/temperature/0",
+      boundaries: { low: 60, medium: 80, high: 90 },
+    };
+    vi.mocked(tauri.getSettings).mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      sensors: {
+        ...DEFAULT_SETTINGS.sensors,
+        gpuTemp: oldGpuTemp as OverlaySettings["sensors"]["gpuTemp"],
+      },
+    });
+
+    await useSettingsStore.getState().loadSettings();
+
+    const config = useSettingsStore.getState().settings.sensors.gpuTemp;
+    expect(config.customReadingId).toBe("/gpu-nvidia/0/temperature/0");
+    expect(config.additionalReadingIds).toEqual([]);
+  });
 });
 
 describe("choosing a GPU on a two-GPU machine", () => {
@@ -116,6 +150,13 @@ describe("choosing a GPU on a two-GPU machine", () => {
     expect(rows.gpuTemp).toBe("/gpu-nvidia/0/temperature/0");
     expect(rows.gpuConsumption).toBe("/gpu-nvidia/0/power/0");
     expect(rows.totalVramUsed).toBe("/gpu-nvidia/0/smalldata/1");
+    expect(rows.gpuTempAdditional).toEqual([]);
+  });
+
+  it("keeps extra values opt-in so existing overlays do not grow on upgrade", () => {
+    useSettingsStore.getState().setSensorData(DATA);
+
+    expect(gpuRows().gpuTempAdditional).toEqual([]);
   });
 });
 
@@ -195,6 +236,25 @@ describe("upgrading an existing install", () => {
 
     expect(gpuRows().gpuTemp).toBe(late);
   });
+
+  it("keeps supplemental readings that have not activated yet", () => {
+    const late = "/gpu-nvidia/0/temperature/9";
+    seed({
+      selectedGpuId: "/gpu-nvidia/0",
+      sensors: {
+        ...DEFAULT_SETTINGS.sensors,
+        gpuTemp: {
+          ...DEFAULT_SETTINGS.sensors.gpuTemp,
+          customReadingId: "/gpu-nvidia/0/temperature/0",
+          additionalReadingIds: [late],
+        },
+      },
+    });
+
+    useSettingsStore.getState().setSensorData(DATA);
+
+    expect(gpuRows().gpuTempAdditional).toEqual([late]);
+  });
 });
 
 describe("selectGpu", () => {
@@ -209,6 +269,26 @@ describe("selectGpu", () => {
     expect(rows.gpuUsage).toBe("/gpu-intel/0/load/0");
     expect(rows.gpuTemp).toBe("/gpu-intel/0/temperature/0");
     expect(rows.gpuConsumption).toBe("/gpu-intel/0/power/0");
+    expect(allRowsOn("/gpu-intel/0")).toBe(true);
+  });
+
+  it("clears supplemental readings tied to the previous GPU", () => {
+    seed({
+      selectedGpuId: "/gpu-nvidia/0",
+      sensors: {
+        ...DEFAULT_SETTINGS.sensors,
+        gpuTemp: {
+          ...DEFAULT_SETTINGS.sensors.gpuTemp,
+          customReadingId: "/gpu-nvidia/0/temperature/0",
+          additionalReadingIds: ["/gpu-nvidia/0/temperature/1"],
+        },
+      },
+    });
+    useSettingsStore.getState().setSensorData(DATA);
+
+    useSettingsStore.getState().selectGpu("/gpu-intel/0");
+
+    expect(gpuRows().gpuTempAdditional).toEqual([]);
     expect(allRowsOn("/gpu-intel/0")).toBe(true);
   });
 

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -22,7 +22,16 @@ import {
   shouldRepickSensor,
   type GpuSilence,
 } from "@/lib/gpu";
+import { sensorReadingIds, sensorReadingPatch } from "@/lib/sensor-readings";
 import * as tauri from "@/lib/tauri";
+
+const GPU_SENSOR_KEYS = [
+  "gpuUsage",
+  "gpuTemp",
+  "gpuConsumption",
+  "vramUsage",
+  "totalVramUsed",
+] as const satisfies readonly SensorKey[];
 
 /**
  * Best sensor of a given type out of an already-narrowed list, by keyword
@@ -71,6 +80,7 @@ function autoSelectSensors(
   settings: OverlaySettings
 ): AutoSelection | null {
   const { sensors, hardwares } = data;
+  const sensorsById = new Map(sensors.map((sensor) => [sensor.identifier, sensor]));
   const patch: Partial<OverlaySettings["sensors"]> = {};
   let changed = false;
 
@@ -124,12 +134,26 @@ function autoSelectSensors(
     prefer: string[]
   ) => {
     const current = settings.sensors[key];
-    if (!shouldRepickSensor(current.customReadingId, selectedGpuId, sensors)) return;
+    const id = shouldRepickSensor(current.customReadingId, selectedGpuId, sensors)
+      ? bestOf(gpuSensors, sType, prefer)
+      : current.customReadingId;
+    // A saved supplemental reading can be absent during GPU warm-up, so keep
+    // unknown identifiers. Once an identifier resolves to another GPU, remove
+    // it rather than allowing one metric to mix sources.
+    const additionalReadingIds = current.additionalReadingIds.filter((readingId) => {
+      const sensor = sensorsById.get(readingId);
+      return sensor === undefined || sensor.hardwareIdentifier === selectedGpuId;
+    });
+    const readingPatch = sensorReadingPatch([id, ...additionalReadingIds]);
+    const unchanged =
+      readingPatch.customReadingId === current.customReadingId &&
+      readingPatch.additionalReadingIds.length === current.additionalReadingIds.length &&
+      readingPatch.additionalReadingIds.every(
+        (readingId, index) => readingId === current.additionalReadingIds[index],
+      );
+    if (unchanged) return;
 
-    const id = bestOf(gpuSensors, sType, prefer);
-    if (id === current.customReadingId) return;
-
-    patch[key] = { ...current, customReadingId: id } as OverlaySettings["sensors"][K];
+    patch[key] = { ...current, ...readingPatch } as OverlaySettings["sensors"][K];
     changed = true;
   };
 
@@ -315,9 +339,15 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       const mergedSensors = { ...DEFAULT_SETTINGS.sensors };
       const savedSensors = (saved?.sensors ?? {}) as Partial<OverlaySettings["sensors"]>;
       for (const key of Object.keys(DEFAULT_SETTINGS.sensors) as (keyof OverlaySettings["sensors"])[]) {
-        mergedSensors[key] = {
+        const merged = {
           ...DEFAULT_SETTINGS.sensors[key],
           ...(savedSensors[key] ?? {}),
+        } as OverlaySettings["sensors"][typeof key];
+        // Older saves have only customReadingId. Normalizing here also removes
+        // duplicate IDs before the settings reach either window.
+        mergedSensors[key] = {
+          ...merged,
+          ...sensorReadingPatch(sensorReadingIds(merged)),
         } as OverlaySettings["sensors"][typeof key];
       }
       const settings: OverlaySettings = saved
@@ -395,7 +425,20 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   selectGpu: (gpuId) => {
     const state = get();
-    const withGpu = { ...state.settings, selectedGpuId: gpuId };
+    let sensorsForGpu = state.settings.sensors;
+    if (gpuId !== state.settings.selectedGpuId) {
+      sensorsForGpu = { ...state.settings.sensors };
+      for (const key of GPU_SENSOR_KEYS) {
+        sensorsForGpu[key] = {
+          ...sensorsForGpu[key],
+          // Supplemental values are tied to the old source. The auto-selector
+          // below chooses a new primary, and the user can add readings exposed
+          // by the newly selected GPU without stale cross-GPU IDs lingering.
+          additionalReadingIds: [],
+        } as OverlaySettings["sensors"][typeof key];
+      }
+    }
+    const withGpu = { ...state.settings, selectedGpuId: gpuId, sensors: sensorsForGpu };
 
     // Re-point every GPU row in the same tick rather than waiting for the
     // next poll to do it. Same code path either way, so the two cannot drift;

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -23,6 +23,7 @@ import {
   type GpuSilence,
 } from "@/lib/gpu";
 import { sensorReadingIds, sensorReadingPatch } from "@/lib/sensor-readings";
+import { isGamePresenting } from "@/lib/game-visibility";
 import * as tauri from "@/lib/tauri";
 
 const GPU_SENSOR_KEYS = [
@@ -259,6 +260,7 @@ interface SettingsStore {
   pipeStatus: PipeStatus;
   sidecarStatus: SidecarStatus;
   overlayVisible: boolean;
+  gameActive: boolean;
   appVersion: string;
   /**
    * How long the selected GPU has been reporting nothing. Read `.settled`;
@@ -327,6 +329,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   sidecarStatus: { exits: 0, spawnError: null },
   gpuSilence: NO_GPU_SILENCE,
   overlayVisible: false,
+  gameActive: false,
   // Empty until loadAppVersion() resolves the real version — better a brief
   // blank than a misleading hardcoded number.
   appVersion: "",
@@ -412,6 +415,14 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       if (settings.fontSizeValue > 24) settings.fontSizeValue = 24;
       if (settings.fontSizeLabel > 18) settings.fontSizeLabel = 18;
       set({ settings });
+      // The sensor listener can win the startup race and show the overlay
+      // before persisted settings finish loading. Reapply the saved policy so
+      // a desktop session never remains visible until the next game transition.
+      if (settings.showOverlayOnlyInGames) {
+        const visible = get().gameActive;
+        set({ overlayVisible: visible });
+        tauri.setOverlayVisible(visible);
+      }
       // Push the persisted target-app to the C# poller so it starts in sync.
       // Empty string means Auto (foreground-window detection on the C# side).
       tauri.selectPresentMonApp(settings.sensors.framerate.targetAppName || "Auto");
@@ -473,9 +484,16 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     });
   },
   updateSettings: (patch) => {
-    const newSettings = { ...get().settings, ...patch };
+    const state = get();
+    const newSettings = { ...state.settings, ...patch };
     set({ settings: newSettings });
     debouncedSave(newSettings);
+
+    if (patch.showOverlayOnlyInGames !== undefined) {
+      const visible = !patch.showOverlayOnlyInGames || state.gameActive;
+      set({ overlayVisible: visible });
+      tauri.setOverlayVisible(visible);
+    }
 
     if (patch.opacity !== undefined) {
       tauri.setOverlayOpacity(patch.opacity);
@@ -549,7 +567,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   setSensorData: (data) => {
     const state = get();
     const wasNull = state.sensorData === null;
-    set({ sensorData: data });
+    const gameActive = isGamePresenting(data);
+    set({ sensorData: data, gameActive });
     // Fill in any sensor still unset, and re-point the GPU rows if they name
     // a sensor on a GPU other than the selected one.
     const selection = autoSelectSensors(data, state.settings);
@@ -575,8 +594,18 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         Date.now(),
       ),
     });
-    // Auto-show overlay on first data arrival
-    if (wasNull && !state.overlayVisible) {
+    // Game-only visibility changes only on an actual game-state transition.
+    // That lets the existing hotkey hide the overlay for the rest of the
+    // current session instead of the next 500ms sensor poll undoing the hide.
+    if (
+      state.settings.showOverlayOnlyInGames &&
+      gameActive !== state.gameActive &&
+      gameActive !== state.overlayVisible
+    ) {
+      set({ overlayVisible: gameActive });
+      tauri.setOverlayVisible(gameActive);
+    } else if (wasNull && !state.settings.showOverlayOnlyInGames && !state.overlayVisible) {
+      // Preserve the original behavior when the opt-in policy is off.
       set({ overlayVisible: true });
       tauri.setOverlayVisible(true);
     }
@@ -604,8 +633,18 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     }
   },
   setPipeStatus: (status) => {
-    const wasConnected = get().pipeStatus.connected;
+    const state = get();
+    const wasConnected = state.pipeStatus.connected;
     set({ pipeStatus: status });
+    // A disconnected sidecar cannot prove a game is active. Reset the edge so
+    // the first live reading after reconnect can show the overlay again.
+    if (!status.connected) {
+      set({ gameActive: false });
+      if (state.settings.showOverlayOnlyInGames && state.overlayVisible) {
+        set({ overlayVisible: false });
+        tauri.setOverlayVisible(false);
+      }
+    }
     // After a (re)connect, resync the target-app filter — the C# poller
     // restarts with `_currentSelectedApp = NONE`, so without this it would
     // count every app's frames again until the next dropdown change.
@@ -616,14 +655,22 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   },
 
   toggleOverlay: () => {
-    const visible = !get().overlayVisible;
+    const state = get();
+    const visible =
+      !state.overlayVisible &&
+      (!state.settings.showOverlayOnlyInGames || state.gameActive);
+    if (visible === state.overlayVisible) return;
     set({ overlayVisible: visible });
     tauri.setOverlayVisible(visible);
   },
 
   setOverlayVisible: (visible) => {
-    set({ overlayVisible: visible });
-    tauri.setOverlayVisible(visible);
+    const state = get();
+    const allowed =
+      visible && (!state.settings.showOverlayOnlyInGames || state.gameActive);
+    if (allowed === state.overlayVisible) return;
+    set({ overlayVisible: allowed });
+    tauri.setOverlayVisible(allowed);
   },
 
   loadAppVersion: async () => {

--- a/tauri-app/src/stores/settings-store.visibility.test.ts
+++ b/tauri-app/src/stores/settings-store.visibility.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HardwareMonitorData, Sensor } from "@/lib/types";
+import { DEFAULT_SETTINGS, SensorType } from "@/lib/types";
+
+vi.mock("@/lib/tauri", () => ({
+  isBrowser: true,
+  clearSettings: vi.fn(),
+  getAppVersion: vi.fn(),
+  getPreferences: vi.fn(),
+  getSettings: vi.fn(),
+  getSidecarStatus: vi.fn(),
+  savePreferences: vi.fn(),
+  saveSettings: vi.fn(),
+  selectPresentMonApp: vi.fn(),
+  setOverlayOpacity: vi.fn(),
+  setOverlayVisible: vi.fn(),
+  setPollingRate: vi.fn(),
+}));
+
+const { useSettingsStore } = await import("./settings-store");
+const tauri = await import("@/lib/tauri");
+
+function presented(value: number): Sensor {
+  return {
+    name: "Presented Frames",
+    identifier: "/presentmon/presented",
+    hardwareIdentifier: "/presentmon",
+    sensorType: SensorType.Load,
+    value,
+  };
+}
+
+function snapshot(fps: number): HardwareMonitorData {
+  return { hardwares: [], sensors: [presented(fps)], lastPollTime: 0 };
+}
+
+function reset(showOnlyInGames = false) {
+  useSettingsStore.setState({
+    settings: {
+      ...DEFAULT_SETTINGS,
+      showOverlayOnlyInGames: showOnlyInGames,
+    },
+    sensorData: null,
+    gameActive: false,
+    overlayVisible: false,
+    pipeStatus: { connected: false },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  reset();
+});
+
+describe("game-only overlay visibility", () => {
+  it("preserves the original first-reading auto-show when the option is off", () => {
+    useSettingsStore.getState().setSensorData(snapshot(0));
+
+    expect(useSettingsStore.getState().overlayVisible).toBe(true);
+    expect(tauri.setOverlayVisible).toHaveBeenCalledOnce();
+    expect(tauri.setOverlayVisible).toHaveBeenLastCalledWith(true);
+  });
+
+  it("shows and hides only when PresentMon game activity changes", () => {
+    reset(true);
+    const store = useSettingsStore.getState();
+
+    store.setSensorData(snapshot(0));
+    expect(tauri.setOverlayVisible).not.toHaveBeenCalled();
+
+    store.setSensorData(snapshot(144));
+    store.setSensorData(snapshot(120));
+    store.setSensorData(snapshot(0));
+
+    expect(vi.mocked(tauri.setOverlayVisible).mock.calls).toEqual([[true], [false]]);
+    expect(useSettingsStore.getState().overlayVisible).toBe(false);
+  });
+
+  it("hides when monitoring disconnects and can show after reconnect data", () => {
+    reset(true);
+    useSettingsStore.setState({ pipeStatus: { connected: true } });
+    useSettingsStore.getState().setSensorData(snapshot(144));
+    vi.mocked(tauri.setOverlayVisible).mockClear();
+
+    useSettingsStore.getState().setPipeStatus({ connected: false });
+    expect(useSettingsStore.getState().gameActive).toBe(false);
+    expect(tauri.setOverlayVisible).toHaveBeenLastCalledWith(false);
+
+    useSettingsStore.getState().setSensorData(snapshot(144));
+    expect(tauri.setOverlayVisible).toHaveBeenLastCalledWith(true);
+  });
+
+  it("does not let the hotkey show the overlay outside a game", () => {
+    reset(true);
+
+    useSettingsStore.getState().toggleOverlay();
+
+    expect(useSettingsStore.getState().overlayVisible).toBe(false);
+    expect(tauri.setOverlayVisible).not.toHaveBeenCalled();
+  });
+
+  it("keeps a manual in-game hide until game activity changes", () => {
+    reset(true);
+    useSettingsStore.getState().setSensorData(snapshot(144));
+    useSettingsStore.getState().toggleOverlay();
+    vi.mocked(tauri.setOverlayVisible).mockClear();
+
+    useSettingsStore.getState().setSensorData(snapshot(120));
+
+    expect(useSettingsStore.getState().overlayVisible).toBe(false);
+    expect(tauri.setOverlayVisible).not.toHaveBeenCalled();
+  });
+
+  it("applies setting changes immediately", () => {
+    useSettingsStore.setState({ overlayVisible: true, gameActive: false });
+
+    useSettingsStore.getState().updateSettings({ showOverlayOnlyInGames: true });
+    expect(tauri.setOverlayVisible).toHaveBeenLastCalledWith(false);
+
+    useSettingsStore.getState().updateSettings({ showOverlayOnlyInGames: false });
+    expect(tauri.setOverlayVisible).toHaveBeenLastCalledWith(true);
+  });
+
+  it("hydrates older settings with the option disabled", async () => {
+    const oldSettings = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
+    delete oldSettings.showOverlayOnlyInGames;
+    vi.mocked(tauri.getSettings).mockResolvedValue(
+      oldSettings as typeof DEFAULT_SETTINGS,
+    );
+
+    await useSettingsStore.getState().loadSettings();
+
+    expect(useSettingsStore.getState().settings.showOverlayOnlyInGames).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for displaying multiple GPU temperature readings and introduces an optional game-only overlay visibility mode.

Closes #59 

## Changes

- Add backward-compatible supplemental reading IDs to sensor settings
- Add a transactional multi-select sensor picker for GPU temperatures
- Render the primary GPU temperature with the existing gauge
- Render supplemental temperatures as compact labeled values
- Preserve unavailable sensor selections until they become active
- Clear supplemental readings when switching GPUs
- Add the "Show only in games" General setting
- Detect active games through the existing PresentMon presented-frame sensor
- Hide the overlay when the game stops or monitoring disconnects
- Prevent the visibility hotkey from showing the overlay outside a game
- Add Rust serialization and named-pipe regression coverage

## Testing

- 134 unit tests passed
- ESLint passed
- TypeScript type-check passed
- Production Vite build passed
- Verified the settings UI in light and dark themes
- Verified switch interaction and accessibility state
- Confirmed no browser console warnings or errors