### PR TITLE
Add 1% and 0.1% low framerate readings

### DIFF
--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -664,6 +664,8 @@ public class MonitorPoller(
         sensorList.Add(MapSensor(_presentMonPoller.Displayed));
         sensorList.Add(MapSensor(_presentMonPoller.Presented));
         sensorList.Add(MapSensor(_presentMonPoller.Frametime));
+        sensorList.Add(MapSensor(_presentMonPoller.OnePercentLow));
+        sensorList.Add(MapSensor(_presentMonPoller.ZeroPointOnePercentLow));
 
         sharedMemoryData.Sensors = sensorList;
     }

--- a/HardwareMonitor/HardwareMonitor/PresentMon/FrameLows.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/FrameLows.cs
@@ -1,0 +1,158 @@
+namespace HardwareMonitor.PresentMon;
+
+/// <summary>
+/// Percentile-low framerates ("1% low", "0.1% low") for a play session.
+///
+/// There is no single industry definition and the three in circulation
+/// disagree by a wide margin on the same gameplay:
+///
+///   1. Frame-count percentile (P1): the single frametime sitting at the 1%
+///      position once sorted. Intel PresentMon and CapFrameX's "1% percentile"
+///      report this. It ignores everything worse than that one frame, so a
+///      handful of severe hitches move it not at all.
+///   2. Time-integral threshold: sort slowest-first, accumulate frametimes
+///      until the sum reaches 1% of total session time, report the frametime
+///      at that crossing point. <b>This is what RTSS / MSI Afterburner
+///      reports</b>, and it is a percentile whose N is derived from time
+///      rather than fixed at the 99th.
+///   3. Average of the tail: average the frametimes of the slowest 1% of
+///      frames. GamersNexus popularised this; CapFrameX ships it separately
+///      as "1% low average".
+///
+/// This implements (2), to agree with the overlay most Cleanmeter users
+/// already have running. The practical difference is large: on 999 frames at
+/// 8ms plus a single 200ms hitch, (3) reads 36.8 fps while (2) reads 5.0 fps,
+/// because one catastrophic frame alone covers the whole 1% time budget.
+///
+/// Held as a histogram of frametimes rather than a list of them. The window is
+/// the whole session (RTSS's "unlimited" default), and a four-hour session at
+/// 300fps is 4.3M frames, which is not something to keep in a list and re-sort
+/// once a second. Bucketed counts make both memory and compute constant no
+/// matter how long the session runs, and because every frame in a bucket
+/// shares one quantised frametime, walking the histogram from the slow end
+/// gives exactly the answer walking the sorted frames would.
+///
+/// RTSS bounds the same problem by keeping only the 1024 slowest frames, which
+/// saturates in a long session once those 1024 no longer cover 1% of elapsed
+/// time. The histogram has no such ceiling, so it tracks the definition RTSS
+/// documents rather than reproducing that truncation.
+///
+/// <b>Not thread-safe. Callers must serialize access.</b> Every member mutates
+/// or reads unsynchronised state, and the two callers live on different
+/// threads: <c>Add</c> runs on PresentMon's output callback thread, while
+/// <c>Compute</c>, <c>Clear</c> and <c>FrameCount</c> run on the diagnostics
+/// loop. Both hold <c>PresentMonPoller._stateLock</c>, which is the only
+/// reason this is correct — an unlocked <c>Add</c> added later would tear
+/// <c>_totalMs</c>, <c>_frameCount</c> and <c>_highestBucket</c> against each
+/// other with nothing local to signal it.
+/// </summary>
+public sealed class FrameLows
+{
+    /// Histogram resolution. 0.01ms keeps the reported figure within about
+    /// 0.1% of the exact answer even up at 250fps, where a frametime is only
+    /// 4ms and coarse buckets would start to show.
+    public const double BucketMs = 0.01;
+
+    /// Frames at or beyond this land in the top bucket. A frame taking a full
+    /// second is already a catastrophic hitch, and clamping only changes the
+    /// reported number in the case where the answer itself is 1 fps.
+    public const double MaxFrametimeMs = 1000.0;
+
+    private const int BucketCount = (int)(MaxFrametimeMs / BucketMs) + 1;
+
+    private readonly uint[] _buckets = new uint[BucketCount];
+    private double _totalMs;
+    private long _frameCount;
+    // Highest populated bucket, so the walk starts at the slowest frame seen
+    // instead of scanning 100k empty buckets from the top every time.
+    private int _highestBucket = -1;
+
+    public long FrameCount => _frameCount;
+
+    /// Total frame time recorded, quantised the same way the buckets are so
+    /// the budget and the walk cannot disagree by a rounding error.
+    public double TotalMs => _totalMs;
+
+    /// <summary>Record one frame interval, in milliseconds.</summary>
+    public void Add(float intervalMs)
+    {
+        // Infinity has to be rejected explicitly, not just by the `> 0` test
+        // it passes: float.TryParse yields PositiveInfinity for "Infinity" or
+        // an overflowing literal like "1e40", Math.Round preserves it, and
+        // .NET 8 leaves the unchecked (int) conversion of a non-finite double
+        // UNSPECIFIED — in practice int.MinValue, which slips past the
+        // `>= BucketCount` clamp below and indexes the array negatively.
+        // One malformed PresentMon row would then throw
+        // IndexOutOfRangeException on the per-frame path. IsFinite also
+        // covers NaN, so this subsumes the NaN case.
+        if (!float.IsFinite(intervalMs) || intervalMs <= 0) return;
+
+        // Clamp in the double domain BEFORE the cast, not after. Any interval
+        // above ~2.1e7 ms makes `intervalMs / BucketMs` exceed int.MaxValue,
+        // and .NET 8 leaves that unchecked conversion unspecified — it lands
+        // on int.MinValue, which is not `>= BucketCount`, so a post-cast clamp
+        // never sees it and the negative index throws. float.MaxValue arrives
+        // here from a garbage CSV field like "1e30", which parses as perfectly
+        // finite.
+        var clampedMs = intervalMs >= MaxFrametimeMs ? MaxFrametimeMs : intervalMs;
+        var index = (int)Math.Round(clampedMs / BucketMs);
+        if (index >= BucketCount) index = BucketCount - 1;
+
+        _buckets[index]++;
+        _totalMs += index * BucketMs;
+        _frameCount++;
+        if (index > _highestBucket) _highestBucket = index;
+    }
+
+    /// <summary>Forget the session so far (app switch, or the game is gone).</summary>
+    public void Clear()
+    {
+        Array.Clear(_buckets, 0, _buckets.Length);
+        _totalMs = 0;
+        _frameCount = 0;
+        _highestBucket = -1;
+    }
+
+    /// <summary>
+    /// The percentile low, in frames per second.
+    /// </summary>
+    /// <param name="fraction">0.01 for a 1% low, 0.001 for a 0.1% low.</param>
+    /// <param name="minTotalMs">
+    /// Refuse to report until this much frame time has accumulated. RTSS has
+    /// no warm-up and reports from the first frame, but a figure derived from
+    /// half a second of play changes on every poll and reads as broken rather
+    /// than as early. Returns 0 below the threshold, the same "nothing to
+    /// show" convention the Presented/Displayed sensors use.
+    /// </param>
+    /// <returns>Frames per second, or 0 when there is not enough data yet.</returns>
+    public float Compute(double fraction, double minTotalMs)
+    {
+        if (_frameCount == 0 || _totalMs < minTotalMs) return 0f;
+        if (fraction <= 0 || fraction > 1) return 0f;
+
+        var budgetMs = _totalMs * fraction;
+        if (budgetMs <= 0) return 0f;
+
+        double accumulated = 0;
+        for (var index = _highestBucket; index >= 0; index--)
+        {
+            var count = _buckets[index];
+            if (count == 0) continue;
+
+            var frametimeMs = index * BucketMs;
+            accumulated += frametimeMs * count;
+
+            // Every frame in this bucket shares one frametime, so it makes no
+            // difference whether the budget is crossed by the bucket's first
+            // frame or its last — the answer is this bucket's frametime
+            // either way. That is what makes the histogram exact rather than
+            // an approximation of the frame-by-frame walk.
+            if (accumulated >= budgetMs)
+            {
+                return frametimeMs > 0 ? (float)(1000.0 / frametimeMs) : 0f;
+            }
+        }
+
+        return 0f;
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
@@ -19,6 +19,8 @@ public class PresentMonPoller(ILogger logger)
     public PresentMonSensor Displayed { get; private set; }
     public PresentMonSensor Presented { get; private set; }
     public PresentMonSensor Frametime { get; private set; }
+    public PresentMonSensor OnePercentLow { get; private set; }
+    public PresentMonSensor ZeroPointOnePercentLow { get; private set; }
 
     public Action OnUpdateApps;
 
@@ -98,6 +100,30 @@ public class PresentMonPoller(ILogger logger)
     private double _latestStartTimeMs;
     private long _lastRowArrivalMs;
 
+    // Percentile lows (1% / 0.1%) accumulate over the whole session rather
+    // than the 1s window above, which holds ~120 frames at 120fps and so has
+    // no meaningful "worst 1%" at all. Session-length is also what RTSS / MSI
+    // Afterburner use by default ("unlimited"), and matching the overlay most
+    // of our users already run matters more than any window we could pick:
+    // the common way someone sanity-checks this number is to run both at once.
+    //
+    // See FrameLows for why this is a histogram and not a list of frametimes,
+    // and for which of the three competing "1% low" definitions it implements.
+    private const double ONE_PERCENT = 0.01;
+    private const double ZERO_POINT_ONE_PERCENT = 0.001;
+    private const double LOWS_MIN_TOTAL_MS = 5_000;
+    // A short gap (alt-tab, a loading screen, a pause menu) must NOT wipe a
+    // session-long statistic, so this deliberately survives the FPS_STALE_MS
+    // zeroing that resets the 1s averages. It is dropped only once rows have
+    // been absent long enough that the game is plainly gone, rather than
+    // leaving a dead game's lows on screen at the desktop.
+    private const int LOWS_ABANDON_MS = 30_000;
+    private readonly FrameLows _lows = new();
+    // The app whose frames are currently in the histogram. See the reset guard
+    // in ParseData for why attribution is tracked here rather than inferred
+    // from the selection or the foreground.
+    private string _lowsApp = "";
+
     // FPS diagnostics. Counters live under _stateLock alongside the other
     // attribution state. Rollup task logs once per FPS_DIAG_WINDOW_MS so the
     // log line cadence matches what the overlay shows; raw-row dump is one-
@@ -155,6 +181,13 @@ public class PresentMonPoller(ILogger logger)
             Displayed = new PresentMonSensor(_hardware, "displayed", 0, "Displayed Frames");
             Presented = new PresentMonSensor(_hardware, "presented", 1, "Presented Frames");
             Frametime = new PresentMonSensor(_hardware, "frametime", 2, "Frametime");
+            // Spelled out rather than "1% Low": MonitorPoller.RemoveSpecialCharacters
+            // rewrites anything outside [a-zA-Z0-9_ .] to an underscore before the
+            // name goes on the wire, so "1% Low" would reach the sensor picker as
+            // "1_ Low". The overlay resolves these by identifier, but the picker
+            // shows the name.
+            OnePercentLow = new PresentMonSensor(_hardware, "onepercentlow", 3, "1 Percent Low");
+            ZeroPointOnePercentLow = new PresentMonSensor(_hardware, "zeropointonepercentlow", 4, "0.1 Percent Low");
 
             // Resolve the foreground app once, synchronously, before PresentMon
             // starts emitting rows. Without this, the first ~500ms of CSV output
@@ -454,6 +487,36 @@ public class PresentMonPoller(ILogger logger)
             _presentedSumMs += ftMs;
             UpdateFromBuffer(_presentedFrames, ref _presentedSumMs, Presented);
 
+            // The percentile lows read the same present-to-present interval as
+            // the Presented sensor (the reading the overlay defaults to), but
+            // accumulate for the session instead of a 1s window. One
+            // increment per row: no trim, no re-sort, no growth.
+            //
+            // Reset on the app whose frames are actually being counted, not on
+            // the setting or the foreground, because three separate paths can
+            // change it and only one of them is an explicit user action:
+            // SetSelectedApp (the user picks another app), a foreground change
+            // in Auto mode, and — the one that has no event at all — the
+            // fallback at the top of this method, which starts counting the
+            // foreground once a manually-picked app has been silent for
+            // SELECTED_APP_STALE_MS. Without this guard that last path blends
+            // apps into one histogram indefinitely, and since the window is
+            // the whole session it never ages out.
+            //
+            // Worst case is the fallback engaging and disengaging repeatedly,
+            // which SELECTED_APP_STALE_MS caps at one reset per 5s. That keeps
+            // the histogram under its warm-up so the overlay shows nothing,
+            // which is the right outcome when attribution is genuinely
+            // ambiguous: no reading beats a blended one.
+            if (!string.Equals(_lowsApp, rowApp, StringComparison.OrdinalIgnoreCase))
+            {
+                _lows.Clear();
+                OnePercentLow.Value = 0;
+                ZeroPointOnePercentLow.Value = 0;
+                _lowsApp = rowApp;
+            }
+            _lows.Add(ftMs);
+
             // Displayed FPS uses the display-to-display interval (column
             // 17), NOT the present-to-present interval. The presented-FPS
             // and displayed-FPS values diverge whenever the display
@@ -514,6 +577,14 @@ public class PresentMonPoller(ILogger logger)
             Presented.Value = 0;
             Displayed.Value = 0;
             Frametime.Value = 0;
+            // The lows survive an alt-tab (see LOWS_ABANDON_MS) but never a
+            // change of monitored app: the window is the whole session, so
+            // without this the old game's stutters would sit in the new
+            // game's reading for as long as the app stays open.
+            _lows.Clear();
+            _lowsApp = "";
+            OnePercentLow.Value = 0;
+            ZeroPointOnePercentLow.Value = 0;
             // Reset the stale-fallback clock so a freshly-picked app gets a
             // full SELECTED_APP_STALE_MS grace period before we'd ever
             // fall back to foreground attribution.
@@ -679,6 +750,7 @@ public class PresentMonPoller(ILogger logger)
             int presentedQueue, displayedQueue;
             float fps, ft;
             bool stale;
+            long lowsFrames;
             lock (_stateLock)
             {
                 // Re-trim and recompute under the lock so the overlay value
@@ -698,6 +770,21 @@ public class PresentMonPoller(ILogger logger)
                     Presented.Value = 0;
                     Displayed.Value = 0;
                     Frametime.Value = 0;
+
+                    // The percentile buffer is deliberately NOT cleared here.
+                    // Staleness fires on every alt-tab, loading screen and
+                    // pause menu, and wiping a session-long statistic each time
+                    // would leave it permanently empty for anyone who tabs
+                    // out. It is dropped only once the game has been gone for
+                    // LOWS_ABANDON_MS, so the desktop doesn't sit there
+                    // showing a closed game's lows.
+                    if (_lastRowArrivalMs == 0 || wallNow - _lastRowArrivalMs > LOWS_ABANDON_MS)
+                    {
+                        _lows.Clear();
+                        _lowsApp = "";
+                        OnePercentLow.Value = 0;
+                        ZeroPointOnePercentLow.Value = 0;
+                    }
                 }
                 else
                 {
@@ -722,6 +809,23 @@ public class PresentMonPoller(ILogger logger)
                 displayedQueue = _displayedFrames.Count;
                 fps = Presented.Value ?? 0f;
                 ft = Frametime.Value ?? 0f;
+                // Computed under the lock rather than on a snapshot taken out
+                // of it. The walk starts at the slowest frame recorded and
+                // stops at the 1% crossing, so it reads a few thousand bucket
+                // counts and takes microseconds — nothing like sorting a
+                // session's frametimes, which the histogram means never
+                // happens. Publishing here also keeps the write to
+                // PresentMonSensor.Value (a float?, so a torn read is
+                // possible) on the same lock the pipe serializer takes.
+                //
+                // Deliberately outside the stale/else split above: when rows
+                // have merely paused, the session's frames are still there and
+                // the lows should keep reporting rather than blank out with
+                // the 1s averages.
+                OnePercentLow.Value = _lows.Compute(ONE_PERCENT, LOWS_MIN_TOTAL_MS);
+                ZeroPointOnePercentLow.Value =
+                    _lows.Compute(ZERO_POINT_ONE_PERCENT, LOWS_MIN_TOTAL_MS);
+                lowsFrames = _lows.FrameCount;
             }
             var countedStr = counted.Count == 0
                 ? "-"
@@ -731,13 +835,14 @@ public class PresentMonPoller(ILogger logger)
                 : string.Join(", ", dropped.OrderByDescending(kv => kv.Value).Select(kv => $"{kv.Key}:{kv.Value}"));
 
             logger.LogDebug(
-                "[FPS-DEBUG] fg={Fg} sel={Sel} fps={Fps:F1} ft={Ft:F2}ms buf.presented={QP} buf.displayed={QD} rows={Total} short={Short} stale={Stale} counted=[{Counted}] dropped=[{Dropped}]",
+                "[FPS-DEBUG] fg={Fg} sel={Sel} fps={Fps:F1} ft={Ft:F2}ms buf.presented={QP} buf.displayed={QD} lows.frames={LowsFrames} rows={Total} short={Short} stale={Stale} counted=[{Counted}] dropped=[{Dropped}]",
                 string.IsNullOrEmpty(fg) ? "(empty)" : fg,
                 sel,
                 fps,
                 ft,
                 presentedQueue,
                 displayedQueue,
+                lowsFrames,
                 total,
                 shortRows,
                 stale,
@@ -781,6 +886,15 @@ public class PresentMonPoller(ILogger logger)
                             Presented.Value = 0;
                             Displayed.Value = 0;
                             Frametime.Value = 0;
+                            // The percentile histogram is deliberately NOT
+                            // cleared here. A foreground change is not the
+                            // same event as "a different app's frames arrived"
+                            // — alt-tabbing to something that never presents
+                            // (Notepad, a settings window) would wipe a
+                            // session-long statistic that LOWS_ABANDON_MS
+                            // exists to protect. ParseData resets it on the
+                            // precise condition instead, when a row from a
+                            // different app is actually counted.
                         }
                     }
                 }

--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -190,6 +190,23 @@ impl Default for SensorConfig {
     }
 }
 
+/// A `SensorConfig` that starts switched off, for readings added after release.
+///
+/// Two things depend on this. First, `#[serde(default = ...)]` on the fields
+/// using it is load-bearing, not tidiness: every settings.json written before
+/// these fields existed omits them, a missing field fails the whole parse, and
+/// `Settings::load_from_file` quarantines an unparseable file — so without a
+/// default, upgrading would wipe every setting the user has. Second, the
+/// default has to be `false` where `SensorConfig::default()` is `true`,
+/// because an upgrade must not add readings to an overlay the user has
+/// already sized and positioned without being asked.
+fn sensor_config_disabled() -> SensorConfig {
+    SensorConfig {
+        is_enabled: false,
+        custom_reading_id: String::new(),
+    }
+}
+
 // Mirrors the TS FramerateSensorConfig: SensorConfig + the PresentMon app
 // filter. `default` on target_app_name keeps existing saved settings loadable
 // (older builds didn't write the field).
@@ -236,6 +253,10 @@ impl Default for GraphSensorConfig {
 pub struct SensorsConfig {
     pub framerate: FramerateSensorConfig,
     pub frametime: SensorConfig,
+    #[serde(rename = "onePercentLow", default = "sensor_config_disabled")]
+    pub one_percent_low: SensorConfig,
+    #[serde(rename = "zeroPointOnePercentLow", default = "sensor_config_disabled")]
+    pub zero_point_one_percent_low: SensorConfig,
     #[serde(rename = "cpuTemp")]
     pub cpu_temp: GraphSensorConfig,
     #[serde(rename = "cpuUsage")]
@@ -265,6 +286,8 @@ impl Default for SensorsConfig {
         SensorsConfig {
             framerate: FramerateSensorConfig::default(),
             frametime: SensorConfig::default(),
+            one_percent_low: sensor_config_disabled(),
+            zero_point_one_percent_low: sensor_config_disabled(),
             cpu_temp: GraphSensorConfig::default(),
             cpu_usage: GraphSensorConfig::default(),
             cpu_consumption: SensorConfig::default(),

--- a/tauri-app/src/components/overlay/FpsSection.tsx
+++ b/tauri-app/src/components/overlay/FpsSection.tsx
@@ -19,8 +19,14 @@ export function FpsSection({ isHorizontal }: FpsSectionProps) {
   const labelFontSize = settings.fontSizeLabel ?? 12;
   const valueFontWeight = settings.fontWeight ?? 500;
   const labelFontWeight = settings.labelFontWeight ?? 500;
-  const { framerate, frametime } = settings.sensors;
-  if (!framerate.isEnabled && !frametime.isEnabled) return null;
+  const { framerate, frametime, onePercentLow, zeroPointOnePercentLow } = settings.sensors;
+  if (
+    !framerate.isEnabled &&
+    !frametime.isEnabled &&
+    !onePercentLow.isEnabled &&
+    !zeroPointOnePercentLow.isEnabled
+  )
+    return null;
 
   // Resolve the FPS sensor: the configured reading first, then fall back to the
   // PresentMon "presented" sensor (frametime-derived — populated on every GPU,
@@ -39,65 +45,140 @@ export function FpsSection({ isHorizontal }: FpsSectionProps) {
         s.name.toLowerCase().includes("framerate")
     );
 
+  // Percentile lows, same custom-reading-then-identifier resolution. No
+  // name-based fallback: these identifiers only ever come from our own
+  // PresentMon poller, so there is no third-party naming to guess at.
+  const onePercentLowSensor =
+    findSensorById(sensors, onePercentLow.customReadingId) ??
+    sensors.find((s) => s.identifier === "/presentmon/onepercentlow");
+  const zeroPointOneLowSensor =
+    findSensorById(sensors, zeroPointOnePercentLow.customReadingId) ??
+    sensors.find((s) => s.identifier === "/presentmon/zeropointonepercentlow");
+
   const fpsValue = Math.round(fpsSensor?.value ?? 0);
+  const onePercentValue = Math.round(onePercentLowSensor?.value ?? 0);
+  const zeroPointOneValue = Math.round(zeroPointOneLowSensor?.value ?? 0);
   const lastFrametime = frametimeHistory.length > 0 ? frametimeHistory[frametimeHistory.length - 1] : 0;
   const showFrametime = frametime.isEnabled && frametimeHistory.length > 2;
+  // The sidecar reports 0 for a low during its warm-up (the first few seconds
+  // of a session, and again after the monitored app changes or the game is
+  // gone). Hiding the cluster is right rather than printing "0 1%", which
+  // reads as "your worst frames were 0 fps".
+  const showOnePercent = onePercentLow.isEnabled && onePercentValue > 0;
+  const showZeroPointOne = zeroPointOnePercentLow.isEnabled && zeroPointOneValue > 0;
+
+  const valueStyle: React.CSSProperties = {
+    fontSize: valueFontSize,
+    fontWeight: valueFontWeight,
+    color: "var(--overlay-text)",
+    fontFamily: "Inter",
+    letterSpacing: "-0.02em",
+  };
+  // Figma 2785:1409 / 2785:1414: the "1%" and "0.1%" suffixes take the same
+  // node treatment as every other unit in the HUD — label font, label weight,
+  // +4% tracking — so they follow the Label font settings while their numbers
+  // follow the Stats font, exactly like "°C", "%" and "GB".
+  //
+  // Colour deviates from those two nodes on purpose (Saad, 2026-08-27): they
+  // carry node opacity 0.7 in the frame, but the units they sit next to
+  // ("°C" 2785:1356, "%" 2785:1373, "GB" 2785:1380) are all full white, and
+  // only "ms" is muted. Full white keeps the lows reading as units of a
+  // reading rather than as secondary text.
+  const suffixStyle: React.CSSProperties = {
+    fontSize: labelFontSize,
+    fontWeight: labelFontWeight,
+    color: "var(--overlay-text)",
+    fontFamily: "Inter",
+    letterSpacing: "0.04em",
+  };
+
+  // "6.2 ms" keeps its 0.7 (Figma 2785:1343 / 2785:1545), unchanged.
+  const frametimeStyle: React.CSSProperties = {
+    ...suffixStyle,
+    color: "var(--overlay-text-muted)",
+  };
 
   const valueText = framerate.isEnabled && (
-    <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">
+    <span style={valueStyle} className="tabular-nums">
       {formatValue(fpsValue)}
     </span>
   );
 
-  // Figma 2202:3261/3176/3173: "6.2 ms" is ONE text node at 12px / weight 500
-  // / letterSpacing +4% / opacity 0.7 at EVERY value-font step — the whole
-  // frametime reading (number included) tracks the LABEL font settings, not
-  // the Stats font, and both parts are muted.
+  // Figma 2785:1407 / 2785:1412 (Frame 57): value and suffix are one cluster at
+  // gap 4, and each cluster is a sibling of the average at the pill's own 12px
+  // spacing — the lows are full-size readings, not decorations on the average.
+  const lowCluster = (value: number, suffix: string) => (
+    <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+      <span style={valueStyle} className="tabular-nums">
+        {formatValue(value)}
+      </span>
+      <span style={suffixStyle} className="tabular-nums">
+        {suffix}
+      </span>
+    </div>
+  );
+
   const frametimeText = showFrametime && (
-    <span className="tabular-nums" style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text-muted)", fontFamily: "Inter", letterSpacing: "0.04em" }}>
+    <span className="tabular-nums" style={frametimeStyle}>
       {formatValue(lastFrametime, 1)} ms
     </span>
   );
 
   if (isHorizontal) {
-    // Figma 2202:2664 (Frame 73): value, graph, and ms form ONE cluster with
-    // 6px gaps on both sides of the graph — tighter than the pill-level 12px
-    // cluster gap. The 100×7 band sits at y=9 of the 29-high row — 2px above
-    // flex-center (y=11) — so nudge the centered canvas up by that constant
-    // (the sweep only specifies font 24; the -2 is kept fixed across fonts).
+    // Figma 2785:1337: the pill's own 12px spacing separates FPS / 120 / the
+    // two low clusters / the graph cluster. The graph and its "6.2 ms" stay a
+    // tighter 6px pair (2785:1402), but the average is no longer inside that
+    // pair the way it was before the lows existed.
+    //
+    // The 100×7 band sits at y=9 of the 29-high row (measured on 2785:1342) —
+    // 2px above flex-center (y=11) — so nudge the centered canvas up by that
+    // constant. Same offset as before; the graph frame did not move.
     return (
       <Pill title="FPS" isHorizontal>
-        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-          {valueText}
-          {showFrametime && (
+        {valueText}
+        {showOnePercent && lowCluster(onePercentValue, "1%")}
+        {showZeroPointOne && lowCluster(zeroPointOneValue, "0.1%")}
+        {showFrametime && (
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <div style={{ position: "relative", top: -2 }}>
               <FrametimeGraph history={frametimeHistory} width={100} />
             </div>
-          )}
-          {frametimeText}
-        </div>
+            {frametimeText}
+          </div>
+        )}
       </Pill>
     );
   }
 
-  // Figma 2202:3255 (Frame 80 + 81): the value row holds "120" and "6.2 ms"
-  // at the pill's regular 12px gap, and the graph gets its own full-width
-  // 24px row below (band offset 6 from the row top, per the 134×24 frame
-  // wrapping a 134×7 vector).
+  // Figma 2785:1476: the value row holds "120" plus both low clusters at the
+  // pill's 12px gap, and the graph gets its own row below at the pill's 8px
+  // row gap. The "6.2 ms" reading now lives in THAT row beside the graph
+  // (2785:1542, gap 6) rather than up in the value row where it used to sit —
+  // with two more numbers on the value row it no longer fits there.
+  //
+  // Row height tracks the value font: Figma's 29 is the 24px value text at the
+  // HUD's unitless 1.2 line-height (OverlayHud.tsx), and the row is sized to
+  // match the value row above it, so deriving it keeps the two rows equal at
+  // every font step instead of pinning one sweep's number.
+  const graphRowHeight = Math.round(valueFontSize * 1.2);
   return (
     <Pill
       title="FPS"
       isHorizontal={false}
       graphRow={
         showFrametime && (
-          <div style={{ height: 24, paddingTop: 6 }}>
-            <FrametimeGraph history={frametimeHistory} width="fill" />
+          <div style={{ display: "flex", alignItems: "center", gap: 6, height: graphRowHeight }}>
+            <div style={{ flex: 1, minWidth: 0, position: "relative", top: -2 }}>
+              <FrametimeGraph history={frametimeHistory} width="fill" />
+            </div>
+            {frametimeText}
           </div>
         )
       }
     >
       {valueText}
-      {frametimeText}
+      {showOnePercent && lowCluster(onePercentValue, "1%")}
+      {showZeroPointOne && lowCluster(zeroPointOneValue, "0.1%")}
     </Pill>
   );
 }

--- a/tauri-app/src/components/settings/stats/FpsSection.tsx
+++ b/tauri-app/src/components/settings/stats/FpsSection.tsx
@@ -10,15 +10,27 @@ import { SelectFieldTrigger } from "@/components/ui/SelectField";
 import { InfoIcon } from "../settings/icons";
 import { useSettingsStore } from "@/stores/settings-store";
 import { AUTO_OPTION, monitorAppOptions } from "@/lib/fps-apps";
+import { DEFAULT_SETTINGS } from "@/lib/types";
 import { SectionCard } from "./SectionCard";
+
+// Every reading this card owns, in the order the checkboxes appear. The card's
+// master toggle stores and restores all of them, so a reading added later only
+// has to be listed here rather than threaded through the toggle by hand.
+const FPS_READINGS = [
+  "framerate",
+  "frametime",
+  "onePercentLow",
+  "zeroPointOnePercentLow",
+] as const;
+type FpsReading = (typeof FPS_READINGS)[number];
 
 export function FpsSection() {
   const settings = useSettingsStore((s) => s.settings);
   const updateSensor = useSettingsStore((s) => s.updateSensor);
   const presentMonApps = useSettingsStore((s) => s.presentMonApps);
-  const { framerate, frametime } = settings.sensors;
-  const anyEnabled = framerate.isEnabled || frametime.isEnabled;
-  const prevState = useRef<{ framerate: boolean; frametime: boolean } | null>(null);
+  const { framerate, frametime, onePercentLow, zeroPointOnePercentLow } = settings.sensors;
+  const anyEnabled = FPS_READINGS.some((key) => settings.sensors[key].isEnabled);
+  const prevState = useRef<Record<FpsReading, boolean> | null>(null);
   // `|| ""` guards a settings.json written before targetAppName existed, where
   // the field is absent at runtime whatever the type says.
   const { value: selectedApp, options: appOptions } = monitorAppOptions({
@@ -32,13 +44,21 @@ export function FpsSection() {
       enabled={anyEnabled}
       onToggle={(enabled) => {
         if (!enabled) {
-          prevState.current = { framerate: framerate.isEnabled, frametime: frametime.isEnabled };
-          updateSensor("framerate", { isEnabled: false });
-          updateSensor("frametime", { isEnabled: false });
+          prevState.current = Object.fromEntries(
+            FPS_READINGS.map((key) => [key, settings.sensors[key].isEnabled]),
+          ) as Record<FpsReading, boolean>;
+          FPS_READINGS.forEach((key) => updateSensor(key, { isEnabled: false }));
         } else {
           const prev = prevState.current;
-          updateSensor("framerate", { isEnabled: prev ? prev.framerate : true });
-          updateSensor("frametime", { isEnabled: prev ? prev.frametime : true });
+          // With nothing stored (the card was already off at launch), fall back
+          // to each reading's shipped default rather than switching everything
+          // on: the two percentile lows default to off, and a blanket `true`
+          // here would enable readings the user never asked for.
+          FPS_READINGS.forEach((key) =>
+            updateSensor(key, {
+              isEnabled: prev ? prev[key] : DEFAULT_SETTINGS.sensors[key].isEnabled,
+            }),
+          );
         }
       }}
     >
@@ -56,6 +76,22 @@ export function FpsSection() {
             onCheckedChange={(v) => updateSensor("frametime", { isEnabled: v === true })}
           />
           <span className="text-[14px] font-medium text-foreground">Frame time graph</span>
+        </label>
+        <label className="flex cursor-pointer items-center gap-2">
+          <Checkbox
+            checked={onePercentLow.isEnabled}
+            onCheckedChange={(v) => updateSensor("onePercentLow", { isEnabled: v === true })}
+          />
+          <span className="text-[14px] font-medium text-foreground">1% Lows</span>
+        </label>
+        <label className="flex cursor-pointer items-center gap-2">
+          <Checkbox
+            checked={zeroPointOnePercentLow.isEnabled}
+            onCheckedChange={(v) =>
+              updateSensor("zeroPointOnePercentLow", { isEnabled: v === true })
+            }
+          />
+          <span className="text-[14px] font-medium text-foreground">0.1% Lows</span>
         </label>
       </div>
 

--- a/tauri-app/src/lib/preview-fixture.ts
+++ b/tauri-app/src/lib/preview-fixture.ts
@@ -1,6 +1,6 @@
 import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
-import type { HardwareMonitorData } from "./types";
-import { HardwareType, SensorType } from "./types";
+import type { HardwareMonitorData, OverlaySettings } from "./types";
+import { DEFAULT_SETTINGS, HardwareType, SensorType } from "./types";
 
 /**
  * What the browser preview (`npm run dev`) pretends the sidecar is sending.
@@ -90,6 +90,12 @@ export function previewSensorData(): HardwareMonitorData {
 
       sensor("/presentmon", "/presentmon/presented", "Presented", SensorType.Load, 144),
       sensor("/presentmon", "/presentmon/frametime", "Frametime", SensorType.Load, 6.94),
+      // Values taken from the Figma sample (2785:1408 "65", 2785:1413 "12") so
+      // the preview can be diffed against the frame directly. The sidecar
+      // reports 0 for either of these until its window holds enough frames,
+      // and the overlay hides a 0 — set one to 0 here to preview that state.
+      sensor("/presentmon", "/presentmon/onepercentlow", "1 Percent Low", SensorType.Load, 65),
+      sensor("/presentmon", "/presentmon/zeropointonepercentlow", "0.1 Percent Low", SensorType.Load, 12),
     ],
   };
 }
@@ -97,6 +103,36 @@ export function previewSensorData(): HardwareMonitorData {
 /** Something for the FPS app picker to list. */
 export function previewPresentMonApps(): string[] {
   return ["Cyberpunk2077.exe", "cs2.exe"];
+}
+
+/**
+ * The settings the browser preview starts from.
+ *
+ * Identical to the shipped defaults except that both percentile lows are
+ * switched on. They ship off so an upgrade doesn't add readings to an overlay
+ * someone has already sized, but a preview that inherits that leaves the FPS
+ * pill rendering exactly as it did before the feature existed, hiding the one
+ * layout worth reviewing. Same reasoning as the two-GPU sensor snapshot above:
+ * the preview should show the state we design against.
+ */
+export function previewSettings(): OverlaySettings {
+  // The HUD has two layouts and the settings window that toggles them is a
+  // different Tauri window, which the browser preview does not have — so
+  // without this the vertical pill is unreachable at
+  // http://localhost:1420/overlay.html. Add ?vertical to see it.
+  const vertical = new URLSearchParams(window.location.search).has("vertical");
+  return {
+    ...DEFAULT_SETTINGS,
+    isHorizontal: !vertical,
+    sensors: {
+      ...DEFAULT_SETTINGS.sensors,
+      onePercentLow: { ...DEFAULT_SETTINGS.sensors.onePercentLow, isEnabled: true },
+      zeroPointOnePercentLow: {
+        ...DEFAULT_SETTINGS.sensors.zeroPointOnePercentLow,
+        isEnabled: true,
+      },
+    },
+  };
 }
 
 /**

--- a/tauri-app/src/lib/tauri.ts
+++ b/tauri-app/src/lib/tauri.ts
@@ -7,7 +7,12 @@ import type {
   AppPreferences,
   SidecarStatus,
 } from "./types";
-import { previewPresentMonApps, previewSensorData, previewUpdate } from "./preview-fixture";
+import {
+  previewPresentMonApps,
+  previewSensorData,
+  previewSettings,
+  previewUpdate,
+} from "./preview-fixture";
 
 // ─── Browser detection ──────────────────────────────────────────
 // When running via `npm run dev` in a browser (no Tauri runtime),
@@ -67,7 +72,15 @@ async function safeListen<T>(
 
 // ─── Settings Commands ──────────────────────────────────────────
 
-export const getSettings = () => safeInvoke<OverlaySettings>("get_settings");
+export const getSettings = () =>
+  // The percentile lows ship disabled, so a browser preview left on the
+  // shipped defaults renders the FPS pill without them and the one layout
+  // that needs reviewing is the one you cannot see. Same reasoning as the
+  // two-GPU sensor fixture: the preview should show the state we design
+  // against, and `usePreviewFixture` keeps it out of any built bundle.
+  usePreviewFixture
+    ? Promise.resolve(previewSettings())
+    : safeInvoke<OverlaySettings>("get_settings");
 export const saveSettings = (settings: OverlaySettings) =>
   safeInvoke("save_settings", { settings });
 export const clearSettings = () => safeInvoke("clear_settings");

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -65,6 +65,8 @@ export interface FramerateSensorConfig extends SensorConfig {
 export interface SensorsConfig {
   framerate: FramerateSensorConfig;
   frametime: SensorConfig;
+  onePercentLow: SensorConfig;
+  zeroPointOnePercentLow: SensorConfig;
   cpuTemp: GraphSensorConfig;
   cpuUsage: GraphSensorConfig;
   cpuConsumption: SensorConfig;
@@ -213,6 +215,12 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   sensors: {
     framerate: { isEnabled: true, customReadingId: "", targetAppName: "" },
     frametime: { isEnabled: true, customReadingId: "" },
+    // Off by default. These are new readings, and an upgrade that silently
+    // adds two numbers to an overlay someone has already positioned and sized
+    // is a change they did not ask for. The Figma settings card shows both
+    // unchecked for the same reason.
+    onePercentLow: { isEnabled: false, customReadingId: "" },
+    zeroPointOnePercentLow: { isEnabled: false, customReadingId: "" },
     cpuTemp: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     cpuUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     cpuConsumption: { isEnabled: true, customReadingId: "" },


### PR DESCRIPTION
## What changed

Adds two new FPS readings to the overlay: the **1% low** and the **0.1% low**. Both are off by default and toggled independently from the FPS card in Stats.

| Area | Change |
|---|---|
| Sidecar | New `FrameLows` histogram accumulating every presented frame for the session; two new PresentMon sensors published through the existing pipe |
| Rust | `onePercentLow` / `zeroPointOnePercentLow` on the sensors config, defaulting off |
| Settings | Two checkboxes under Frame count and Frame time graph |
| Overlay | Both readings in the FPS pill, horizontal and vertical |

## Why these numbers, specifically

"1% low" is not one agreed formula, and the three in circulation disagree by a wide margin on identical gameplay. This implements the **RTSS / MSI Afterburner** one, so the reading agrees with the overlay most users already have running: sort frames slowest-first, accumulate frametimes until the sum reaches 1% of total session time, report the frametime at that crossing point.

On 999 frames at 8ms plus a single 200ms hitch:

| Method | Reads | Used by |
|---|---|---|
| Time-integral threshold (**this PR**) | 5.0 fps | RTSS / MSI Afterburner |
| Average of the slowest 1% | 36.8 fps | GamersNexus, CapFrameX "1% low average" |
| Frame-count percentile (P1) | unmoved | Intel PresentMon, CapFrameX "1% percentile" |

`FrameLows` documents all three and which one it implements, so switching is a single edit.

The window is the whole session, matching RTSS's "unlimited" default. That rules out keeping a list of frametimes (four hours at 300fps is 4.3M frames), so frames go into a histogram: constant memory and constant compute regardless of session length. Because every frame in a bucket shares one quantised frametime, walking the histogram from the slow end gives exactly the answer walking the sorted frames would.

## What this fixes

- Average FPS cannot distinguish a smooth 120fps session from one hitching every few seconds. These readings measure the worst frames instead of the typical ones.
- The session accumulator is keyed on the app whose frames are actually counted, so it resets whenever that changes. Three paths change it and only one is an explicit user action: picking another app, a foreground change in Auto mode, and the fallback that starts counting the foreground once a manually-picked app has been silent for 5s. Without that, alt-tabbing to a browser would accumulate that window's frametimes into the game's reading for the rest of the session.
- Brief gaps (alt-tab, loading screens, pause menus) deliberately do not reset it; only 30s of no frames does, so the desktop does not sit showing a closed game's numbers.

## Settings safety

The serde defaults on the two new fields are load-bearing rather than tidiness. A missing field fails the whole settings parse, and `Settings::load_from_file` quarantines an unparseable file, so without them every existing user would lose all their settings on upgrade. The frontend store independently merges per sensor against defaults, so both layers cover it.

Both readings ship disabled: an upgrade should not add numbers to an overlay someone has already sized and positioned.

## Design

Overlay pill follows Figma `2785:1335` (horizontal) and `2785:1474` (vertical). Gaps, padding, radii, label slot and band offset were extracted from the nodes and verified against the rendered DOM.

One intentional deviation: the `1%` and `0.1%` suffixes render full white where the frames have them at opacity 0.7. This matches `°C`, `%` and `GB` in the same pill, which are all full white; only `ms` is muted. Recorded in a comment next to the style so a later design pass does not silently revert it.

In the vertical layout the `6.2 ms` reading moves into the graph row per `2785:1542`. It was previously in the value row and no longer fits there alongside two more numbers.

## Not included

- **No reset hotkey.** Because the window is the whole session, an early hitch drags the reading until enough playtime dilutes it, which is also how Afterburner behaves on "unlimited". A reset is deferred until the readings have been compared against Afterburner on real hardware. `Alt+F11` already emits an unhandled `toggle-recording` event and is the natural place to hang it.
- **No committed test for the percentile math.** The sidecar has no test project, and no sibling C# logic is tested. The math was verified out-of-tree against an independent implementation of the RTSS rule (18 assertions, agreement within 0.002%). Adding a test project is a separate change.
- Both readings use the present-to-present interval, matching the Presented sensor the overlay defaults to. No displayed-frame variant.

## Verification

| Check | Result |
|---|---|
| `dotnet build` Debug + Release | 0 warnings, 0 errors |
| `tsc --noEmit` | 0 errors |
| `eslint .` | clean |
| `vitest` unit | 110/110 |
| `cargo clippy --all-targets` | exit 0, no new warnings |
| `cargo test` (lib) | 20/20 |
| Percentile math vs independent reference | 18/18, max relative error 0.002% |
| Overlay rendering | verified in the browser preview, both orientations |

`cargo test` cannot run the `--bin cleanmeter` target locally: the exe manifest is `requireAdministrator`, so it exits with `os error 740`. Pre-existing and unrelated.

**Still needs a real-hardware check:** the numbers have been verified against the RTSS *definition*, not measured side by side with Afterburner in a game. Worth doing before release.



## Review follow-up

Two issues raised in review, both accepted and fixed in `d1c2dd1`:

1. **Non-finite frame intervals could crash the sidecar.** The guard rejected NaN, zero and negatives but `PositiveInfinity > 0` is true, so infinity reached the histogram index. Now rejected via `float.IsFinite`.
2. **The stale-selection fallback blended apps into the lows.** When a manually-picked app stops presenting, attribution falls back to the foreground, and no reset path covered it. The reset is now keyed on the app whose frames are counted, which covers all three attribution paths at once.

While testing the first fix, a second overflow surfaced that the review did not cover: `float.MaxValue` is finite, so it passes the guard, but `MaxValue / 0.01` overflows the `int` cast before the bucket clamp can catch it. The clamp now happens in the double domain, before the cast. A garbage CSV field parses to exactly this.

Verification extended to 23 assertions covering infinity, `float.MaxValue`, and the parse path that produces them.
