### PR TITLE
Bump version to 2.2.17

### DIFF
--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cleanmeter",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cleanmeter",
-      "version": "2.2.16",
+      "version": "2.2.17",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@fluentui/react-components": "^9.73.4",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleanmeter",
   "private": true,
-  "version": "2.2.16",
+  "version": "2.2.17",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "cleanmeter"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "byteorder",
  "dirs",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cleanmeter"
-version = "2.2.16"
+version = "2.2.17"
 description = "Gaming performance overlay"
 authors = ["Cleanmeter"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui/toolkits/refs/heads/main/tauri/schema.json",
   "productName": "Cleanmeter",
   "identifier": "com.cleanmeter.desktop",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## What changed

Bumps the app version `2.2.16` → `2.2.17` in the five places that carry it, per `RELEASING.md`:

| File | Entry |
| --- | --- |
| `tauri-app/src-tauri/tauri.conf.json` | `version` |
| `tauri-app/package.json` | `version` |
| `tauri-app/package-lock.json` | both root entries |
| `tauri-app/src-tauri/Cargo.toml` | `[package] version` |
| `tauri-app/src-tauri/Cargo.lock` | `cleanmeter` package entry |

No functional changes.

## What this release contains

Everything on `main` since `v2.2.16`:

- Add 1% and 0.1% low framerate readings (#61)

## Verification

- `cargo metadata --locked` passes — `Cargo.lock` agrees with `Cargo.toml`.
- `npm ci --dry-run` passes — `package-lock.json` agrees with `package.json`.
- `grep` finds no remaining `2.2.16` reference under `tauri-app/`.

## Not included

Tagging. Once this merges, `v2.2.17` gets tagged on `main` and pushed, which triggers `build.yml` to build, sign, and open the **draft** release for QA.