### PR TITLE
Fix monitoring reconnection after sensor reader disconnects

### DIFF
--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod pipe_client;
+mod pipe_input;
 mod shortcuts;
 mod settings;
 mod tray;

--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -421,16 +421,18 @@ pub async fn run_pipe_client(
                 });
 
                 // Async loop: forward events to Tauri and handle outgoing commands
-                loop {
-                    tokio::select! {
-                        Some(cmd) = cmd_rx.recv() => {
+                while let Some(input) =
+                    crate::pipe_input::next_input(&mut cmd_rx, &mut event_rx).await
+                {
+                    match input {
+                        crate::pipe_input::PipeInput::Command(cmd) => {
                             let bytes = build_command(&cmd);
                             if let Err(e) = writer.write_all(&bytes) {
                                 error!("Failed to send command: {}", e);
                                 break;
                             }
                         }
-                        Some(event) = event_rx.recv() => {
+                        crate::pipe_input::PipeInput::Event(event) => {
                             match event {
                                 ParsedEvent::SensorData(data) => {
                                     let _ = app_for_read.emit("sensor-data", &data);
@@ -440,7 +442,6 @@ pub async fn run_pipe_client(
                                 }
                             }
                         }
-                        else => break,
                     }
 
                     if !running.load(Ordering::Relaxed) {
@@ -448,6 +449,10 @@ pub async fn run_pipe_client(
                     }
                 }
 
+                // Report the lost connection before waiting or retrying. On
+                // reader EOF its task has finished and joining cannot stall.
+                let _ = app.emit("pipe-status", PipeStatus { connected: false });
+                announced_disconnect = true;
                 let _ = read_handle.await;
                 // The connection just ended: start a fresh fast-poll window so a
                 // sidecar crash reconnects as quickly as a cold start does.

--- a/tauri-app/src-tauri/src/pipe_input.rs
+++ b/tauri-app/src-tauri/src/pipe_input.rs
@@ -1,0 +1,80 @@
+use tokio::sync::mpsc;
+
+pub(crate) enum PipeInput<C, E> {
+    Command(C),
+    Event(E),
+}
+
+/// Reader EOF ends this connection even while the app's command sender lives.
+/// Matching only `Some(event)` inside select would disable that branch at EOF
+/// and wait indefinitely for a user command instead of reconnecting.
+pub(crate) async fn next_input<C, E>(
+    commands: &mut mpsc::Receiver<C>,
+    events: &mut mpsc::Receiver<E>,
+) -> Option<PipeInput<C, E>> {
+    tokio::select! {
+        Some(command) = commands.recv() => Some(PipeInput::Command(command)),
+        event = events.recv() => event.map(PipeInput::Event),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn reader_eof_ends_connection_with_command_sender_still_alive() {
+        let (command_tx, mut commands) = mpsc::channel::<()>(1);
+        let (event_tx, mut events) = mpsc::channel::<()>(1);
+        drop(event_tx);
+
+        let input = timeout(Duration::from_secs(1), next_input(&mut commands, &mut events))
+            .await
+            .expect("reader EOF must not wait for a user command");
+        assert!(input.is_none());
+        assert!(!command_tx.is_closed());
+    }
+
+    #[tokio::test]
+    async fn queued_sensor_events_are_drained_before_eof() {
+        let (_command_tx, mut commands) = mpsc::channel::<()>(1);
+        let (event_tx, mut events) = mpsc::channel(1);
+        event_tx.send(42).await.unwrap();
+        drop(event_tx);
+
+        assert!(matches!(
+            next_input(&mut commands, &mut events).await,
+            Some(PipeInput::Event(42))
+        ));
+        assert!(next_input(&mut commands, &mut events).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn commands_still_flow_while_reader_is_idle() {
+        let (command_tx, mut commands) = mpsc::channel(1);
+        let (_event_tx, mut events) = mpsc::channel::<()>(1);
+        command_tx.send(7).await.unwrap();
+
+        assert!(matches!(
+            next_input(&mut commands, &mut events).await,
+            Some(PipeInput::Command(7))
+        ));
+    }
+
+    #[tokio::test]
+    async fn closed_command_channel_does_not_drop_sensor_events() {
+        let (command_tx, mut commands) = mpsc::channel::<()>(1);
+        let (event_tx, mut events) = mpsc::channel(1);
+        drop(command_tx);
+        event_tx.send(42).await.unwrap();
+        drop(event_tx);
+
+        assert!(matches!(
+            next_input(&mut commands, &mut events).await,
+            Some(PipeInput::Event(42))
+        ));
+        assert!(next_input(&mut commands, &mut events).await.is_none());
+    }
+}


### PR DESCRIPTION
When the HardwareMonitor reader exits, the sensor event channel closes while the app's command sender remains alive. The previous `Some(event)` select branch ignored EOF and could wait indefinitely for a user command, preventing the retry loop from reconnecting to the restarted sidecar.

Handle sensor-channel EOF explicitly, drain queued events before returning, and emit disconnected status before joining the reader and entering the existing retry path. The channel-selection helper is used by the production loop and has four focused regression tests.

Validation:
- All four tests pass against the production helper using Tokio 1.50.0 (the repository's locked version) in an isolated Cargo harness on macOS.
- Restoring the old `Some(event)` selection behavior in a temporary copy makes the EOF regression test fail by timeout.
- `git diff --check` passes.
- Full Windows app build and runtime integration verification remain outstanding; the isolated harness does not validate the Tauri integration.

@saadah7 — please review the code and check on Windows: start monitoring, terminate the Cleanmeter HardwareMonitor sidecar without changing settings or pressing a shortcut, and verify sensor updates resume automatically after the supervisor restarts it. Please also check repeated crashes and normal commands while monitoring is connected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core pipe I/O multiplexing and disconnect signaling; behavior is unit-tested but full Windows/Tauri integration is still called out as unverified in the PR.
> 
> **Overview**
> Fixes monitoring staying stuck disconnected when the **HardwareMonitor** pipe reader exits while the app’s command channel is still open. The pipe client loop now uses a shared **`next_input`** helper that treats sensor-channel **EOF** as end-of-connection (instead of only waking on `Some(event)`), drains any queued events first, then exits so the existing reconnect path can run.
> 
> After the loop ends, the client **emits `pipe-status` disconnected** before joining the reader task and resetting the fast-poll window, so the UI reflects the drop and sidecar restarts reconnect quickly. **`pipe_input`** is wired from **`lib.rs`** and covered by four Tokio tests for EOF, queued events, commands, and a closed command channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8c08fe0c7a1a4a21bdc42943e0f0f5d3a71d5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->