### PR TITLE
Make the live percentile lows a rolling window

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,6 +65,14 @@ jobs:
         working-directory: HardwareMonitor/HardwareMonitor
         run: dotnet build -c Release
 
+      # Covers the percentile-low maths (FrameLows / FrameLowsWindow), which is
+      # pure arithmetic over synthetic frametimes and needs no hardware. The
+      # 1%-low reading shipped once already with a window that could not report
+      # a framerate recovery; these tests are what would have caught it.
+      - name: Test sidecar
+        working-directory: HardwareMonitor/HardwareMonitor.Tests
+        run: dotnet test -c Release
+
   rust:
     name: Rust (clippy, tests)
     runs-on: windows-latest

--- a/HardwareMonitor/HardwareMonitor.Tests/FrameLowsTests.cs
+++ b/HardwareMonitor/HardwareMonitor.Tests/FrameLowsTests.cs
@@ -1,0 +1,381 @@
+using HardwareMonitor.PresentMon;
+using Xunit;
+
+namespace HardwareMonitor.Tests;
+
+/// <summary>
+/// The two percentile-low accumulators, and specifically the difference in
+/// behaviour that made the live overlay reading look broken: a
+/// session-cumulative figure cannot report a recovery, a windowed one can.
+///
+/// Numbers here are exact rather than approximate wherever the workload is
+/// synthetic and uniform, because the whole class of bug being guarded against
+/// is a figure that does not move when it should.
+/// </summary>
+public class FrameLowsTests
+{
+    private const double OnePercent = 0.01;
+    private const double PointOnePercent = 0.001;
+
+    /// <summary>Feeds a steady framerate into the session histogram.</summary>
+    private static void Feed(FrameLows lows, double fps, double seconds)
+    {
+        var intervalMs = (float)(1000.0 / fps);
+        var frames = (int)Math.Round(fps * seconds);
+        for (var i = 0; i < frames; i++) lows.Add(intervalMs);
+    }
+
+    /// <summary>
+    /// Feeds a steady framerate into the rolling window, advancing PresentMon's
+    /// CPUStartTime clock by each frame's own interval — which is what the real
+    /// caller passes and what the eviction test compares against.
+    /// </summary>
+    private sealed class WindowFeeder(FrameLowsWindow window)
+    {
+        private double _nowMs;
+
+        public void Feed(double fps, double seconds)
+        {
+            var intervalMs = (float)(1000.0 / fps);
+            var frames = (int)Math.Round(fps * seconds);
+            for (var i = 0; i < frames; i++)
+            {
+                window.Add(_nowMs, intervalMs);
+                _nowMs += intervalMs;
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------- the bug
+
+    /// <summary>
+    /// The reported bug, as arithmetic. A session-length window pins the 1% low
+    /// to the slow phase for 99x its duration, so 30s at 60fps holds the
+    /// reading at 60 through nearly an hour of 240fps play. Correct for a
+    /// benchmark run — every frame of the run counts, which is the point — and
+    /// completely wrong for a live reading, which is why the live reading is no
+    /// longer this class.
+    /// </summary>
+    [Fact]
+    public void SessionLows_StayPinnedToTheSlowPhase_LongAfterFramerateRecovers()
+    {
+        var lows = new FrameLows();
+        Feed(lows, 60, 30);
+        Assert.Equal(60.0f, lows.Compute(OnePercent, 0), 1);
+
+        Feed(lows, 240, 300);
+        Assert.Equal(60.0f, lows.Compute(OnePercent, 0), 1);
+
+        // Still pinned after 45 minutes at 240fps. 30s of 60fps needs 99x that
+        // — 49.5 minutes — before it stops owning 1% of total session time.
+        Feed(lows, 240, 2400);
+        Assert.Equal(60.0f, lows.Compute(OnePercent, 0), 1);
+    }
+
+    /// <summary>
+    /// The 0.1% low needs 999x, which for the same 30s slow phase is over eight
+    /// hours. Recorded so nobody reads the 1% figure above as the worst case.
+    /// </summary>
+    [Fact]
+    public void SessionLows_PinThePointOnePercentEvenLonger()
+    {
+        var lows = new FrameLows();
+        Feed(lows, 60, 30);
+        Feed(lows, 240, 3600);
+        Assert.Equal(60.0f, lows.Compute(PointOnePercent, 0), 1);
+    }
+
+    // ---------------------------------------------------------------- the fix
+
+    /// <summary>
+    /// The fix. Same framerate change, but the window ages the slow frames out,
+    /// so the reading is back on the current framerate once the window has
+    /// turned over — bounded staleness instead of unbounded.
+    /// </summary>
+    [Fact]
+    public void WindowedLows_RecoverOnceTheWindowHasTurnedOver()
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+
+        feeder.Feed(60, 30);
+        Assert.Equal(60.0f, window.Compute(OnePercent, 0), 1);
+
+        // Halfway through the window the slow frames still hold more than 1% of
+        // its time, so the reading is still 60. A phase change is a step, not a
+        // glide, and this documents that it is expected.
+        feeder.Feed(240, 5);
+        Assert.Equal(60.0f, window.Compute(OnePercent, 0), 1);
+
+        // Past the window, every 60fps frame has aged out.
+        feeder.Feed(240, 6);
+        Assert.Equal(240.0f, window.Compute(OnePercent, 0), 1);
+    }
+
+    /// <summary>
+    /// The recovery is bounded by the window and nothing else, so a longer slow
+    /// phase does not make it slower. This is the property the session
+    /// accumulator does not have.
+    /// </summary>
+    [Theory]
+    [InlineData(30)]
+    [InlineData(120)]
+    [InlineData(600)]
+    public void WindowedLows_RecoverInTheSameTimeRegardlessOfHowLongTheSlowPhaseLasted(
+        double slowSeconds)
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+
+        feeder.Feed(60, slowSeconds);
+        feeder.Feed(240, 11);
+
+        Assert.Equal(240.0f, window.Compute(OnePercent, 0), 1);
+    }
+
+    /// <summary>
+    /// A drop still lands on the next poll. The asymmetry was never the
+    /// problem — a stutter SHOULD show up immediately — so windowing must not
+    /// have slowed that down.
+    /// </summary>
+    [Fact]
+    public void WindowedLows_ReportADropImmediately()
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+
+        feeder.Feed(240, 11);
+        Assert.Equal(240.0f, window.Compute(OnePercent, 0), 1);
+
+        feeder.Feed(60, 0.5);
+        Assert.Equal(60.0f, window.Compute(OnePercent, 0), 1);
+    }
+
+    // -------------------------------------------------- agreement on the maths
+
+    /// <summary>
+    /// Both classes implement RTSS's integral definition, so on a workload that
+    /// fits entirely inside the window they must produce the same number. The
+    /// case is the one FrameLows documents: 999 frames at 8ms plus a single
+    /// 200ms hitch reads 5.0 fps, because one catastrophic frame covers the
+    /// whole 1% time budget on its own. An "average the slowest 1%" rule reads
+    /// 36.8 here, so this also pins down which definition is implemented.
+    /// </summary>
+    [Fact]
+    public void BothAccumulators_AgreeWithRtssIntegralDefinition_OnASingleHitch()
+    {
+        var lows = new FrameLows();
+        var window = new FrameLowsWindow();
+        var nowMs = 0.0;
+
+        for (var i = 0; i < 999; i++)
+        {
+            lows.Add(8f);
+            window.Add(nowMs, 8f);
+            nowMs += 8;
+        }
+        lows.Add(200f);
+        window.Add(nowMs, 200f);
+
+        Assert.Equal(5.0f, lows.Compute(OnePercent, 0), 2);
+        Assert.Equal(5.0f, window.Compute(OnePercent, 0), 2);
+    }
+
+    /// <summary>
+    /// A smaller fraction crosses its budget earlier, on a slower frame, so the
+    /// 0.1% low can never read above the 1% low. Two readings that inverted
+    /// would be unactionable, and it is the reason one hotkey drives both.
+    /// </summary>
+    [Fact]
+    public void WindowedLows_NeverReportPointOnePercentAboveOnePercent()
+    {
+        var window = new FrameLowsWindow();
+        var random = new Random(1234);
+        var nowMs = 0.0;
+
+        // Jittery, with occasional hitches — the shape that separates the two.
+        for (var i = 0; i < 20_000; i++)
+        {
+            var intervalMs = (float)(4.0 + random.NextDouble() * 2.0);
+            if (i % 500 == 0) intervalMs = (float)(30.0 + random.NextDouble() * 40.0);
+            window.Add(nowMs, intervalMs);
+            nowMs += intervalMs;
+        }
+
+        var onePercent = window.Compute(OnePercent, 0);
+        var pointOne = window.Compute(PointOnePercent, 0);
+
+        Assert.True(onePercent > 0);
+        Assert.True(pointOne > 0);
+        Assert.True(
+            pointOne <= onePercent,
+            $"0.1% low ({pointOne}) must not exceed 1% low ({onePercent})");
+    }
+
+    // ------------------------------------------------------------- the window
+
+    [Fact]
+    public void WindowedLows_EvictFramesOlderThanTheWindow()
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+
+        feeder.Feed(120, 60);
+
+        // A minute fed in, ~10s retained. One frame of slack: eviction is on
+        // `>` the window, so the frame sitting exactly on the boundary stays.
+        Assert.InRange(window.TotalMs, FrameLowsWindow.DefaultWindowMs,
+            FrameLowsWindow.DefaultWindowMs + 1000.0 / 120 * 2);
+    }
+
+    /// <summary>
+    /// The window is a duration, so an uncapped menu running at thousands of
+    /// frames per second would otherwise size the queue and the per-poll sort
+    /// off the framerate.
+    /// </summary>
+    [Fact]
+    public void WindowedLows_CapRetainedFramesEvenWhenTheWindowWouldHoldMore()
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+
+        // 4,000fps for the full window is 40,000 frames, well past the cap.
+        feeder.Feed(4000, 10);
+
+        Assert.True(
+            window.FrameCount <= FrameLowsWindow.MaxFrames,
+            $"retained {window.FrameCount} frames, cap is {FrameLowsWindow.MaxFrames}");
+        Assert.Equal(4000.0f, window.Compute(OnePercent, 0), 0);
+    }
+
+    [Fact]
+    public void WindowedLows_ReportNothingBeforeTheWarmUpThreshold()
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+
+        feeder.Feed(240, 1);
+        Assert.Equal(0f, window.Compute(OnePercent, 5_000));
+
+        feeder.Feed(240, 5);
+        Assert.True(window.Compute(OnePercent, 5_000) > 0);
+    }
+
+    /// <summary>
+    /// A frame arriving long after the last one drops the whole stale window in
+    /// one pass, because eviction runs on every Add and compares CPUStartTime.
+    /// This is what lets SetLowsMode return to Live without clearing first: a
+    /// user unfreezing while still playing keeps a full window, and one who
+    /// unfreezes after a long gap gets the stale frames flushed by the first
+    /// new frame rather than blended into the reading.
+    /// </summary>
+    [Fact]
+    public void WindowedLows_FlushStaleFramesOnTheFirstFrameAfterAGap()
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+
+        feeder.Feed(240, 11);
+        Assert.True(window.FrameCount > 1000);
+
+        // Twenty minutes of frozen-at-the-desktop, then one frame.
+        window.Add(11_000 + 20 * 60 * 1000, 4.1667f);
+
+        Assert.Equal(1, window.FrameCount);
+    }
+
+    [Fact]
+    public void WindowedLows_ClearForgetsEverything()
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+
+        feeder.Feed(240, 11);
+        Assert.True(window.Compute(OnePercent, 0) > 0);
+
+        window.Clear();
+
+        Assert.Equal(0, window.FrameCount);
+        Assert.Equal(0, window.TotalMs);
+        Assert.Equal(0f, window.Compute(OnePercent, 0));
+    }
+
+    /// <summary>
+    /// A garbled PresentMon CSV field parses to infinity or NaN as happily as
+    /// to a number. In a running sum that is permanent damage — the eviction
+    /// subtraction can never bring the total back to finite — so it has to be
+    /// rejected at the door, not clamped downstream.
+    /// </summary>
+    [Theory]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NaN)]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    public void WindowedLows_RejectUnusableIntervals(float intervalMs)
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+        feeder.Feed(240, 11);
+
+        var before = window.Compute(OnePercent, 0);
+        window.Add(11_000, intervalMs);
+
+        Assert.Equal(before, window.Compute(OnePercent, 0), 3);
+        Assert.True(double.IsFinite(window.TotalMs));
+    }
+
+    [Fact]
+    public void WindowedLows_RejectANonFiniteTimestamp()
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+        feeder.Feed(240, 11);
+
+        var before = window.Compute(OnePercent, 0);
+        window.Add(double.PositiveInfinity, 4.1667f);
+
+        Assert.Equal(before, window.Compute(OnePercent, 0), 3);
+        Assert.True(double.IsFinite(window.TotalMs));
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(1.5)]
+    public void WindowedLows_RefuseFractionsOutsideZeroToOne(double fraction)
+    {
+        var window = new FrameLowsWindow();
+        var feeder = new WindowFeeder(window);
+        feeder.Feed(240, 11);
+
+        Assert.Equal(0f, window.Compute(fraction, 0));
+    }
+
+    // ------------------------------------------------------------- the protocol
+
+    /// <summary>
+    /// The mode discriminants are the pipe payload
+    /// (MonitorPacketCommand.SetLowsMode), and 0/1 carry the meanings the
+    /// earlier boolean payload had. Reordering them would silently change what
+    /// a keypress does across a version mismatch.
+    /// </summary>
+    [Fact]
+    public void LowsMode_WireValuesAreFixed()
+    {
+        Assert.Equal(0, (int)LowsMode.Frozen);
+        Assert.Equal(1, (int)LowsMode.Recording);
+        Assert.Equal(2, (int)LowsMode.Live);
+    }
+
+    /// <summary>
+    /// The warm-up has to be shorter than the window or the live reading never
+    /// appears at all: the window can never hold more than its own length.
+    /// </summary>
+    [Fact]
+    public void WindowIsLongerThanTheWarmUpThresholdUsedByThePoller()
+    {
+        // LOWS_MIN_TOTAL_MS in PresentMonPoller.
+        const double warmUpMs = 5_000;
+        Assert.True(FrameLowsWindow.DefaultWindowMs > warmUpMs);
+    }
+}

--- a/HardwareMonitor/HardwareMonitor.Tests/FrameLowsTests.cs
+++ b/HardwareMonitor/HardwareMonitor.Tests/FrameLowsTests.cs
@@ -248,6 +248,38 @@ public class FrameLowsTests
         Assert.Equal(4000.0f, window.Compute(OnePercent, 0), 0);
     }
 
+    /// <summary>
+    /// Above ~3,277fps the frame cap binds before the warm-up threshold does:
+    /// MaxFrames is 16,384 frames, which is only 4,096ms at 4,000fps, so the
+    /// window's total can never reach a 5,000ms threshold no matter how long the
+    /// game runs. Without a full buffer counting as warmed up, the live lows
+    /// would read 0 forever at exactly the uncapped-menu framerate the
+    /// MaxFrames comment cites.
+    /// </summary>
+    [Fact]
+    public void WindowedLows_ReportFromAFullBufferEvenBelowTheWarmUpThreshold()
+    {
+        var window = new FrameLowsWindow();
+        const double fps = 4000;
+        const float frametimeMs = (float)(1000.0 / fps);
+        var nowMs = 0.0;
+
+        // Fill the cap and then some, so eviction is by MaxFrames, not by time.
+        for (var i = 0; i < FrameLowsWindow.MaxFrames * 2; i++)
+        {
+            window.Add(nowMs, frametimeMs);
+            nowMs += frametimeMs;
+        }
+
+        Assert.Equal(FrameLowsWindow.MaxFrames, window.FrameCount);
+        // The whole point: the buffer is full but holds less than the threshold.
+        Assert.True(window.TotalMs < 5_000, $"expected a capped span, got {window.TotalMs}ms");
+
+        Assert.True(window.Compute(OnePercent, 5_000) > 0, "1% low blanked on a full buffer");
+        Assert.True(window.Compute(PointOnePercent, 5_000) > 0, "0.1% low blanked on a full buffer");
+        Assert.Equal(fps, window.Compute(OnePercent, 5_000), 0);
+    }
+
     [Fact]
     public void WindowedLows_ReportNothingBeforeTheWarmUpThreshold()
     {

--- a/HardwareMonitor/HardwareMonitor.Tests/HardwareMonitor.Tests.csproj
+++ b/HardwareMonitor/HardwareMonitor.Tests/HardwareMonitor.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\HardwareMonitor\HardwareMonitor.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/HardwareMonitor/HardwareMonitor.Tests/PercentileLowWiringTests.cs
+++ b/HardwareMonitor/HardwareMonitor.Tests/PercentileLowWiringTests.cs
@@ -1,0 +1,203 @@
+using System.Globalization;
+using HardwareMonitor.PresentMon;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace HardwareMonitor.Tests;
+
+/// <summary>
+/// The percentile-low wiring, driven through the real CSV row path.
+///
+/// <see cref="FrameLowsTests"/> covers the arithmetic; this covers the part
+/// around it that only exists in <see cref="PresentMonPoller"/> — which
+/// accumulator a row feeds, what each mode publishes, and whether a frozen run
+/// really stops moving. That wiring is where the reported bug actually lived:
+/// the maths was doing exactly what it was asked to, on the wrong span.
+///
+/// Rows are synthetic PresentMon CSV, so no PresentMon process, no game and no
+/// hardware is involved.
+/// </summary>
+public class PercentileLowWiringTests
+{
+    private const string App = "game.exe";
+
+    /// <summary>
+    /// A poller with its sensors up and <see cref="App"/> selected, but nothing
+    /// started — no PresentMon process, no background loops.
+    /// </summary>
+    private static PresentMonPoller NewPoller()
+    {
+        var poller = new PresentMonPoller(NullLogger.Instance)
+        {
+            OnUpdateApps = () => { }
+        };
+        poller.InitializeSensors();
+        poller.SetSelectedApp(App);
+        return poller;
+    }
+
+    /// <summary>
+    /// One PresentMon CSV row. Only columns 0 (application), 8 (CPUStartTime),
+    /// 9 (FrameTime) and 17 (DisplayedTime) are read; the rest just have to be
+    /// there, because a row under 18 columns is discarded as short.
+    /// </summary>
+    private static string Row(double startMs, double frametimeMs)
+    {
+        var parts = new string[18];
+        for (var i = 0; i < parts.Length; i++) parts[i] = "0";
+        parts[0] = App;
+        parts[8] = startMs.ToString("R", CultureInfo.InvariantCulture);
+        parts[9] = frametimeMs.ToString("R", CultureInfo.InvariantCulture);
+        parts[17] = frametimeMs.ToString("R", CultureInfo.InvariantCulture);
+        return string.Join(",", parts);
+    }
+
+    /// <summary>Feeds a steady framerate, advancing the frame clock.</summary>
+    private static void Feed(PresentMonPoller poller, ref double nowMs, double fps, double seconds)
+    {
+        var frametimeMs = 1000.0 / fps;
+        var frames = (int)Math.Round(fps * seconds);
+        for (var i = 0; i < frames; i++)
+        {
+            poller.ParseData(Row(nowMs, frametimeMs));
+            nowMs += frametimeMs;
+        }
+    }
+
+    /// <summary>
+    /// The reported bug, through the whole path: a game that runs at 60fps and
+    /// then at 240fps must not leave the live 1% low reading 60.
+    ///
+    /// Live is the startup mode, so this is what a user who never touches the
+    /// hotkey sees — which is who reported it.
+    /// </summary>
+    [Fact]
+    public void LiveLows_FollowTheFramerateAfterASuddenChange()
+    {
+        var poller = NewPoller();
+        var nowMs = 0.0;
+
+        Feed(poller, ref nowMs, 60, 30);
+        poller.SetLowsMode(LowsMode.Live);
+        Assert.Equal(60f, poller.OnePercentLow.Value!.Value, 0);
+
+        Feed(poller, ref nowMs, 240, 11);
+        poller.SetLowsMode(LowsMode.Live);
+        Assert.Equal(240f, poller.OnePercentLow.Value!.Value, 0);
+        Assert.Equal(240f, poller.ZeroPointOnePercentLow.Value!.Value, 0);
+    }
+
+    /// <summary>
+    /// A recording run is still cumulative over the whole run, which is the
+    /// point of it — a benchmark that forgot its first thirty seconds would be
+    /// the opposite bug. So the same framerate change that the live reading
+    /// follows must leave the run's figure on the slow phase.
+    /// </summary>
+    [Fact]
+    public void RecordedLows_StayCumulativeAcrossTheSameFramerateChange()
+    {
+        var poller = NewPoller();
+        var nowMs = 0.0;
+
+        poller.SetLowsMode(LowsMode.Recording);
+        Feed(poller, ref nowMs, 60, 30);
+        Feed(poller, ref nowMs, 240, 11);
+
+        poller.SetLowsMode(LowsMode.Frozen);
+        Assert.Equal(60f, poller.OnePercentLow.Value!.Value, 0);
+    }
+
+    /// <summary>
+    /// A frozen run is a result somebody is reading. Frames arriving while it is
+    /// frozen must not move it — not the figure, and not the accumulators
+    /// behind the figure.
+    /// </summary>
+    [Fact]
+    public void FrozenLows_DoNotMoveWhileFramesKeepArriving()
+    {
+        var poller = NewPoller();
+        var nowMs = 0.0;
+
+        poller.SetLowsMode(LowsMode.Recording);
+        Feed(poller, ref nowMs, 60, 30);
+        poller.SetLowsMode(LowsMode.Frozen);
+
+        var frozen = poller.OnePercentLow.Value!.Value;
+        Assert.Equal(60f, frozen, 0);
+
+        Feed(poller, ref nowMs, 240, 60);
+
+        Assert.Equal(frozen, poller.OnePercentLow.Value!.Value);
+    }
+
+    /// <summary>
+    /// Leaving a frozen run returns to a live reading of the CURRENT framerate,
+    /// not the run's. Without this the hotkey would have no way back to a
+    /// number that tracks the game.
+    /// </summary>
+    [Fact]
+    public void LeavingAFrozenRun_ReturnsToALiveReading()
+    {
+        var poller = NewPoller();
+        var nowMs = 0.0;
+
+        poller.SetLowsMode(LowsMode.Recording);
+        Feed(poller, ref nowMs, 60, 30);
+        poller.SetLowsMode(LowsMode.Frozen);
+        Assert.Equal(60f, poller.OnePercentLow.Value!.Value, 0);
+
+        // Back to live, then keep playing at the higher framerate.
+        poller.SetLowsMode(LowsMode.Live);
+        Feed(poller, ref nowMs, 240, 11);
+        poller.SetLowsMode(LowsMode.Live);
+
+        Assert.Equal(240f, poller.OnePercentLow.Value!.Value, 0);
+    }
+
+    /// <summary>
+    /// Starting a run measures from zero rather than inheriting whatever the
+    /// live window had, which is the contract Afterburner's "begin recording"
+    /// has. A run started during a smooth stretch must not already know about
+    /// stutters from before it began.
+    /// </summary>
+    [Fact]
+    public void StartingARun_MeasuresFromZero()
+    {
+        var poller = NewPoller();
+        var nowMs = 0.0;
+
+        Feed(poller, ref nowMs, 60, 30);
+        poller.SetLowsMode(LowsMode.Recording);
+        Feed(poller, ref nowMs, 240, 11);
+        poller.SetLowsMode(LowsMode.Frozen);
+
+        // Only the 240fps frames were in the run.
+        Assert.Equal(240f, poller.OnePercentLow.Value!.Value, 0);
+    }
+
+    /// <summary>
+    /// Frames belonging to another application are not counted, in any mode.
+    /// The lows are attributed the same way the FPS reading is.
+    /// </summary>
+    [Fact]
+    public void LowsIgnoreRowsFromAnotherApplication()
+    {
+        var poller = NewPoller();
+        var nowMs = 0.0;
+
+        Feed(poller, ref nowMs, 240, 11);
+        poller.SetLowsMode(LowsMode.Live);
+        var before = poller.OnePercentLow.Value!.Value;
+        Assert.Equal(240f, before, 0);
+
+        // A second app stuttering badly, for as long again.
+        for (var i = 0; i < 2640; i++)
+        {
+            poller.ParseData(Row(nowMs, 100.0).Replace(App, "other.exe"));
+            nowMs += 100.0;
+        }
+        poller.SetLowsMode(LowsMode.Live);
+
+        Assert.Equal(before, poller.OnePercentLow.Value!.Value);
+    }
+}

--- a/HardwareMonitor/HardwareMonitor.Tests/PercentileLowWiringTests.cs
+++ b/HardwareMonitor/HardwareMonitor.Tests/PercentileLowWiringTests.cs
@@ -131,6 +131,47 @@ public class PercentileLowWiringTests
     }
 
     /// <summary>
+    /// Freezing out of Live freezes the LIVE reading, not the run accumulator.
+    ///
+    /// SetLowsMode publishes off the OUTGOING mode's source for this case: in
+    /// Live the session histogram holds nothing at all, so a freeze that read it
+    /// unconditionally would publish 0 and blank the overlay at the moment the
+    /// user asked to hold the number they were looking at.
+    ///
+    /// Reachable without ever pressing the key twice: pipe_client re-asserts the
+    /// stored mode on every reconnect, and a respawned sidecar starts in Live.
+    /// The other frozen tests all enter from Recording, where the outgoing
+    /// source and the histogram are the same thing, so this is the only test
+    /// that can tell the two apart.
+    /// </summary>
+    [Fact]
+    public void FreezingOutOfLive_HoldsTheLiveReadingNotAnEmptyRun()
+    {
+        var poller = NewPoller();
+        var nowMs = 0.0;
+
+        // Never enters Recording, so _lows is empty for the whole test.
+        Feed(poller, ref nowMs, 240, 30);
+
+        // Publication normally happens on the diagnostics tick, which nothing
+        // starts here, so this is what forces the live window on screen. Live
+        // -> Live only republishes; it clears nothing.
+        poller.SetLowsMode(LowsMode.Live);
+        var live = poller.OnePercentLow.Value!.Value;
+        Assert.Equal(240f, live, 0);
+
+        poller.SetLowsMode(LowsMode.Frozen);
+
+        // The frozen figure is the live one, not 0 off the untouched histogram.
+        Assert.Equal(live, poller.OnePercentLow.Value!.Value);
+        Assert.True(poller.OnePercentLow.Value!.Value > 0);
+
+        // And it stays put while the game keeps running slower.
+        Feed(poller, ref nowMs, 60, 30);
+        Assert.Equal(live, poller.OnePercentLow.Value!.Value);
+    }
+
+    /// <summary>
     /// Leaving a frozen run returns to a live reading of the CURRENT framerate,
     /// not the run's. Without this the hotkey would have no way back to a
     /// number that tracks the game.

--- a/HardwareMonitor/HardwareMonitor.sln
+++ b/HardwareMonitor/HardwareMonitor.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HardwareMonitorTester", "Ha
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Updater", "Updater\Updater.csproj", "{A5991FC1-069F-43D7-8E8D-158D1EE8DE02}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HardwareMonitor.Tests", "HardwareMonitor.Tests\HardwareMonitor.Tests.csproj", "{1F69CC95-7163-4388-A5B3-C68D03FA31B1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{A5991FC1-069F-43D7-8E8D-158D1EE8DE02}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5991FC1-069F-43D7-8E8D-158D1EE8DE02}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A5991FC1-069F-43D7-8E8D-158D1EE8DE02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F69CC95-7163-4388-A5B3-C68D03FA31B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F69CC95-7163-4388-A5B3-C68D03FA31B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F69CC95-7163-4388-A5B3-C68D03FA31B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F69CC95-7163-4388-A5B3-C68D03FA31B1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/HardwareMonitor/HardwareMonitor/HardwareMonitor.csproj
+++ b/HardwareMonitor/HardwareMonitor/HardwareMonitor.csproj
@@ -14,6 +14,13 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- Lets HardwareMonitor.Tests drive PresentMonPoller.ParseData with
+             synthetic PresentMon CSV rows, so the percentile-low wiring is
+             covered and not just the arithmetic classes it calls. -->
+        <InternalsVisibleTo Include="HardwareMonitor.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <!-- PawnIO-based build. WinRing0 was removed upstream (LHM PR #1857) and
              replaced by the PawnIO driver, which Defender does not flag. The
              driver is installed at first launch by the elevated Cleanmeter

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPacketCommand.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPacketCommand.cs
@@ -9,9 +9,16 @@ public enum MonitorPacketCommand : short
     SelectPollingRate = 4,
 
     /// <summary>
-    /// Start (payload 1) or stop (payload 0) accumulating frametimes into the
-    /// percentile-low histogram. Sent by the Rust side when the recording
-    /// hotkey is pressed; see PresentMonPoller.SetLowsRecording.
+    /// Set what the percentile-low readings measure: payload 0 freezes a
+    /// finished run, 1 starts a session-cumulative recording run, 2 returns to
+    /// the rolling live window. Sent by the Rust side when the recording hotkey
+    /// is pressed; see PresentMonPoller.SetLowsMode and LowsMode, whose values
+    /// these are.
+    ///
+    /// 0 and 1 keep the meanings the original boolean payload had, so a client
+    /// and sidecar that disagree by one version still agree about stop and
+    /// start; only 2 is new, and an older sidecar rejects it and stays where it
+    /// was rather than misreading it.
     /// </summary>
-    SetLowsRecording = 5
+    SetLowsMode = 5
 }

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -300,8 +300,8 @@ public class MonitorPoller(
             case MonitorPacketCommand.SelectPollingRate:
                 SelectPollingRate(data);
                 break;
-            case MonitorPacketCommand.SetLowsRecording:
-                SetLowsRecording(data);
+            case MonitorPacketCommand.SetLowsMode:
+                SetLowsMode(data);
                 break;
 
             // server -> client cases 
@@ -312,7 +312,7 @@ public class MonitorPoller(
                 // Logged and dropped, never thrown. This runs on the pipe read
                 // loop, so an exception here takes the pipe down with it and
                 // the client sees "pipe is being closed" — observed for real
-                // when a newer client sent SetLowsRecording (5) to a sidecar
+                // when a newer client sent SetLowsMode (5) to a sidecar
                 // built before that command existed. The two ship together, so
                 // that pairing should not happen, but a partial update or a
                 // failed file replacement is enough to produce it, and losing
@@ -348,22 +348,23 @@ public class MonitorPoller(
         return BitConverter.ToInt16(data, 2);
     }
 
-    private void SetLowsRecording(byte[] data)
+    private void SetLowsMode(byte[] data)
     {
-        if (ReadPayload(data, MonitorPacketCommand.SetLowsRecording) is not { } payload) return;
-        // The protocol defines exactly 1 and 0, so anything else is a
-        // malformed packet rather than a truthy one. Treated as `!= 0`, a
-        // garbled payload of 2 would start a recording run and clear the
-        // histogram, throwing away a finished result the user was reading.
-        // Dropping it costs nothing: the only writer sends 1 or 0.
-        if (payload is not (0 or 1))
+        if (ReadPayload(data, MonitorPacketCommand.SetLowsMode) is not { } payload) return;
+        // The protocol defines exactly 0, 1 and 2, so anything else is a
+        // malformed packet rather than a value to coerce. Cast blindly to the
+        // enum, an out-of-range payload would land on a LowsMode no switch arm
+        // handles, which reads as Frozen at every call site and would silently
+        // stop the readings updating. Dropping it costs nothing: the only
+        // writer sends 0, 1 or 2.
+        if (payload is not (0 or 1 or 2))
         {
             logger.LogWarning(
-                "Dropping SetLowsRecording with payload {Payload}; expected 0 or 1",
+                "Dropping SetLowsMode with payload {Payload}; expected 0, 1 or 2",
                 payload);
             return;
         }
-        _presentMonPoller.SetLowsRecording(payload == 1);
+        _presentMonPoller.SetLowsMode((LowsMode)payload);
     }
 
     private void SelectPollingRate(byte[] data)

--- a/HardwareMonitor/HardwareMonitor/PresentMon/FrameLows.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/FrameLows.cs
@@ -24,18 +24,31 @@
 /// 8ms plus a single 200ms hitch, (3) reads 36.8 fps while (2) reads 5.0 fps,
 /// because one catastrophic frame alone covers the whole 1% time budget.
 ///
-/// Held as a histogram of frametimes rather than a list of them. The window is
-/// the whole session (RTSS's "unlimited" default), and a four-hour session at
-/// 300fps is 4.3M frames, which is not something to keep in a list and re-sort
-/// once a second. Bucketed counts make both memory and compute constant no
-/// matter how long the session runs, and because every frame in a bucket
-/// shares one quantised frametime, walking the histogram from the slow end
-/// gives exactly the answer walking the sorted frames would.
+/// <b>This is the accumulator for an explicitly started recording run, not for
+/// the live overlay reading.</b> Its window is the whole run (RTSS's
+/// "unlimited" default), which is right for a benchmark — every frame between
+/// the two keypresses counts — and unusable as a live figure, because banked
+/// slow frames keep the entire 1% time budget until the fast run is 99x
+/// longer. <see cref="FrameLowsWindow"/> is the live one and carries that
+/// arithmetic. Both compute the same statistic over different spans.
 ///
-/// RTSS bounds the same problem by keeping only the 1024 slowest frames, which
-/// saturates in a long session once those 1024 no longer cover 1% of elapsed
-/// time. The histogram has no such ceiling, so it tracks the definition RTSS
-/// documents rather than reproducing that truncation.
+/// Held as a histogram of frametimes rather than a list of them, because the
+/// span is unbounded: a four-hour session at 300fps is 4.3M frames, which is
+/// not something to keep in a list and re-sort once a second. Bucketed counts
+/// make both memory and compute constant no matter how long the run lasts, and
+/// because every frame in a bucket shares one quantised frametime, walking the
+/// histogram from the slow end gives exactly the answer walking the sorted
+/// frames would.
+///
+/// RTSS bounds the same problem by keeping only the 1024 slowest frames while
+/// still taking the budget from total session time, so the two populations
+/// drift apart and the buffer eventually cannot cover 1% of the session. Its
+/// walk then finds no crossing, and since it only assigns the published figure
+/// when it found one, the reading freezes permanently. (Read off
+/// CFrametimeStats::AppendData in the RTSS SDK, which is the reference
+/// implementation its release notes point at.) The histogram has no such
+/// ceiling — samples and budget are the same population — so it tracks the
+/// definition RTSS documents rather than reproducing that truncation.
 ///
 /// <b>Not thread-safe. Callers must serialize access.</b> Every member mutates
 /// or reads unsynchronised state, and the two callers live on different

--- a/HardwareMonitor/HardwareMonitor/PresentMon/FrameLowsWindow.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/FrameLowsWindow.cs
@@ -165,7 +165,16 @@ public sealed class FrameLowsWindow
     /// <returns>Frames per second, or 0 when the window is too short yet.</returns>
     public float Compute(double fraction, double minTotalMs)
     {
-        if (_frames.Count == 0 || _sumMs < minTotalMs) return 0f;
+        if (_frames.Count == 0) return 0f;
+        // A full buffer counts as warmed up even when it holds less than
+        // minTotalMs. MaxFrames caps the window at 16,384 frames, which is
+        // 4,096ms at 4,000fps — under the poller's 5,000ms threshold — so above
+        // ~3,277fps the sum can never reach it and the reading would stay 0
+        // forever. An uncapped menu is exactly that fast, and it is the case
+        // the MaxFrames comment above cites. A full buffer is all the data this
+        // window will ever hold, so refusing to report from it reports nothing
+        // at all rather than reporting from a shorter span.
+        if (_sumMs < minTotalMs && _frames.Count < MaxFrames) return 0f;
         if (fraction <= 0 || fraction > 1) return 0f;
 
         var budgetMs = _sumMs * fraction;

--- a/HardwareMonitor/HardwareMonitor/PresentMon/FrameLowsWindow.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/FrameLowsWindow.cs
@@ -1,0 +1,212 @@
+﻿namespace HardwareMonitor.PresentMon;
+
+/// <summary>
+/// Percentile-low framerates over a ROLLING WINDOW of recent frames, for the
+/// always-on overlay reading.
+///
+/// This is the counterpart to <see cref="FrameLows"/>, which measures a whole
+/// session. Both compute the same statistic — RTSS's integral percentile, the
+/// frametime at which the slowest frames have used up 1% (or 0.1%) of the
+/// measured time — and they differ only in what "the measured time" is.
+///
+/// <b>Why this exists.</b> A session-length window cannot report a recovery.
+/// The slow frames it has already banked keep owning the whole 1% budget until
+/// the fast run is long enough to dilute them, and the arithmetic is brutal:
+/// the reading is pinned until
+///
+///     T_fast &gt; T_slow * (1 / fraction - 1)
+///
+/// which is 99x the slow phase for a 1% low and 999x for a 0.1% low. Thirty
+/// seconds capped at 60fps therefore pins the 1% low at 60 for the next 49
+/// minutes of 240fps play, and pins the 0.1% low for over eight hours. Drops
+/// land on the next poll but recoveries effectively never do, so the number
+/// only ever ratchets downward and reads as frozen.
+///
+/// MSI Afterburner has the same problem and the same fix. RTSS's "Percentile
+/// buffer" option switches its lows between an unlimited buffer and a rolling
+/// ring, and its own documentation says which is which:
+///
+///   "Unlimited mode is preferred if you manually start benchmarking session
+///    with a hotkey. Ring mode can be preferred if you permanently keep the
+///    benchmark mode enabled and want to see 1% and 0.1% low metrics
+///    reflecting just a few last seconds of gameplay."
+///
+/// Cleanmeter's overlay pill is the second case — permanently on, from launch
+/// — so the live reading is a ring and only an explicitly started run is
+/// unlimited. That is Afterburner's split, not one invented here.
+///
+/// <b>The part that actually matters.</b> Bounding the SAMPLES is not the fix
+/// on its own; the budget has to come from the same window. RTSS's unlimited
+/// mode keeps the 1024 slowest frames of the session but takes the budget from
+/// total session time, and the two populations drift apart until the buffer
+/// can no longer cover 1% of the session — at which point its loop finds no
+/// crossing at all, leaves the published figure untouched and stays frozen for
+/// good. (Verified against Unwinder's own reference implementation, shipped as
+/// CFrametimeStats in the RTSS SDK.) So <see cref="Compute"/> derives the
+/// budget from <see cref="TotalMs"/>, which is the sum of the frames still in
+/// the window and nothing else. Window in, window out.
+///
+/// <b>Not thread-safe. Callers must serialize access.</b> Same contract as
+/// <see cref="FrameLows"/> and for the same reason: <c>Add</c> runs on
+/// PresentMon's output callback thread while <c>Compute</c> and <c>Clear</c>
+/// run on the diagnostics loop, and both callers hold
+/// <c>PresentMonPoller._stateLock</c>.
+/// </summary>
+public sealed class FrameLowsWindow
+{
+    /// <summary>
+    /// How much recent frame time the window holds.
+    ///
+    /// This is the worst-case staleness of the reading, and there is no way to
+    /// make it smaller than the window: a phase change is a step, not a glide,
+    /// because the old phase keeps more than 1% of the window's time until
+    /// almost all of it has aged out. A 10s window is pinned for ~9.9s and
+    /// then moves.
+    ///
+    /// 10s rather than RTSS's 1024 frames. RTSS counts frames because 1024 is
+    /// the size of the shared-memory buffer it exports, and that makes its
+    /// window 4.3s at 240fps but 17s at 60fps — the reading recovers at a
+    /// different speed depending on how fast the game is running, which is the
+    /// one property this fix exists to remove. Ten seconds sits inside the
+    /// range RTSS spans at real framerates and behaves the same at both ends
+    /// of it.
+    /// </summary>
+    public const double DefaultWindowMs = 10_000;
+
+    /// <summary>
+    /// Hard cap on retained frames, independent of the window.
+    ///
+    /// The window is a duration, so the frame count it implies scales with
+    /// framerate: 10s is 2,400 frames at 240fps but 40,000 in a menu running
+    /// uncapped at 4,000fps. The cap keeps both the queue and the per-poll
+    /// sort bounded there. 16,384 frames is 10s at 1,638fps, so any workload
+    /// fast enough to hit it gets a shorter window on frames so uniform that
+    /// the 1% budget still spans hundreds of them.
+    /// </summary>
+    public const int MaxFrames = 16_384;
+
+    private readonly Queue<(double startTimeMs, float intervalMs)> _frames = new();
+    private readonly double _windowMs;
+    private double _sumMs;
+    // PresentMon's own CPUStartTime, monotonic ms since capture start. Game
+    // time rather than wall clock, matching the 1s Presented/Displayed windows
+    // in PresentMonPoller: ETW delivers rows in bursts, so trimming on arrival
+    // time would evict a burst's own frames against each other.
+    private double _latestStartTimeMs;
+    // Reused across polls so a once-per-second Compute does not hand the GC a
+    // multi-thousand-element array every time. Grown, never shrunk.
+    private float[] _sorted = new float[1024];
+
+    public FrameLowsWindow(double windowMs = DefaultWindowMs)
+    {
+        _windowMs = windowMs > 0 ? windowMs : DefaultWindowMs;
+    }
+
+    /// <summary>Frames currently inside the window.</summary>
+    public int FrameCount => _frames.Count;
+
+    /// <summary>Total frame time currently inside the window, in ms.</summary>
+    public double TotalMs => _sumMs;
+
+    /// <summary>
+    /// Record one frame, then evict everything that has aged out.
+    /// </summary>
+    /// <param name="startTimeMs">PresentMon CPUStartTime for this frame.</param>
+    /// <param name="intervalMs">Present-to-present interval, in ms.</param>
+    public void Add(double startTimeMs, float intervalMs)
+    {
+        // Same rejection as FrameLows.Add and for the same reason: float
+        // parsing yields PositiveInfinity for an overflowing CSV field like
+        // "1e40", and letting one into _sumMs makes the sum non-finite
+        // permanently — the eviction subtraction can never bring it back, so
+        // every later reading is NaN rather than just this frame's.
+        if (!float.IsFinite(intervalMs) || intervalMs <= 0) return;
+        if (!double.IsFinite(startTimeMs)) return;
+
+        if (startTimeMs > _latestStartTimeMs) _latestStartTimeMs = startTimeMs;
+
+        _frames.Enqueue((startTimeMs, intervalMs));
+        _sumMs += intervalMs;
+
+        while (_frames.Count > 0
+               && (_latestStartTimeMs - _frames.Peek().startTimeMs > _windowMs
+                   || _frames.Count > MaxFrames))
+        {
+            _sumMs -= _frames.Dequeue().intervalMs;
+        }
+
+        // Floating-point drift only, not a correctness guard: _sumMs is a
+        // running add-and-subtract over millions of frames, so it can land a
+        // hair off zero once the queue empties. Left alone it would make the
+        // next budget negative and Compute would answer with the fastest frame
+        // in the window instead of the slowest.
+        if (_frames.Count == 0) _sumMs = 0;
+    }
+
+    /// <summary>Forget the window (app switch, or the game is gone).</summary>
+    public void Clear()
+    {
+        _frames.Clear();
+        _sumMs = 0;
+        _latestStartTimeMs = 0;
+    }
+
+    /// <summary>
+    /// The percentile low over the current window, in frames per second.
+    /// </summary>
+    /// <param name="fraction">0.01 for a 1% low, 0.001 for a 0.1% low.</param>
+    /// <param name="minTotalMs">
+    /// Refuse to report until the window holds this much frame time, so the
+    /// figure does not swing wildly over its first second. Returns 0 below the
+    /// threshold, the same "nothing to show" convention the Presented and
+    /// Displayed sensors use. Must be shorter than the window, or the reading
+    /// never appears at all.
+    /// </param>
+    /// <returns>Frames per second, or 0 when the window is too short yet.</returns>
+    public float Compute(double fraction, double minTotalMs)
+    {
+        if (_frames.Count == 0 || _sumMs < minTotalMs) return 0f;
+        if (fraction <= 0 || fraction > 1) return 0f;
+
+        var budgetMs = _sumMs * fraction;
+        if (budgetMs <= 0) return 0f;
+
+        var count = _frames.Count;
+        if (_sorted.Length < count) _sorted = new float[Math.Max(count, _sorted.Length * 2)];
+
+        var i = 0;
+        foreach (var (_, intervalMs) in _frames) _sorted[i++] = intervalMs;
+
+        // Ascending, then walked from the back. Array.Sort has no descending
+        // overload that does not either allocate a comparer or pay
+        // Comparison<T> indirection on every comparison, and this runs on the
+        // diagnostics tick over a few thousand floats.
+        Array.Sort(_sorted, 0, count);
+
+        double accumulated = 0;
+        for (var index = count - 1; index >= 0; index--)
+        {
+            var frametimeMs = _sorted[index];
+            accumulated += frametimeMs;
+
+            // `>=` walking from the slow end is exactly equivalent to the
+            // strict `>` RTSS's ring mode applies walking from the fast end
+            // (CalcIntegralRank in the SDK's OverlayDataSource.cpp), ties
+            // included: the two were checked against 18 constructed exact ties
+            // and 4,000 random sessions with zero disagreements. Ring is the
+            // half to match here, since it is the mode RTSS's own docs prefer
+            // for a permanently-enabled overlay.
+            //
+            // FrameLows is the one that parts from CFrametimeStats (RTSS's
+            // unlimited mode), which skips to the next faster frame on a tie.
+            // Only on an exact tie, which its bucket arithmetic did not produce
+            // once across 200,000 simulated sessions.
+            if (accumulated >= budgetMs)
+            {
+                return frametimeMs > 0 ? (float)(1000.0 / frametimeMs) : 0f;
+            }
+        }
+
+        return 0f;
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/PresentMon/LowsMode.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/LowsMode.cs
@@ -1,0 +1,49 @@
+namespace HardwareMonitor.PresentMon;
+
+/// <summary>
+/// What the 1% / 0.1% low readings are currently measuring.
+///
+/// These are MSI Afterburner's two answers to the same question, kept apart
+/// because they are genuinely different statistics and a single one cannot do
+/// both jobs. RTSS exposes the choice as its "Percentile buffer" option and
+/// documents when each is wanted: unlimited "if you manually start
+/// benchmarking session with a hotkey", ring "if you permanently keep the
+/// benchmark mode enabled and want to see 1% and 0.1% low metrics reflecting
+/// just a few last seconds of gameplay".
+///
+/// The overlay pill is on from launch, so <see cref="Live"/> is the default
+/// and <see cref="Recording"/> is what the hotkey opts into. See
+/// <see cref="FrameLowsWindow"/> for why a session-length window cannot serve
+/// as a live reading.
+///
+/// Wire values are the payload of <c>MonitorPacketCommand.SetLowsMode</c> and
+/// are load-bearing: 0 and 1 keep the meanings the older boolean payload had
+/// (0 stop, 1 start), so a sidecar and a client that disagree by one version
+/// still agree about those two.
+/// </summary>
+public enum LowsMode
+{
+    /// <summary>
+    /// A finished run, held on screen. Nothing accumulates and nothing is
+    /// published, so the figures stay exactly as the run left them — a user
+    /// who stopped to read a benchmark keeps that number while they alt-tab
+    /// away, quit the game, or pick another app in the dropdown.
+    /// </summary>
+    Frozen = 0,
+
+    /// <summary>
+    /// An explicitly started benchmark run: session-cumulative from the moment
+    /// the hotkey was pressed, over every frame since. This is the figure that
+    /// belongs in a benchmark result, and the one that agrees with RTSS's
+    /// default unlimited buffer.
+    /// </summary>
+    Recording = 1,
+
+    /// <summary>
+    /// The always-on live reading: a rolling window of the last few seconds,
+    /// so it tracks what the game is doing NOW and recovers from a framerate
+    /// change within the window rather than staying pinned to the worst phase
+    /// of the whole session.
+    /// </summary>
+    Live = 2
+}

--- a/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
@@ -100,15 +100,24 @@ public class PresentMonPoller(ILogger logger)
     private double _latestStartTimeMs;
     private long _lastRowArrivalMs;
 
-    // Percentile lows (1% / 0.1%) accumulate over the whole session rather
-    // than the 1s window above, which holds ~120 frames at 120fps and so has
-    // no meaningful "worst 1%" at all. Session-length is also what RTSS / MSI
-    // Afterburner use by default ("unlimited"), and matching the overlay most
-    // of our users already run matters more than any window we could pick:
-    // the common way someone sanity-checks this number is to run both at once.
+    // Percentile lows (1% / 0.1%) need a longer window than the 1s one above,
+    // which holds ~120 frames at 120fps and so has no meaningful "worst 1%" at
+    // all. There are two of them because MSI Afterburner has two, for the two
+    // different questions being asked (see LowsMode):
     //
-    // See FrameLows for why this is a histogram and not a list of frametimes,
-    // and for which of the three competing "1% low" definitions it implements.
+    //   _lowsLive   rolling ~10s window, the always-on overlay reading
+    //   _lows       session-cumulative, an explicitly started benchmark run
+    //
+    // The live one is not a nicety. A session-cumulative figure cannot report
+    // a recovery: banked slow frames keep the whole 1% time budget until the
+    // fast run is 99x longer, so 30s capped at 60fps pins the 1% low at 60 for
+    // the next 49 minutes of 240fps play. FrameLowsWindow has the arithmetic
+    // and the RTSS documentation that says to use a ring for a permanently-on
+    // reading.
+    //
+    // See FrameLows for why the session one is a histogram and not a list of
+    // frametimes, and for which of the three competing "1% low" definitions
+    // both implement.
     private const double ONE_PERCENT = 0.01;
     private const double ZERO_POINT_ONE_PERCENT = 0.001;
     private const double LOWS_MIN_TOTAL_MS = 5_000;
@@ -119,22 +128,28 @@ public class PresentMonPoller(ILogger logger)
     // leaving a dead game's lows on screen at the desktop.
     private const int LOWS_ABANDON_MS = 30_000;
     private readonly FrameLows _lows = new();
+    private readonly FrameLowsWindow _lowsLive = new();
     // The app whose frames are currently in the histogram. See the reset guard
     // in ParseData for why attribution is tracked here rather than inferred
     // from the selection or the foreground.
     private string _lowsApp = "";
-    // Whether a recording run is accumulating. True at startup, which is the
-    // unbounded-from-launch behaviour this had before the hotkey existed: a
-    // user who never binds the key sees no change at all.
+    // What the published figures are measuring. Live at startup: the overlay
+    // pill is on from launch, and RTSS's own guidance for a permanently-on
+    // reading is a rolling window rather than an unbounded one.
     //
-    // While false the histogram is inert — ParseData does not add to it, the
-    // diagnostics loop does not recompute from it, and neither the app-change
-    // guard nor the LOWS_ABANDON_MS sweep clears it. That inertness is the
-    // point: a stopped run is a result, and alt-tabbing to look at it, or
-    // quitting the game it measured, must not wipe the number being read.
-    // Only an explicit start clears it. Guarded by _stateLock like every other
-    // field here.
-    private bool _lowsRecording = true;
+    // While Frozen both accumulators are inert — ParseData does not add to
+    // them, the diagnostics loop does not recompute from them, and neither the
+    // app-change guard nor the LOWS_ABANDON_MS sweep clears them. That
+    // inertness is the point: a stopped run is a result, and alt-tabbing to
+    // look at it, or quitting the game it measured, must not wipe the number
+    // being read. Only an explicit mode change moves off it.
+    //
+    // While Recording the live window keeps filling even though nothing reads
+    // it, so returning to Live shows a current number immediately instead of
+    // blanking for the warm-up. It costs one enqueue per frame.
+    //
+    // Guarded by _stateLock like every other field here.
+    private LowsMode _lowsMode = LowsMode.Live;
 
     // FPS diagnostics. Counters live under _stateLock alongside the other
     // attribution state. Rollup task logs once per FPS_DIAG_WINDOW_MS so the
@@ -184,22 +199,31 @@ public class PresentMonPoller(ILogger logger)
     // absent text file became a permanent once-a-second crash loop rather than a
     // degraded feature. The existing guard inside RunPresentMonAsync only ever
     // covered the work after this point.
+    // Split out of Start so the sensors and the CSV number format can be set up
+    // without spawning PresentMon, which is what HardwareMonitor.Tests needs to
+    // drive ParseData directly. Start's behaviour is unchanged: this is the
+    // first thing it does.
+    internal void InitializeSensors()
+    {
+        _cultureInfo.NumberFormat.NumberDecimalSeparator = ".";
+
+        Displayed = new PresentMonSensor(_hardware, "displayed", 0, "Displayed Frames");
+        Presented = new PresentMonSensor(_hardware, "presented", 1, "Presented Frames");
+        Frametime = new PresentMonSensor(_hardware, "frametime", 2, "Frametime");
+        // Spelled out rather than "1% Low": MonitorPoller.RemoveSpecialCharacters
+        // rewrites anything outside [a-zA-Z0-9_ .] to an underscore before the
+        // name goes on the wire, so "1% Low" would reach the sensor picker as
+        // "1_ Low". The overlay resolves these by identifier, but the picker
+        // shows the name.
+        OnePercentLow = new PresentMonSensor(_hardware, "onepercentlow", 3, "1 Percent Low");
+        ZeroPointOnePercentLow = new PresentMonSensor(_hardware, "zeropointonepercentlow", 4, "0.1 Percent Low");
+    }
+
     public async Task Start(CancellationToken stoppingToken)
     {
         try
         {
-            _cultureInfo.NumberFormat.NumberDecimalSeparator = ".";
-
-            Displayed = new PresentMonSensor(_hardware, "displayed", 0, "Displayed Frames");
-            Presented = new PresentMonSensor(_hardware, "presented", 1, "Presented Frames");
-            Frametime = new PresentMonSensor(_hardware, "frametime", 2, "Frametime");
-            // Spelled out rather than "1% Low": MonitorPoller.RemoveSpecialCharacters
-            // rewrites anything outside [a-zA-Z0-9_ .] to an underscore before the
-            // name goes on the wire, so "1% Low" would reach the sensor picker as
-            // "1_ Low". The overlay resolves these by identifier, but the picker
-            // shows the name.
-            OnePercentLow = new PresentMonSensor(_hardware, "onepercentlow", 3, "1 Percent Low");
-            ZeroPointOnePercentLow = new PresentMonSensor(_hardware, "zeropointonepercentlow", 4, "0.1 Percent Low");
+            InitializeSensors();
 
             // Resolve the foreground app once, synchronously, before PresentMon
             // starts emitting rows. Without this, the first ~500ms of CSV output
@@ -398,7 +422,12 @@ public class PresentMonPoller(ILogger logger)
         }
     }
 
-    private void ParseData(string? argsData)
+    // internal, not private, so HardwareMonitor.Tests can drive the real row
+    // path with synthetic PresentMon CSV rows. The percentile-low wiring —
+    // which accumulator a row feeds, the app-change guard, what each mode
+    // publishes — only exists here, and a unit test of the accumulators alone
+    // cannot see any of it.
+    internal void ParseData(string? argsData)
     {
         if (argsData == null) return;
         var parts = argsData.Split(",");
@@ -520,16 +549,22 @@ public class PresentMonPoller(ILogger logger)
             // the histogram under its warm-up so the overlay shows nothing,
             // which is the right outcome when attribution is genuinely
             // ambiguous: no reading beats a blended one.
-            if (_lowsRecording)
+            if (_lowsMode != LowsMode.Frozen)
             {
                 if (!string.Equals(_lowsApp, rowApp, StringComparison.OrdinalIgnoreCase))
                 {
                     _lows.Clear();
+                    _lowsLive.Clear();
                     OnePercentLow.Value = 0;
                     ZeroPointOnePercentLow.Value = 0;
                     _lowsApp = rowApp;
                 }
-                _lows.Add(ftMs);
+                // Both are fed whenever frames are being counted, even though
+                // only one of them is read (see _lowsMode). The session
+                // histogram is only meaningful for a run that was explicitly
+                // started, so it is the one gated on the mode.
+                _lowsLive.Add(startMs, ftMs);
+                if (_lowsMode == LowsMode.Recording) _lows.Add(ftMs);
             }
 
             // Displayed FPS uses the display-to-display interval (column
@@ -579,54 +614,110 @@ public class PresentMonPoller(ILogger logger)
     }
 
     /// <summary>
-    /// Start or stop a percentile-low recording run.
+    /// Switch what the percentile lows are measuring. See <see cref="LowsMode"/>.
     ///
-    /// Start clears the histogram and zeroes the published figures, so a run
-    /// always measures from zero — the same contract MSI Afterburner's "begin
-    /// recording" has. Stop computes the run's final figures and freezes both
-    /// them and the histogram; see the <c>_lowsRecording</c> field for what
-    /// else stands down while stopped.
+    /// <c>Recording</c> clears the histogram and zeroes the published figures,
+    /// so a run always measures from zero — the same contract MSI Afterburner's
+    /// "begin recording" has. <c>Frozen</c> computes the final figures off
+    /// whatever the outgoing mode was reading and freezes them. <c>Live</c>
+    /// publishes the rolling window straight away rather than leaving a
+    /// finished run's figures on screen until the next diagnostics tick.
     ///
-    /// Idempotent: starting an already-running recording still clears, which
-    /// is what a user pressing the key twice by accident at the start line
-    /// wants. Stopping an already-stopped one recomputes the same figures off
-    /// the same frozen histogram, so it is a no-op in effect. Only the pipe
-    /// reconnect in pipe_client.rs actually does that.
+    /// Idempotent in the ways that matter: starting an already-running
+    /// recording still clears, which is what a user pressing the key twice by
+    /// accident at the start line wants, and re-freezing an already-frozen run
+    /// recomputes the same figures off the same frozen histogram. Only the pipe
+    /// reconnect in pipe_client.rs actually does the latter.
     /// </summary>
-    public void SetLowsRecording(bool recording)
+    public void SetLowsMode(LowsMode mode)
     {
         lock (_stateLock)
         {
-            if (recording)
+            switch (mode)
             {
-                _lows.Clear();
-                // Cleared too, so the first row of the new run re-attributes
-                // through ParseData's guard rather than continuing to count
-                // against whatever app the last run measured.
-                _lowsApp = "";
-                OnePercentLow.Value = 0;
-                ZeroPointOnePercentLow.Value = 0;
+                case LowsMode.Recording:
+                    _lows.Clear();
+                    // Cleared too, so the first row of the new run re-attributes
+                    // through ParseData's guard rather than continuing to count
+                    // against whatever app the last run measured. That guard
+                    // also drops the live window, which is the right trade: it
+                    // refills inside its own window and nothing reads it during
+                    // a run anyway.
+                    _lowsApp = "";
+                    OnePercentLow.Value = 0;
+                    ZeroPointOnePercentLow.Value = 0;
+                    break;
+
+                case LowsMode.Frozen:
+                    // Publish once more BEFORE freezing. The diagnostics loop
+                    // recomputes on a FPS_DIAG_WINDOW_MS tick, so the figure
+                    // standing when the key is pressed is up to a second old and
+                    // the last second of the run — 1.7% of a 60s benchmark, and
+                    // the part most likely to hold the frames the user was
+                    // watching for — would never reach the number they stopped to
+                    // read. Afterburner computes its result at end-of-recording;
+                    // so does this.
+                    //
+                    // Off the OUTGOING mode's source, not unconditionally off the
+                    // histogram: freezing from Live has to freeze the number the
+                    // user was actually looking at, and the histogram holds
+                    // nothing at all in that case.
+                    PublishLows(_lowsMode);
+                    break;
+
+                case LowsMode.Live:
+                    // Straight away, so leaving a finished run does not leave
+                    // its figures standing for up to a second while the live
+                    // reading is already available — the window kept filling
+                    // throughout the run.
+                    //
+                    // Not cleared first, even though a long freeze leaves stale
+                    // frames in it. FrameLowsWindow is indexed on PresentMon's
+                    // CPUStartTime and evicts on every Add, so the first frame
+                    // after unfreezing carries a timestamp far enough ahead to
+                    // drop the whole stale window in one pass — microseconds
+                    // later, at any framerate. Clearing here would instead
+                    // blank the reading for the warm-up in the common case,
+                    // which is a user unfreezing WHILE still playing, where the
+                    // window is seconds old and perfectly good. If the game is
+                    // gone there are no new frames either way, and the
+                    // LOWS_ABANDON_MS sweep — live again the moment this stops
+                    // being Frozen — clears it within 30s.
+                    PublishLows(LowsMode.Live);
+                    break;
             }
-            else
-            {
-                // Publish once more BEFORE freezing. The diagnostics loop
-                // recomputes on a FPS_DIAG_WINDOW_MS tick, so the figure
-                // standing when the key is pressed is up to a second old and
-                // the last second of the run — 1.7% of a 60s benchmark, and
-                // the part most likely to hold the frames the user was
-                // watching for — would never reach the number they stopped to
-                // read. Afterburner computes its result at end-of-recording;
-                // so does this.
+
+            _lowsMode = mode;
+        }
+
+        logger.LogInformation("Percentile-low mode {Mode}", mode);
+    }
+
+    /// <summary>
+    /// Recompute and publish the two low figures from whichever accumulator
+    /// <paramref name="source"/> names. No-op for <see cref="LowsMode.Frozen"/>,
+    /// which is what makes "frozen" true of the published values and not just
+    /// of their inputs.
+    ///
+    /// Caller must hold <c>_stateLock</c>: it writes
+    /// <c>PresentMonSensor.Value</c> (a <c>float?</c>, so a torn read is
+    /// possible) on the same lock the pipe serializer takes.
+    /// </summary>
+    private void PublishLows(LowsMode source)
+    {
+        switch (source)
+        {
+            case LowsMode.Live:
+                OnePercentLow.Value = _lowsLive.Compute(ONE_PERCENT, LOWS_MIN_TOTAL_MS);
+                ZeroPointOnePercentLow.Value =
+                    _lowsLive.Compute(ZERO_POINT_ONE_PERCENT, LOWS_MIN_TOTAL_MS);
+                break;
+            case LowsMode.Recording:
                 OnePercentLow.Value = _lows.Compute(ONE_PERCENT, LOWS_MIN_TOTAL_MS);
                 ZeroPointOnePercentLow.Value =
                     _lows.Compute(ZERO_POINT_ONE_PERCENT, LOWS_MIN_TOTAL_MS);
-            }
-            _lowsRecording = recording;
+                break;
         }
-
-        logger.LogInformation(
-            "Percentile-low recording {State}",
-            recording ? "started" : "stopped");
     }
 
     public void SetSelectedApp(string appName)
@@ -653,9 +744,10 @@ public class PresentMonPoller(ILogger logger)
             // Picking another app in the dropdown to read its name, with a
             // benchmark frozen on the overlay, must not throw the benchmark
             // away.
-            if (_lowsRecording)
+            if (_lowsMode != LowsMode.Frozen)
             {
                 _lows.Clear();
+                _lowsLive.Clear();
                 _lowsApp = "";
                 OnePercentLow.Value = 0;
                 ZeroPointOnePercentLow.Value = 0;
@@ -853,10 +945,11 @@ public class PresentMonPoller(ILogger logger)
                     // out. It is dropped only once the game has been gone for
                     // LOWS_ABANDON_MS, so the desktop doesn't sit there
                     // showing a closed game's lows.
-                    if (_lowsRecording
+                    if (_lowsMode != LowsMode.Frozen
                         && (_lastRowArrivalMs == 0 || wallNow - _lastRowArrivalMs > LOWS_ABANDON_MS))
                     {
                         _lows.Clear();
+                        _lowsLive.Clear();
                         _lowsApp = "";
                         OnePercentLow.Value = 0;
                         ZeroPointOnePercentLow.Value = 0;
@@ -886,29 +979,26 @@ public class PresentMonPoller(ILogger logger)
                 fps = Presented.Value ?? 0f;
                 ft = Frametime.Value ?? 0f;
                 // Computed under the lock rather than on a snapshot taken out
-                // of it. The walk starts at the slowest frame recorded and
-                // stops at the 1% crossing, so it reads a few thousand bucket
-                // counts and takes microseconds — nothing like sorting a
-                // session's frametimes, which the histogram means never
-                // happens. Publishing here also keeps the write to
-                // PresentMonSensor.Value (a float?, so a torn read is
+                // of it. In Recording the walk starts at the slowest frame
+                // recorded and stops at the 1% crossing, so it reads a few
+                // thousand bucket counts and takes microseconds — nothing like
+                // sorting a session's frametimes, which the histogram means
+                // never happens. In Live it sorts the window, which is a few
+                // thousand floats once per tick. Publishing here also keeps the
+                // write to PresentMonSensor.Value (a float?, so a torn read is
                 // possible) on the same lock the pipe serializer takes.
                 //
                 // Deliberately outside the stale/else split above: when rows
-                // have merely paused, the session's frames are still there and
-                // the lows should keep reporting rather than blank out with
-                // the 1s averages.
-                // Skipped entirely while stopped rather than recomputed from a
-                // frozen histogram: the two are the same number today, but
+                // have merely paused, the frames already measured are still
+                // there and the lows should keep reporting rather than blank
+                // out with the 1s averages.
+                //
+                // Skipped entirely while Frozen rather than recomputed from a
+                // frozen accumulator: the two are the same number today, but
                 // leaving the write out is what makes "frozen" true of the
                 // published value and not just of its inputs.
-                if (_lowsRecording)
-                {
-                    OnePercentLow.Value = _lows.Compute(ONE_PERCENT, LOWS_MIN_TOTAL_MS);
-                    ZeroPointOnePercentLow.Value =
-                        _lows.Compute(ZERO_POINT_ONE_PERCENT, LOWS_MIN_TOTAL_MS);
-                }
-                lowsFrames = _lows.FrameCount;
+                PublishLows(_lowsMode);
+                lowsFrames = _lowsMode == LowsMode.Live ? _lowsLive.FrameCount : _lows.FrameCount;
             }
             var countedStr = counted.Count == 0
                 ? "-"

--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -44,10 +44,11 @@ pub enum PipeCommand {
     RefreshPresentMonApps,
     SelectPresentMonApp(String),
     SelectPollingRate(u16),
-    /// Start (true) or stop (false) accumulating frametimes into the
-    /// percentile-low histogram. Start clears what is there; stop computes a
-    /// final figure and freezes it. See MonitorPacketCommand.SetLowsRecording.
-    SetLowsRecording(bool),
+    /// Set what the percentile lows measure: 0 freezes a finished run, 1
+    /// starts a session-cumulative recording run, 2 returns to the rolling
+    /// live window. See MonitorPacketCommand.SetLowsMode and the C# LowsMode,
+    /// whose values these are, and shortcuts::LowsMode for this side's copy.
+    SetLowsMode(u8),
 }
 
 /// Parse a Data packet (command 0) from raw bytes
@@ -229,9 +230,9 @@ fn build_command(cmd: &PipeCommand) -> Vec<u8> {
         // u16 payload rather than a byte: every other command in this
         // protocol is u16-aligned, and the C# reader indexes fixed offsets
         // (BitConverter.ToInt16(data, 2)) rather than reading a stream.
-        PipeCommand::SetLowsRecording(recording) => {
+        PipeCommand::SetLowsMode(mode) => {
             buf.write_u16::<LittleEndian>(5).unwrap();
-            buf.write_u16::<LittleEndian>(u16::from(*recording)).unwrap();
+            buf.write_u16::<LittleEndian>(u16::from(*mode)).unwrap();
         }
     }
     buf
@@ -321,20 +322,24 @@ pub async fn run_pipe_client(
                         continue;
                     }
                 };
-                // Re-assert the recording state on every connect.
+                // Re-assert the lows mode on every connect.
                 //
                 // A sidecar that crashes is respawned by the supervisor in
-                // lib.rs within ~1s, and it comes back with its histogram
-                // recording (that is its startup default). Without this, a
-                // stopped run — a benchmark result somebody is reading —
-                // would quietly start moving again the moment the sidecar
-                // bounced, and nothing on screen would say why. Only sent
-                // when stopped: the fresh sidecar already agrees otherwise.
+                // lib.rs within ~1s, and it comes back on the rolling live
+                // window (that is its startup default). Without this, a
+                // frozen run — a benchmark result somebody is reading — would
+                // quietly start moving again the moment the sidecar bounced,
+                // and a run still in progress would silently become a live
+                // reading mid-benchmark. Neither says anything on screen.
+                //
+                // Skipped for Live: the fresh sidecar already agrees, so
+                // there is nothing to correct.
                 if let Some(state) = app.try_state::<crate::shortcuts::ShortcutRegistry>() {
-                    if !state.is_recording() {
-                        let bytes = build_command(&PipeCommand::SetLowsRecording(false));
+                    let mode = state.lows_mode();
+                    if mode != crate::shortcuts::LowsMode::Live {
+                        let bytes = build_command(&PipeCommand::SetLowsMode(mode.wire()));
                         if let Err(e) = writer.write_all(&bytes) {
-                            warn!("Could not re-assert the stopped recording state: {}", e);
+                            warn!("Could not re-assert the {:?} lows mode: {}", mode, e);
                         }
                     }
                 }
@@ -488,6 +493,7 @@ fn read_u32<R: Read>(reader: &mut R) -> io::Result<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shortcuts::LowsMode;
 
     /// The measured shape of the bug. Sidecar startup, from process start to the
     /// pipe existing, ran to 13.7s across 114 logged launches, with the app then
@@ -529,6 +535,33 @@ mod tests {
     #[test]
     fn the_poll_interval_bounds_the_remaining_delay() {
         assert!(FAST_POLL_INTERVAL <= Duration::from_millis(300));
+    }
+
+    /// The lows-mode payload is the whole protocol for the recording hotkey, and
+    /// the sidecar drops anything outside 0..=2 rather than coercing it, so a
+    /// wrong byte here is a key that silently does nothing. Command id 5 and a
+    /// u16 little-endian payload, matching MonitorPacketCommand.SetLowsMode.
+    #[test]
+    fn the_lows_mode_command_is_id_five_and_a_u16_payload() {
+        for mode in [LowsMode::Frozen, LowsMode::Recording, LowsMode::Live] {
+            let bytes = build_command(&PipeCommand::SetLowsMode(mode.wire()));
+            assert_eq!(
+                bytes,
+                vec![5, 0, mode.wire(), 0],
+                "wire bytes for {:?}",
+                mode
+            );
+        }
+    }
+
+    /// Shared with the sidecar's LowsMode enum. 0 and 1 keep the meanings the
+    /// earlier boolean payload had, so a client and sidecar one version apart
+    /// still agree about stop and start.
+    #[test]
+    fn the_lows_mode_wire_values_are_fixed() {
+        assert_eq!(LowsMode::Frozen.wire(), 0);
+        assert_eq!(LowsMode::Recording.wire(), 1);
+        assert_eq!(LowsMode::Live.wire(), 2);
     }
 
     /// Builds a Data payload the way MonitorPoller writes one: both counts, then

--- a/tauri-app/src-tauri/src/shortcuts.rs
+++ b/tauri-app/src-tauri/src/shortcuts.rs
@@ -9,21 +9,32 @@
 //!
 //! ## The recording run
 //!
-//! The 1% / 0.1% low figures accumulate from launch and never stop — the
-//! histogram in the sidecar's `PresentMonPoller` is cleared only when the
-//! monitored app changes or the game has been gone for 30s. That is RTSS's
-//! "unlimited" default and it stays the default here: nothing about the
-//! numbers changes for anyone who never presses the key.
+//! The 1% / 0.1% low figures are a rolling window of the last ~10s by
+//! default, so they track what the game is doing now. They used to
+//! accumulate from launch and never stop, which cannot report a recovery:
+//! banked slow frames keep the entire 1% time budget until the fast run is
+//! 99x longer, so a game capped at 60fps for 30s pinned the reading at 60 for
+//! the next 49 minutes of 240fps play. See `FrameLowsWindow` in the sidecar.
 //!
-//! What the key adds is MSI Afterburner's benchmark shape on top of it:
+//! MSI Afterburner draws the same line, and its own documentation says where:
+//! an unlimited buffer "is preferred if you manually start benchmarking
+//! session with a hotkey", a rolling ring "if you permanently keep the
+//! benchmark mode enabled". The overlay pill is the second case, the hotkey
+//! is the first, so the key cycles between them:
 //!
-//!   start  clear the histogram, accumulate from zero
-//!   stop   compute the run's final figure and freeze it on the overlay
+//!   Live       rolling window, the default — tracks the last few seconds
+//!   Recording  clear and accumulate from zero, for the whole run
+//!   Frozen     the run's final figure, held on the overlay to be read
+//!
+//! Three states on one key rather than two, because a benchmark result has to
+//! survive being looked at (Recording -> Frozen) AND the user has to be able
+//! to get back to a live number afterwards (Frozen -> Live). A two-state
+//! toggle can do either one but not both.
 //!
 //! ONE key covers BOTH percentiles, which is why the binding lives in
 //! Settings once (Figma 2819:8960, "Start/stop FPS lows recording") rather
 //! than under each low in Stats. "1% low" and "0.1% low" are two queries
-//! against one frametime histogram — which is exactly why 0.1% low is always
+//! against one set of frametimes — which is exactly why 0.1% low is always
 //! <= 1% low — so there is one run to start and stop, not one per reading.
 //! Two independent runs would measure two different windows and could report
 //! a 0.1% low ABOVE the 1% low, which is not a reading anybody can act on.
@@ -34,7 +45,7 @@
 //! would make a hidden window part of the path.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Mutex;
 
 use log::{info, warn};
@@ -66,13 +77,55 @@ pub enum ShortcutAction {
     ToggleRecording,
 }
 
-/// Whether a run is currently accumulating, and which accelerator is
+/// What the percentile lows are measuring. Mirrors the sidecar's `LowsMode`
+/// (HardwareMonitor/PresentMon/LowsMode.cs); the discriminants ARE the pipe
+/// payload, so they may not be reordered independently of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowsMode {
+    /// A finished run, held on the overlay to be read.
+    Frozen = 0,
+    /// An explicitly started run: session-cumulative from the keypress.
+    Recording = 1,
+    /// The default. A rolling window of the last few seconds.
+    Live = 2,
+}
+
+impl LowsMode {
+    /// The pipe payload for this mode.
+    pub fn wire(self) -> u8 {
+        self as u8
+    }
+
+    /// The next mode the hotkey moves to: Live -> Recording -> Frozen -> Live.
+    fn next(self) -> Self {
+        match self {
+            LowsMode::Live => LowsMode::Recording,
+            LowsMode::Recording => LowsMode::Frozen,
+            LowsMode::Frozen => LowsMode::Live,
+        }
+    }
+
+    fn from_wire(v: u8) -> Self {
+        match v {
+            0 => LowsMode::Frozen,
+            1 => LowsMode::Recording,
+            // Live is the startup default, so an impossible value resolving
+            // to it degrades to "the readings keep updating" rather than to a
+            // silently frozen overlay.
+            _ => LowsMode::Live,
+        }
+    }
+}
+
+/// What the lows are currently measuring, and which accelerator is
 /// registered for each action. Named Registry, not State, because
 /// `ShortcutState` is the plugin's own press/release enum.
 pub struct ShortcutRegistry {
-    /// True while the sidecar is accumulating. Starts true: that is the
-    /// unbounded-from-launch behaviour the app already had.
-    recording: AtomicBool,
+    /// The sidecar's current lows mode, as a `LowsMode` discriminant. Starts
+    /// Live, which is the sidecar's own startup default — the two have to
+    /// agree without anything being sent, because nothing is sent until the
+    /// key is pressed.
+    lows_mode: AtomicU8,
     /// Accelerator currently registered with the OS per action, so a change
     /// can unregister the right one. Absent = nothing registered.
     registered: Mutex<HashMap<ShortcutAction, String>>,
@@ -81,13 +134,13 @@ pub struct ShortcutRegistry {
 impl ShortcutRegistry {
     pub fn new() -> Self {
         ShortcutRegistry {
-            recording: AtomicBool::new(true),
+            lows_mode: AtomicU8::new(LowsMode::Live.wire()),
             registered: Mutex::new(HashMap::new()),
         }
     }
 
-    pub fn is_recording(&self) -> bool {
-        self.recording.load(Ordering::Relaxed)
+    pub fn lows_mode(&self) -> LowsMode {
+        LowsMode::from_wire(self.lows_mode.load(Ordering::Relaxed))
     }
 }
 
@@ -97,12 +150,14 @@ impl Default for ShortcutRegistry {
     }
 }
 
-/// Flip the recording run on or off, tell the sidecar, and tell the windows.
+/// Advance the lows mode one step (Live -> Recording -> Frozen -> Live), tell
+/// the sidecar, and tell the windows.
 ///
-/// `swap`, not load-then-store: the global-shortcut callback runs on its own
-/// thread, and two presses landing close together would otherwise both read
-/// the same value and send the same command twice, leaving the sidecar and
-/// this flag disagreeing about whether a run is going.
+/// `fetch_update`, not load-then-store: the global-shortcut callback runs on
+/// its own thread, and two presses landing close together would otherwise both
+/// read the same value and send the same command twice, leaving the sidecar and
+/// this state disagreeing about what is being measured. The CAS loop makes two
+/// presses advance two steps.
 ///
 /// `try_send` rather than `send`: that thread is not a Tokio context, so
 /// awaiting is not available. The channel is 32 deep against a keypress, so a
@@ -112,29 +167,44 @@ pub fn toggle_recording(app: &AppHandle) {
     let Some(state) = app.try_state::<ShortcutRegistry>() else {
         return;
     };
-    let was = state.recording.fetch_xor(true, Ordering::Relaxed);
-    let next = !was;
+    // Infallible: the closure always returns Some, so the Err arm is
+    // unreachable and `unwrap_or` only satisfies the type.
+    let was = state
+        .lows_mode
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+            Some(LowsMode::from_wire(v).next().wire())
+        })
+        .unwrap_or(LowsMode::Live.wire());
+    let previous = LowsMode::from_wire(was);
+    let next = previous.next();
 
     if let Some(sender) = app.try_state::<PipeCommandSender>() {
-        if let Err(e) = sender.0.try_send(PipeCommand::SetLowsRecording(next)) {
-            // Put the flag back. `fetch_xor` above has to happen first to
+        if let Err(e) = sender.0.try_send(PipeCommand::SetLowsMode(next.wire())) {
+            // Put the mode back. `fetch_update` above has to happen first to
             // serialise two presses landing together, but a command the
             // sidecar never received must not leave this side believing the
-            // run changed state: a dropped stop would have us reporting
-            // "stopped" while the histogram kept accumulating. The reconnect
-            // in pipe_client re-asserts whatever this flag says, so the value
-            // it holds has to stay the truth.
-            state.recording.store(was, Ordering::Relaxed);
-            warn!("Could not send recording state to the sidecar, reverting: {}", e);
+            // mode changed: a dropped freeze would have us reporting "frozen"
+            // while the sidecar kept publishing. The reconnect in pipe_client
+            // re-asserts whatever this holds, so the value it holds has to
+            // stay the truth.
+            state.lows_mode.store(was, Ordering::Relaxed);
+            warn!("Could not send the lows mode to the sidecar, reverting: {}", e);
             return;
         }
     }
-    info!("Percentile-low recording {}", if next { "started" } else { "stopped" });
+    info!("Percentile-low mode {:?} -> {:?}", previous, next);
     // Emitted for the UI's benefit. Nothing renders it yet — the Figma card
     // shows the binding, not the run state — but the shortcut is global and a
     // user pressing it with the window open should not be looking at a window
     // that disagrees with the sidecar.
-    let _ = app.emit("recording-changed", next);
+    let _ = app.emit(
+        "recording-changed",
+        match next {
+            LowsMode::Live => "live",
+            LowsMode::Recording => "recording",
+            LowsMode::Frozen => "frozen",
+        },
+    );
 }
 
 /// Register both shortcuts from a settings snapshot.
@@ -269,3 +339,47 @@ pub fn set_capturing(app: &AppHandle, capturing: bool, settings: &OverlaySetting
     info!("Global shortcuts released for capture");
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The hotkey is one key covering three states, so the cycle order IS the
+    /// feature: a live reading you can start a run from, a run you can stop and
+    /// read, and a way back to live. Any reordering strands one of them.
+    #[test]
+    fn the_hotkey_cycles_live_to_recording_to_frozen_and_back() {
+        assert_eq!(LowsMode::Live.next(), LowsMode::Recording);
+        assert_eq!(LowsMode::Recording.next(), LowsMode::Frozen);
+        assert_eq!(LowsMode::Frozen.next(), LowsMode::Live);
+    }
+
+    /// Three presses return to where they started, so a user who taps the key
+    /// without watching the overlay cannot end up somewhere unreachable.
+    #[test]
+    fn three_presses_return_to_the_starting_mode() {
+        for start in [LowsMode::Live, LowsMode::Recording, LowsMode::Frozen] {
+            assert_eq!(start.next().next().next(), start, "cycling from {:?}", start);
+        }
+    }
+
+    /// A registry starts on the sidecar's own startup default. Nothing is sent
+    /// until the key is pressed, so a mismatch here would make the first press
+    /// send a mode the sidecar was already in and skip a step forever after.
+    #[test]
+    fn a_fresh_registry_agrees_with_the_sidecar_default() {
+        assert_eq!(ShortcutRegistry::new().lows_mode(), LowsMode::Live);
+    }
+
+    /// An out-of-range byte resolves to Live rather than Frozen: the failure
+    /// mode of guessing wrong is an overlay whose readings stop updating with
+    /// nothing on screen to say why.
+    #[test]
+    fn an_unknown_wire_value_degrades_to_live() {
+        assert_eq!(LowsMode::from_wire(0), LowsMode::Frozen);
+        assert_eq!(LowsMode::from_wire(1), LowsMode::Recording);
+        assert_eq!(LowsMode::from_wire(2), LowsMode::Live);
+        for v in [3u8, 7, 255] {
+            assert_eq!(LowsMode::from_wire(v), LowsMode::Live, "wire value {}", v);
+        }
+    }
+}

--- a/tauri-app/src/app/globals.css
+++ b/tauri-app/src/app/globals.css
@@ -471,8 +471,15 @@ body {
 }
 @layer utilities {
   .cm-shortcut-listening {
-    --cm-shortcut-blue: #155dfc;
+    --cm-shortcut-blue: var(--blue600);
     position: relative;
+  }
+  /* Blue/600 is the frame's value and stays on light. It only scores 3.60
+     against the dark surface, where Blue/400 scores 7.15 — and Blue/400 is the
+     step the design system already picked for dark in --textLink, so this is
+     the system's dark blue rather than a second opinion about it. */
+  [data-theme="dark"] .cm-shortcut-listening {
+    --cm-shortcut-blue: var(--blue400);
   }
   .cm-shortcut-listening::after {
     content: "";

--- a/tauri-app/src/components/ui/Toast.tsx
+++ b/tauri-app/src/components/ui/Toast.tsx
@@ -9,8 +9,13 @@ import { ErrorIcon } from "./shortcut-icons";
  * and 6/6 vertical against 20 on the right (the badge supplies the optical
  * inset on its side, so the text is the end that needs the room), gap 12. The
  * Bg/Brand fill inverts with the theme for free — #0C111D in light, #FAFAFA
- * in dark — with Text/Inverse tracking it the other way. The 40x40 Yellow/950
- * badge holds the 20px `error` glyph in Bg/Warning Active.
+ * in dark — with Text/Inverse tracking it the other way. The 40x40 badge is
+ * Bg/Warning Bold holding the 20px `error` glyph in Icon/Warning Bold. Both
+ * invert with the theme, so the chip reads as a tint of the pill in either one
+ * (1.35:1 against it on light, 1.25:1 on dark). It was Yellow/950 with
+ * Bg/Warning Active, whose light values these match exactly — but Yellow/950
+ * is a primitive with no dark mode, so on dark the chip stayed a hard dark
+ * disc (13.4:1) punched into the near-white pill.
  *
  * Position is the frame's too: x 175 in a 651-wide window is dead centre, at
  * y 76 down from the window's top edge.
@@ -141,8 +146,8 @@ function ToastPill({ message, open }: { message: string; open: boolean }) {
           "max-w-[calc(651px-var(--spacingXl)*2)] shadow-large"
         }
       >
-        <span className="flex size-[40px] shrink-0 items-center justify-center rounded-[var(--cornerRound)] bg-[var(--yellow950)]">
-          <ErrorIcon className="size-[20px] text-[var(--bgWarningActive)]" />
+        <span className="flex size-[40px] shrink-0 items-center justify-center rounded-[var(--cornerRound)] bg-[var(--bgWarningBold)]">
+          <ErrorIcon className="size-[20px] text-[var(--iconWarningBold)]" />
         </span>
         {/* leading-[17px] is Figma's AUTO line height for Inter 14 — the text
             node measures 17 high on one line (2819:9759). */}


### PR DESCRIPTION
## What changed

The 1% and 0.1% low readings were session-cumulative, which cannot report a framerate recovery. A cumulative integral percentile keeps banked slow frames owning the whole time budget until the fast run is 99x longer, so 30s capped at 60fps pinned the 1% low at 60 for the next 49 minutes of 240fps play. Drops landed on the next poll and recoveries never did, so the number only ratcheted downward.

The window was the problem, not the arithmetic. RTSS draws the same line and its own documentation says where: an unlimited buffer "is preferred if you manually start benchmarking session with a hotkey", a rolling ring "if you permanently keep the benchmark mode enabled". The overlay pill is the second case and the hotkey is the first, so both now exist.

| Area | Change |
|---|---|
| `FrameLowsWindow.cs` (new) | Rolling 10s window, budget derived from the window's own total. That pairing is the fix; bounding samples alone is not enough. |
| `FrameLows.cs` | Behaviour unchanged, now explicitly the run accumulator. Cumulative is correct for a benchmark. |
| `LowsMode.cs` (new) | `Frozen=0 / Recording=1 / Live=2`. The values are the pipe payload. |
| Hotkey | Cycles Live to Recording to Frozen to Live. Three states because a result has to survive being read, and there has to be a way back to a live number. |
| Protocol | `SetLowsRecording` to `SetLowsMode`, payload 0/1/2. 0 and 1 keep their old boolean meanings for version skew; out-of-range payloads are dropped, not coerced. |
| Rust | `AtomicBool` to `AtomicU8`, `fetch_update` CAS instead of `fetch_xor`, unknown wire values degrade to Live rather than a silent freeze. |
| Tokens | Refusal toast and listening shortcut field moved onto warning-bold and blue tokens, which have dark-mode values where the primitives they replace did not. |

### Why 10s and not RTSS's 1024 frames

1024 frames is 4.3s at 240fps but 17s at 60fps. Framerate-dependent recovery speed is the property this change exists to remove, so the window is a duration.

## What this fixes

Reported by a tester: the overlay's 1% low stayed at 60 after the game moved from 60fps to 240fps, and only recovered when the recording was restarted.

## Verification

| Gate | Result |
|---|---|
| Sidecar tests (new) | 30/30 |
| Rust tests | 26/26 |
| Frontend lint / tests / build | pass / 131/131 / pass |
| Clippy | no new warnings in changed files |
| Guard has teeth | 5 unit and 2 integration tests go red without the fix |

Cross-checked against the RTSS SDK reference implementation on both modes: the live window matches ring mode exactly across 18 constructed exact ties and 4,000 random sessions, zero disagreements. The run accumulator differs from unlimited mode only on an exact tie, which its bucket arithmetic did not produce once across 200,000 simulated sessions.

Column layout for the new `CPUStartTime` dependency was verified against a live header from the bundled PresentMon 2.2.0, not assumed.

Light mode is byte-identical for both token swaps: the replacing tokens carry the same light values as the primitives they replace.

## Not included

- No live run against a real game changing framerate. All tests drive synthetic PresentMon CSV rows through the real parse path.
- Nothing renders the mode. `recording-changed` now emits `live`/`recording`/`frozen` and still has no listener, so the three states are not visible in the UI.
- The shortcut label still reads "Start/stop FPS lows recording" for what is now a three-state cycle. Reviewed and kept deliberately.
- The `Live -> Frozen` transition is covered but only reachable via the pipe reconnect, not through the hotkey cycle.


