### PR TITLE
Avoid stalled RAM discovery and keep monitoring startup responsive

### DIFF
--- a/.github/workflows/windows-startup.yml
+++ b/.github/workflows/windows-startup.yml
@@ -1,0 +1,94 @@
+name: Windows startup test build
+
+on:
+  push:
+    branches: [fix/windows-monitor-startup]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-startup-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: tauri-app/package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tauri-app/src-tauri
+      - name: Test real Windows pipe with blocked hardware
+        run: dotnet test HardwareMonitor/HardwareMonitor.Tests -c Release --logger "trx;LogFileName=sidecar.trx" --results-directory evidence
+      - name: Prove the regression test detects hardware-first startup
+        shell: pwsh
+        run: |
+          $path = 'HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs'
+          $original = Get-Content $path -Raw
+          try {
+            $mutated = $original.Replace('_socketHost.StartServer();', '')
+            $mutated = $mutated.Replace('if (_hardwareOverride != null) await _hardwareOverride(stoppingToken);', 'if (_hardwareOverride != null) { await _hardwareOverride(stoppingToken); _socketHost.StartServer(); }')
+            if ($mutated -eq $original) { throw 'Mutation did not apply' }
+            Set-Content $path $mutated
+            dotnet test HardwareMonitor/HardwareMonitor.Tests -c Release --filter FullyQualifiedName~BlockedHardwareStillAllowsConnectionAndProgressThenLateReadings --logger "trx;LogFileName=ordering-mutation.trx" --results-directory evidence 2>&1 | Tee-Object evidence/ordering-mutation.txt
+            if ($LASTEXITCODE -eq 0) { throw 'Hardware-first mutation unexpectedly passed' }
+            if (-not (Select-String evidence/ordering-mutation.txt -Pattern 'TaskCanceledException|OperationCanceledException' -Quiet)) { throw 'Mutation did not fail by connection timeout' }
+          } finally {
+            Set-Content $path $original -NoNewline
+          }
+          $global:LASTEXITCODE = 0
+      - name: Publish sidecar
+        run: dotnet publish HardwareMonitor/HardwareMonitor -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+      - name: Stage PresentMon
+        shell: pwsh
+        run: Copy-Item presentmon/* HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/
+      - name: Rust tests
+        working-directory: tauri-app/src-tauri
+        run: cargo test --lib --target x86_64-pc-windows-msvc
+      - name: Frontend checks
+        working-directory: tauri-app
+        run: |
+          npm ci
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm run lint
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm test
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Build test installer without publishing a release
+        working-directory: tauri-app
+        shell: pwsh
+        run: |
+          '{"version":"2.2.17-startup.1","bundle":{"createUpdaterArtifacts":false}}' | Set-Content startup-build.json
+          npm run tauri:build -- --bundles nsis --config startup-build.json
+      - name: Prepare download
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force download
+          Copy-Item tauri-app/src-tauri/target/release/bundle/nsis/*.exe download/
+          Copy-Item docs/windows-startup-test.md download/README.md
+          "Commit: $env:GITHUB_SHA" | Set-Content download/BUILD.txt
+          Get-ChildItem download/*.exe | Get-FileHash -Algorithm SHA256 | Format-List | Out-File download/SHA256SUMS.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-startup-test-evidence
+          path: evidence/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cleanmeter-windows-startup-test
+          path: download/
+          if-no-files-found: error

--- a/.github/workflows/windows-startup.yml
+++ b/.github/workflows/windows-startup.yml
@@ -75,7 +75,7 @@ jobs:
         working-directory: tauri-app
         shell: pwsh
         run: |
-          '{"version":"2.2.17-startup.1","bundle":{"createUpdaterArtifacts":false}}' | Set-Content startup-build.json
+          '{"version":"2.2.17-startup.2","bundle":{"createUpdaterArtifacts":false}}' | Set-Content startup-build.json
           npm run tauri:build -- --bundles nsis --config startup-build.json
       - name: Prepare download
         shell: pwsh

--- a/.github/workflows/windows-startup.yml
+++ b/.github/workflows/windows-startup.yml
@@ -75,7 +75,7 @@ jobs:
         working-directory: tauri-app
         shell: pwsh
         run: |
-          '{"version":"2.2.17-startup.2","bundle":{"createUpdaterArtifacts":false}}' | Set-Content startup-build.json
+          '{"version":"2.2.17-startup.3","bundle":{"createUpdaterArtifacts":false}}' | Set-Content startup-build.json
           npm run tauri:build -- --bundles nsis --config startup-build.json
       - name: Prepare download
         shell: pwsh

--- a/.github/workflows/windows-startup.yml
+++ b/.github/workflows/windows-startup.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Stage PresentMon
         shell: pwsh
         run: Copy-Item presentmon/* HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish/
+      - name: Run the published Windows sidecar on runner hardware
+        shell: pwsh
+        run: ./scripts/test-windows-sidecar.ps1
       - name: Rust tests
         working-directory: tauri-app/src-tauri
         run: cargo test --lib --target x86_64-pc-windows-msvc

--- a/HardwareMonitor/HardwareMonitor.Tests/MonitorStartupTests.cs
+++ b/HardwareMonitor/HardwareMonitor.Tests/MonitorStartupTests.cs
@@ -1,0 +1,150 @@
+using System.Buffers.Binary;
+using System.IO.Pipes;
+using System.Text.Json;
+using HardwareMonitor.Monitor;
+using HardwareMonitor.Sockets;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace HardwareMonitor.Tests;
+
+public class MonitorStartupTests
+{
+    [Fact]
+    public void FailedMotherboardProbeDoesNotPreventCpuAndGpuDiscovery()
+    {
+        var progress = new MonitorProgress();
+        var discovered = new List<string>();
+        HardwareDiscovery.Run(new (string, Action)[]
+        {
+            ("Motherboard", () => throw new IOException("Synthetic probe failure")),
+            ("CPU", () => discovered.Add("CPU")),
+            ("GPU", () => discovered.Add("GPU")),
+        }, progress, NullLogger.Instance, CancellationToken.None);
+        Assert.Equal(new[] { "CPU", "GPU" }, discovered);
+    }
+
+    [Fact]
+    public void CancellationAfterAProbePreventsStartingTheNextOne()
+    {
+        using var cancelled = new CancellationTokenSource();
+        var secondCalled = false;
+        Assert.Throws<OperationCanceledException>(() => HardwareDiscovery.Run(new (string, Action)[]
+        {
+            ("First", () => cancelled.Cancel()),
+            ("Second", () => secondCalled = true),
+        }, new MonitorProgress(), NullLogger.Instance, cancelled.Token));
+        Assert.False(secondCalled);
+    }
+
+    private static async Task<(short Command, byte[] Payload)> ReadFrame(NamedPipeClientStream client, CancellationToken token)
+    {
+        var header = new byte[6];
+        await client.ReadExactlyAsync(header, token);
+        var length = BinaryPrimitives.ReadInt32LittleEndian(header.AsSpan(2));
+        Assert.InRange(length, 0, 65536);
+        var payload = new byte[length];
+        await client.ReadExactlyAsync(payload, token);
+        return (BinaryPrimitives.ReadInt16LittleEndian(header), payload);
+    }
+
+    [Fact]
+    public async Task BlockedHardwareStillAllowsConnectionAndProgressThenLateReadings()
+    {
+        if (!OperatingSystem.IsWindows()) return; // Real Windows named-pipe transport.
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        using var blocked = new ManualResetEventSlim();
+        using var entered = new ManualResetEventSlim();
+        var name = "cleanmeter-test-" + Guid.NewGuid().ToString("N");
+        var pipe = new PipeHost(NullLogger.Instance, name);
+        var workerDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var monitor = new MonitorPoller(NullLogger<MonitorPoller>.Instance, pipe, _ =>
+        {
+            try
+            {
+                entered.Set();
+                // Deliberately synchronous and NOT cancellable: models native
+                // discovery that remains in Task Manager without completing.
+                blocked.Wait();
+                // A synthetic, valid empty topology proves late publication
+                // crosses the same pipe; no hardware values are claimed here.
+                pipe.SendToAll(new byte[10]);
+                return Task.CompletedTask;
+            }
+            finally { workerDone.SetResult(); }
+        }, startPresentMon: false);
+        try
+        {
+            await monitor.StartAsync(deadline.Token).WaitAsync(deadline.Token);
+            Assert.True(entered.Wait(TimeSpan.FromSeconds(3)));
+            using var client = new NamedPipeClientStream(".", name, PipeDirection.InOut, PipeOptions.Asynchronous);
+            await client.ConnectAsync(deadline.Token);
+            (short Command, byte[] Payload) frame;
+            do { frame = await ReadFrame(client, deadline.Token); } while (frame.Command != 6);
+            using var json = JsonDocument.Parse(frame.Payload);
+            Assert.Equal("starting", json.RootElement.GetProperty("state").GetString());
+            Assert.False(workerDone.Task.IsCompleted);
+
+            // Commands also remain responsive, not just server -> client sends.
+            await client.WriteAsync(new byte[] { 1, 0 }, deadline.Token);
+            do { frame = await ReadFrame(client, deadline.Token); } while (frame.Command != 3);
+
+            blocked.Set();
+            do { frame = await ReadFrame(client, deadline.Token); } while (frame.Command != 0);
+            Assert.Equal(8, frame.Payload.Length);
+            await workerDone.Task.WaitAsync(deadline.Token);
+        }
+        finally
+        {
+            blocked.Set();
+            await workerDone.Task.WaitAsync(TimeSpan.FromSeconds(3));
+            await monitor.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(3));
+        }
+    }
+
+    [Fact]
+    public async Task ShutdownDoesNotWaitForOrCleanUpAnActiveNativeCall()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        using var release = new ManualResetEventSlim();
+        using var entered = new ManualResetEventSlim();
+        var finished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cleanupCalls = 0;
+        var pipe = new PipeHost(NullLogger.Instance, "cleanmeter-test-" + Guid.NewGuid().ToString("N"));
+        using var monitor = new MonitorPoller(NullLogger<MonitorPoller>.Instance, pipe, _ =>
+        {
+            try { entered.Set(); release.Wait(); return Task.CompletedTask; }
+            finally { Interlocked.Increment(ref cleanupCalls); finished.SetResult(); }
+        }, startPresentMon: false);
+        try
+        {
+            await monitor.StartAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(3));
+            Assert.True(entered.Wait(TimeSpan.FromSeconds(3)));
+            await monitor.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(3));
+            Assert.Equal(0, Volatile.Read(ref cleanupCalls));
+        }
+        finally
+        {
+            release.Set();
+            await finished.Task.WaitAsync(TimeSpan.FromSeconds(3));
+        }
+        Assert.Equal(1, cleanupCalls);
+    }
+
+    [Fact]
+    public void ProgressReportsStallsWithoutForgettingLateRecovery()
+    {
+        var progress = new MonitorProgress();
+        progress.Begin("Opening motherboard sensors");
+        Assert.Equal("starting", progress.Read().State);
+        Assert.Equal("delayed", progress.Read(Environment.TickCount64 + 60_000).State);
+        progress.Ready();
+        Assert.Equal("ready", progress.Read(Environment.TickCount64 + 60_000).State);
+        progress.Begin("Reading CPU sensors");
+        Assert.Equal("ready", progress.Read().State); // No flicker between normal reads.
+        Assert.Equal("delayed", progress.Read(Environment.TickCount64 + 60_000).State);
+        progress.Fail();
+        Assert.Equal("failed", progress.Read().State);
+        Assert.Equal("Reading CPU sensors", progress.Read().Stage);
+    }
+}

--- a/HardwareMonitor/HardwareMonitor.Tests/WindowsMemoryTests.cs
+++ b/HardwareMonitor/HardwareMonitor.Tests/WindowsMemoryTests.cs
@@ -1,0 +1,64 @@
+using HardwareMonitor.Monitor;
+using LibreHardwareMonitor.Hardware;
+using Xunit;
+
+namespace HardwareMonitor.Tests;
+
+public class WindowsMemoryTests
+{
+    private const ulong GiB = 1024UL * 1024 * 1024;
+
+    [Fact]
+    public void PhysicalAndCommittedUsageKeepExistingSensorIdsAndUnits()
+    {
+        var sample = new WindowsMemoryHardware.Snapshot(32 * GiB, 12 * GiB, 64 * GiB, 40 * GiB);
+        var physical = new WindowsMemoryHardware(read: () => sample);
+        var committed = new WindowsMemoryHardware(virtualMemory: true, read: () => sample);
+        physical.Update();
+        committed.Update();
+        var sensors = physical.Sensors.Concat(committed.Sensors).ToDictionary(s => s.Identifier.ToString());
+        Assert.Equal(20f, sensors["/ram/data/0"].Value);
+        Assert.Equal(12f, sensors["/ram/data/1"].Value);
+        Assert.Equal(62.5f, sensors["/ram/load/0"].Value);
+        Assert.Equal(24f, sensors["/vram/data/2"].Value);
+        Assert.Equal(40f, sensors["/vram/data/3"].Value);
+        Assert.Equal(37.5f, sensors["/vram/load/1"].Value);
+        Assert.All(sensors.Values, s => Assert.Equal(HardwareType.Memory, s.Hardware.HardwareType));
+
+        sample = sample with { AvailablePhysical = 24 * GiB };
+        physical.Update();
+        Assert.Equal(25f, sensors["/ram/load/0"].Value);
+        Assert.Equal(8f, sensors["/ram/data/0"].Value);
+    }
+
+    [Fact]
+    public void InvalidZeroTotalDoesNotProduceNaNOrInfinity()
+    {
+        var memory = new WindowsMemoryHardware(read: () => default);
+        memory.Update();
+        Assert.All(memory.Sensors, sensor => Assert.Null(sensor.Value));
+    }
+
+    [Fact]
+    public void InconsistentAvailabilityDoesNotUnderflowUnsignedCounters()
+    {
+        var memory = new WindowsMemoryHardware(read: () => new(32 * GiB, 33 * GiB, 0, 0));
+        memory.Update();
+        Assert.Equal(0f, memory.Sensors.Single(s => s.SensorType == SensorType.Load).Value);
+        Assert.Equal(0f, memory.Sensors.Single(s => s.Identifier.ToString() == "/ram/data/0").Value);
+    }
+
+    [Fact]
+    public void RealWindowsApiProvidesMemoryWithoutAnyHardwareDiscovery()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var sample = WindowsMemoryHardware.ReadWindows();
+        Assert.True(sample.TotalPhysical > 0);
+        Assert.InRange(sample.AvailablePhysical, 0UL, sample.TotalPhysical);
+        var hardware = new WindowsMemoryHardware();
+        hardware.Update();
+        var load = hardware.Sensors.Single(s => s.SensorType == SensorType.Load).Value;
+        Assert.NotNull(load);
+        Assert.InRange(load.Value, 0f, 100f);
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/Monitor/HardwareDiscovery.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/HardwareDiscovery.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Logging;
+
+namespace HardwareMonitor.Monitor;
+
+internal static class HardwareDiscovery
+{
+    /// <summary>
+    /// Sequential discovery on the hardware owner. Only exceptions are skipped;
+    /// a blocked probe stays on this worker and is reported by the heartbeat.
+    /// </summary>
+    internal static void Run(IEnumerable<(string Name, Action Probe)> probes,
+        MonitorProgress progress, ILogger logger, CancellationToken token)
+    {
+        foreach (var (name, probe) in probes)
+        {
+            token.ThrowIfCancellationRequested();
+            progress.Begin(name);
+            var started = Environment.TickCount64;
+            logger.LogInformation("Hardware init: {Stage} starting", name);
+            try
+            {
+                probe();
+                logger.LogInformation("Hardware init: {Stage} completed in {ElapsedMs}ms",
+                    name, Environment.TickCount64 - started);
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested) { throw; }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Hardware init: {Stage} failed; continuing with other sensors", name);
+            }
+        }
+        token.ThrowIfCancellationRequested();
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPacketCommand.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPacketCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace HardwareMonitor.Monitor;
+namespace HardwareMonitor.Monitor;
 
 public enum MonitorPacketCommand : short
 {
@@ -20,5 +20,8 @@ public enum MonitorPacketCommand : short
     /// start; only 2 is new, and an older sidecar rejects it and stays where it
     /// was rather than misreading it.
     /// </summary>
-    SetLowsMode = 5
+    SetLowsMode = 5,
+
+    // Server -> client JSON progress; independent of hardware data packets.
+    HardwareStatus = 6
 }

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -1,8 +1,9 @@
-﻿#pragma warning disable CS8601 // Possible null
+#pragma warning disable CS8601 // Possible null
 
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Text.Json;
 using HardwareMonitor.PresentMon;
 using HardwareMonitor.SharedMemory;
 using HardwareMonitor.Sockets;
@@ -12,26 +13,35 @@ using Microsoft.Extensions.Logging;
 
 namespace HardwareMonitor.Monitor;
 
-public class MonitorPoller(
-    IHostApplicationLifetime hostApplicationLifetime,
-    ILogger<MonitorPoller> logger
-) : BackgroundService
+public class MonitorPoller : BackgroundService
 {
-    private readonly Computer _computer = new()
-    {
-        IsCpuEnabled = true,
-        IsGpuEnabled = true,
-        IsMemoryEnabled = true,
-        IsMotherboardEnabled = true,
-        IsControllerEnabled = true,
-        IsNetworkEnabled = true,
-        IsPsuEnabled = true,
-        IsBatteryEnabled = true,
-        IsStorageEnabled = true,
-    };
+    private readonly ILogger<MonitorPoller> logger;
+    private readonly Func<CancellationToken, Task>? _hardwareOverride;
+    private readonly bool _startPresentMon;
+    private readonly MonitorProgress _progress = new();
 
-    private PipeHost _socketHost = new(logger);
-    private readonly PresentMonPoller _presentMonPoller = new(logger);
+    public MonitorPoller(ILogger<MonitorPoller> logger)
+        : this(logger, new PipeHost(logger), null, true) { }
+
+    // Tests replace the hardware operation, not the transport: a real named
+    // pipe must still connect and carry status while that operation is blocked.
+    internal MonitorPoller(ILogger<MonitorPoller> logger, PipeHost pipe,
+        Func<CancellationToken, Task>? hardwareOverride, bool startPresentMon)
+    {
+        this.logger = logger;
+        _socketHost = pipe;
+        _presentMonPoller = new(logger);
+        _hardwareOverride = hardwareOverride;
+        _startPresentMon = startPresentMon;
+    }
+
+    // Open the library first, then enable the same groups one at a time.
+    // LHM 0.9.6 supports enabling groups after Open. This exposes which probe
+    // stalls, and an exception in one group no longer skips every later group.
+    private readonly Computer _computer = new();
+
+    private readonly PipeHost _socketHost;
+    private readonly PresentMonPoller _presentMonPoller;
 
     private short _pollingRate = 500;
     private const short MinimalPollingRate = 33;
@@ -64,35 +74,129 @@ public class MonitorPoller(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        logger.LogInformation("Starting monitor");
+        logger.LogInformation("Starting monitor (pipe-first startup, pid {Pid})", Environment.ProcessId);
+        _presentMonPoller.InitializeSensors();
+        _socketHost.OnClientData += OnClientData;
+        _socketHost.OnClientConnected += OnClientConnected;
+        _presentMonPoller.OnUpdateApps += SendPresentMonAppsToClients;
+        _socketHost.StartServer();
 
-        // The LibreHardwareMonitor kernel driver (WinRing0) can be quarantined
-        // or blocked — Windows Defender flags it as
-        // "VulnerableDriver:WinNT/Winring0", and HVCI / Smart App Control can
-        // refuse to load it. If Open() throws, swallow it so the sidecar keeps
-        // running: FPS (PresentMon) and any sensors that don't need ring0 stay
-        // alive instead of crashing the process into the supervisor's respawn
-        // loop. Only low-level readings (CPU temperature/power via MSRs) are
-        // lost. See SECURITY.md.
+        // Neither transport nor PresentMon depends on LibreHardwareMonitor.
+        // Start runs synchronously up to its first await, so schedule it too.
+        if (_startPresentMon)
+            _ = Task.Run(() => _presentMonPoller.Start(stoppingToken));
+
+        // The worker owns ALL Computer access, including Close in its finally.
+        // A timeout cannot cancel a native call. Never touch or dispose its
+        // Computer from this task, even during shutdown or a reported stall.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                if (_hardwareOverride != null) await _hardwareOverride(stoppingToken);
+                else await PollHardwareAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { }
+            catch (Exception ex)
+            {
+                _progress.Fail();
+                logger.LogError(ex, "Hardware worker stopped at {Stage}", _progress.Read().Stage);
+            }
+        });
+
+        string? lastProblem = null;
         try
         {
-            _computer.Open();
-            _computer.Accept(new UpdateVisitor());
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var status = _progress.Read();
+                if (status.State is "delayed" or "failed" && lastProblem != status.Stage)
+                {
+                    lastProblem = status.Stage;
+                    logger.LogWarning("Hardware {State} at {Stage} ({ElapsedMs}ms). " +
+                        "The pipe is still available; the native call has NOT been cancelled.",
+                        status.State, status.Stage, status.ElapsedMs);
+                }
+                if (status.State == "ready") lastProblem = null;
+                if (_socketHost.HasConnections())
+                {
+                    // Status is separate from sensor data. No empty/zero
+                    // snapshot is presented as successful hardware monitoring.
+                    using var stream = new MemoryStream();
+                    using var writer = new BinaryWriter(stream);
+                    writer.Write((short)MonitorPacketCommand.HardwareStatus);
+                    writer.Write(JsonSerializer.SerializeToUtf8Bytes(status,
+                        new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
+                    await _socketHost.SendToAllAsync(stream.ToArray());
+                }
+                await Task.Delay(1000, stoppingToken);
+            }
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { }
+        finally
         {
-            logger.LogError(ex,
-                "LibreHardwareMonitor failed to initialize — the kernel driver may be " +
-                "blocked or quarantined (Windows Defender 'VulnerableDriver:WinNT/Winring0'). " +
-                "Continuing with FPS and any sensors that initialized; low-level CPU sensors " +
-                "may be unavailable.");
+            // The host can stop promptly even if a native driver call never
+            // returns. The hardware worker alone closes hardware if it returns.
+            _socketHost.OnClientData -= OnClientData;
+            _socketHost.OnClientConnected -= OnClientConnected;
+            _presentMonPoller.OnUpdateApps -= SendPresentMonAppsToClients;
+            _socketHost.Close();
+            if (_startPresentMon) _presentMonPoller.Stop();
         }
+    }
+
+    private async Task PollHardwareAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await PollHardwareCoreAsync(stoppingToken);
+        }
+        finally
+        {
+            logger.LogInformation("Closing hardware on its owning worker");
+            _computer.Close();
+        }
+    }
+
+    private async Task PollHardwareCoreAsync(CancellationToken stoppingToken)
+    {
+        _progress.Begin("Opening hardware library");
+        logger.LogInformation("Hardware init: Computer.Open starting (no groups enabled yet)");
+        _computer.Open();
+        logger.LogInformation("Hardware init: Computer.Open completed");
+        stoppingToken.ThrowIfCancellationRequested();
+
+        // Keep LHM's original ordering, including CPU before GPU (Intel GPU
+        // discovery uses the CPU group). Every category previously enabled is
+        // still enabled; no board-specific blacklist or driver change.
+        HardwareDiscovery.Run(new (string, Action)[]
+        {
+            ("Discovering motherboard sensors", () => _computer.IsMotherboardEnabled = true),
+            ("Discovering CPU sensors", () => _computer.IsCpuEnabled = true),
+            ("Discovering memory sensors", () => _computer.IsMemoryEnabled = true),
+            ("Discovering graphics sensors", () => _computer.IsGpuEnabled = true),
+            ("Discovering controller sensors", () => _computer.IsControllerEnabled = true),
+            ("Discovering storage sensors", () => _computer.IsStorageEnabled = true),
+            ("Discovering network sensors", () => _computer.IsNetworkEnabled = true),
+            ("Discovering power supply sensors", () => _computer.IsPsuEnabled = true),
+            ("Discovering battery sensors", () => _computer.IsBatteryEnabled = true),
+        }, _progress, logger, stoppingToken);
+
+        // Read each device separately as well: a thrown first read on one
+        // device should not prevent initial readings from all later devices.
+        HardwareDiscovery.Run(_computer.Hardware.Select(hw =>
+            ($"First sensor read: {hw.Name}", (Action)(() => hw.Accept(new UpdateVisitor())))),
+            _progress, logger, stoppingToken);
 
         // Before anything is logged or mapped, check LibreHardwareMonitor's
         // GPU list against the device tree. Its GPU groups enumerate once, in
         // their constructors, so a vendor SDK that was not ready here would
         // otherwise leave the GPU missing for the whole session.
+        _progress.Begin("Checking graphics adapters");
+        logger.LogInformation("Hardware init: GPU reconciliation starting");
         ReconcileGpus();
+        logger.LogInformation("Hardware init: GPU reconciliation completed");
+        stoppingToken.ThrowIfCancellationRequested();
         _nextGpuReconcileAt = Environment.TickCount64 + GpuReconcileIntervalMs;
 
         // Log discovered hardware and sensor counts for diagnostics
@@ -123,16 +227,7 @@ public class MonitorPoller(
             if (logged >= 10) break;
         }
 
-        // Deliberately not awaited: Start runs for the lifetime of the sidecar.
-        // It returns a Task (rather than being async void) so a failure inside it
-        // can no longer reach the thread pool unhandled and kill the process; it
-        // logs and leaves sensors running instead.
-        _ = _presentMonPoller.Start(stoppingToken);
-        _presentMonPoller.OnUpdateApps += SendPresentMonAppsToClients;
-        _socketHost.StartServer();
-        _socketHost.OnClientData += OnClientData;
-        _socketHost.OnClientConnected += OnClientConnected;
-
+        _progress.Begin("Mapping sensor readings");
         var sharedMemoryData = QueryHardwareData();
         var knownSensorCount = CountActiveSensors();
         var sensorSetChanges = 0;
@@ -142,6 +237,7 @@ public class MonitorPoller(
         var accumulator = 0;
 
         WriteDataToStream(writer, sharedMemoryData);
+        _progress.Ready();
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -153,6 +249,7 @@ public class MonitorPoller(
             {
                 _nextGpuReconcileAt = Environment.TickCount64 + GpuReconcileIntervalMs;
 
+                _progress.Begin("Refreshing graphics adapters");
                 var reconcile = ReconcileGpus();
                 if (reconcile != GpuReconcileResult.Unchanged)
                 {
@@ -170,6 +267,7 @@ public class MonitorPoller(
             if (!_socketHost.HasConnections())
             {
                 //logger.LogInformation("No clients connected, waiting for connections...");
+                _progress.Ready();
                 await Task.Delay(1000, stoppingToken);
                 continue;
             }
@@ -178,6 +276,7 @@ public class MonitorPoller(
             {
                 try
                 {
+                    _progress.Begin($"Reading sensors: {hardware.Name}");
                     hardware.Update();
                 }
                 catch
@@ -200,6 +299,7 @@ public class MonitorPoller(
             // reuses existing entries, so a StopUpdates() suspension above
             // survives. On GPUs that activate everything up front (e.g. NVIDIA
             // via NvAPI) the count never moves and this whole block is a no-op.
+            _progress.Begin("Mapping sensor readings");
             var activeSensorCount = CountActiveSensors();
             if (activeSensorCount != knownSensorCount)
             {
@@ -218,6 +318,7 @@ public class MonitorPoller(
                 MapHardwareData(sharedMemoryData);
             }
 
+            _progress.Begin("Sending sensor readings");
             WriteDataToStream(writer, sharedMemoryData);
 
             if (_socketHost.HasConnections())
@@ -239,12 +340,11 @@ public class MonitorPoller(
             // collection; with a fixed 500 it instead tracked poll count, so at
             // the 33ms floor it forced a full GC roughly every 66ms, about 15x
             // too often, and only matched its intent at the default rate.
+            _progress.Ready();
             accumulator += _pollingRate;
             await Task.Delay(_pollingRate, stoppingToken);
         }
 
-        Stop();
-        hostApplicationLifetime.StopApplication();
     }
 
     private static void WriteDataToStream(BinaryWriter writer, SharedMemoryData sharedMemoryData)
@@ -754,14 +854,6 @@ public class MonitorPoller(
         }
 
         return count;
-    }
-
-    private void Stop()
-    {
-        _computer.Close();
-        _presentMonPoller.Stop();
-        _socketHost.Close();
-        _socketHost.OnClientData -= OnClientData;
     }
 
     private static SharedMemoryHardware MapHardware(IHardware hardware) => new()

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -39,6 +39,12 @@ public class MonitorPoller : BackgroundService
     // LHM 0.9.6 supports enabling groups after Open. This exposes which probe
     // stalls, and an exception in one group no longer skips every later group.
     private readonly Computer _computer = new();
+    private readonly IHardware[] _windowsMemory = [new WindowsMemoryHardware(), new WindowsMemoryHardware(virtualMemory: true)];
+
+    // MemoryGroup is intentionally never enabled: ordinary usage comes from
+    // Windows, without RAM-driver/SPD discovery. Include these stable sensors
+    // everywhere topology is mapped or counted so later refreshes retain them.
+    private IHardware[] HardwareSnapshot() => [.. _computer.Hardware, .. _windowsMemory];
 
     private readonly PipeHost _socketHost;
     private readonly PresentMonPoller _presentMonPoller;
@@ -166,14 +172,14 @@ public class MonitorPoller : BackgroundService
         logger.LogInformation("Hardware init: Computer.Open completed");
         stoppingToken.ThrowIfCancellationRequested();
 
-        // Keep LHM's original ordering, including CPU before GPU (Intel GPU
-        // discovery uses the CPU group). Every category previously enabled is
-        // still enabled; no board-specific blacklist or driver change.
+        // Keep CPU before GPU (Intel GPU discovery uses the CPU group).
+        // Replace only memory discovery with OS counters; this avoids the
+        // reported stalled MemoryGroup constructor while retaining RAM usage.
         HardwareDiscovery.Run(new (string, Action)[]
         {
             ("Discovering motherboard sensors", () => _computer.IsMotherboardEnabled = true),
             ("Discovering CPU sensors", () => _computer.IsCpuEnabled = true),
-            ("Discovering memory sensors", () => _computer.IsMemoryEnabled = true),
+            ("Reading Windows memory usage (no DIMM probing)", () => { foreach (var memory in _windowsMemory) memory.Update(); }),
             ("Discovering graphics sensors", () => _computer.IsGpuEnabled = true),
             ("Discovering controller sensors", () => _computer.IsControllerEnabled = true),
             ("Discovering storage sensors", () => _computer.IsStorageEnabled = true),
@@ -191,7 +197,7 @@ public class MonitorPoller : BackgroundService
 
         // Read each device separately as well: a thrown first read on one
         // device should not prevent initial readings from all later devices.
-        HardwareDiscovery.Run(_computer.Hardware.Select(hw =>
+        HardwareDiscovery.Run(HardwareSnapshot().Select(hw =>
             ($"First sensor read: {hw.Name}", (Action)(() => hw.Accept(new UpdateVisitor())))),
             _progress, logger, stoppingToken);
 
@@ -208,7 +214,7 @@ public class MonitorPoller : BackgroundService
 
         // Log discovered hardware and sensor counts for diagnostics
         int hwCount = 0, sensorCount = 0;
-        foreach (var hw in _computer.Hardware)
+        foreach (var hw in HardwareSnapshot())
         {
             hwCount++;
             sensorCount += hw.Sensors.Length;
@@ -224,7 +230,7 @@ public class MonitorPoller : BackgroundService
 
         // Log first few sensor values to check if readings are non-zero
         int logged = 0;
-        foreach (var hw in _computer.Hardware)
+        foreach (var hw in HardwareSnapshot())
         {
             foreach (var s in hw.Sensors)
             {
@@ -744,7 +750,7 @@ public class MonitorPoller : BackgroundService
     /// </summary>
     private void MapHardwareData(SharedMemoryData sharedMemoryData)
     {
-        var hardwares = _computer.Hardware;
+        var hardwares = HardwareSnapshot();
 
         MapHardwares(sharedMemoryData, hardwares);
         MapSensors(sharedMemoryData, hardwares);
@@ -851,7 +857,7 @@ public class MonitorPoller : BackgroundService
     {
         var count = 0;
 
-        foreach (var hardware in _computer.Hardware)
+        foreach (var hardware in HardwareSnapshot())
         {
             count += hardware.Sensors.Length;
             foreach (var subHardware in hardware.SubHardware)

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorPoller.cs
@@ -182,6 +182,13 @@ public class MonitorPoller : BackgroundService
             ("Discovering battery sensors", () => _computer.IsBatteryEnabled = true),
         }, _progress, logger, stoppingToken);
 
+        // LHM sets IsGpuEnabled only after all vendor groups are added. If
+        // enabling throws partway through, some groups can exist while the
+        // flag is still false; toggling false/true would not tear them down
+        // and could add duplicates. Keep any surviving groups for this run.
+        if (!_computer.IsGpuEnabled)
+            _gpuGroupRebuilds = MaxGpuGroupRebuilds;
+
         // Read each device separately as well: a thrown first read on one
         // device should not prevent initial readings from all later devices.
         HardwareDiscovery.Run(_computer.Hardware.Select(hw =>

--- a/HardwareMonitor/HardwareMonitor/Monitor/MonitorProgress.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/MonitorProgress.cs
@@ -1,0 +1,37 @@
+namespace HardwareMonitor.Monitor;
+
+internal record HardwareStatus(string State, string Stage, long ElapsedMs);
+
+/// <summary>
+/// One immutable observation shared by the hardware owner and pipe heartbeat.
+/// A delayed status is informational: it never cancels or retries native work.
+/// </summary>
+internal sealed class MonitorProgress
+{
+    internal const long DelayWarningMs = 45_000;
+    private sealed record Stage(string Name, long Since, bool Ready, bool Failed, bool HasReadings);
+    private Stage _stage = new("Starting hardware worker", Environment.TickCount64, false, false, false);
+
+    public void Begin(string name) =>
+        Volatile.Write(ref _stage, new Stage(name, Environment.TickCount64, false, false, Volatile.Read(ref _stage).HasReadings));
+
+    public void Ready() =>
+        Volatile.Write(ref _stage, new Stage("Hardware readings available", Environment.TickCount64, true, false, true));
+
+    public void Fail()
+    {
+        var stage = Volatile.Read(ref _stage);
+        Volatile.Write(ref _stage, stage with { Failed = true });
+    }
+
+    public HardwareStatus Read() => Read(Environment.TickCount64);
+
+    internal HardwareStatus Read(long now)
+    {
+        var stage = Volatile.Read(ref _stage);
+        var elapsed = Math.Max(0, now - stage.Since);
+        var state = stage.Failed ? "failed" : stage.Ready ? "ready"
+            : elapsed >= DelayWarningMs ? "delayed" : stage.HasReadings ? "ready" : "starting";
+        return new HardwareStatus(state, stage.Name, stage.Ready ? 0 : elapsed);
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/Monitor/WindowsMemoryHardware.cs
+++ b/HardwareMonitor/HardwareMonitor/Monitor/WindowsMemoryHardware.cs
@@ -1,0 +1,124 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using LibreHardwareMonitor.Hardware;
+
+namespace HardwareMonitor.Monitor;
+
+/// <summary>
+/// OS memory usage only. Deliberately never creates LHM's MemoryGroup, whose
+/// constructor also loads a RAM driver and probes DIMMs over SMBus. Those
+/// optional temperature/detail probes must not gate ordinary RAM usage.
+/// </summary>
+internal sealed class WindowsMemoryHardware : IHardware
+{
+    internal readonly record struct Snapshot(ulong TotalPhysical, ulong AvailablePhysical,
+        ulong TotalCommit, ulong AvailableCommit);
+
+    private readonly bool _virtual;
+    private readonly Func<Snapshot> _read;
+    private readonly MemorySensor _used;
+    private readonly MemorySensor _available;
+    private readonly MemorySensor _load;
+
+    internal WindowsMemoryHardware(bool virtualMemory = false, Func<Snapshot>? read = null)
+    {
+        _virtual = virtualMemory;
+        _read = read ?? ReadWindows;
+        Name = virtualMemory ? "Virtual Memory" : "Total Memory";
+        Identifier = new Identifier(virtualMemory ? "vram" : "ram");
+        // Preserve LHM 0.9.6 identifiers and GiB units, including its legacy
+        // /vram name for system committed memory (not GPU VRAM).
+        _used = new(this, "Memory Used", SensorType.Data, virtualMemory ? 2 : 0);
+        _available = new(this, "Memory Available", SensorType.Data, virtualMemory ? 3 : 1);
+        _load = new(this, "Memory", SensorType.Load, virtualMemory ? 1 : 0);
+        Sensors = [_used, _available, _load];
+    }
+
+    public void Update()
+    {
+        var sample = _read();
+        var total = _virtual ? sample.TotalCommit : sample.TotalPhysical;
+        var available = Math.Min(total, _virtual ? sample.AvailableCommit : sample.AvailablePhysical);
+        const double gib = 1024d * 1024 * 1024;
+        _used.Set(total == 0 ? null : (float)((total - available) / gib));
+        _available.Set(total == 0 ? null : (float)(available / gib));
+        _load.Set(total == 0 ? null : (float)(100d * (total - available) / total));
+    }
+
+    public HardwareType HardwareType => HardwareType.Memory;
+    public Identifier Identifier { get; }
+    public string Name { get; set; }
+    public IHardware Parent => null!;
+    public ISensor[] Sensors { get; }
+    public IHardware[] SubHardware => [];
+    public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
+#pragma warning disable CS0067 // Fixed topology; these events never fire.
+    public event SensorEventHandler? SensorAdded;
+    public event SensorEventHandler? SensorRemoved;
+#pragma warning restore CS0067
+    public void Accept(IVisitor visitor) => visitor.VisitHardware(this);
+    public void Traverse(IVisitor visitor) { foreach (var sensor in Sensors) sensor.Accept(visitor); }
+    public string GetReport() => "Windows GlobalMemoryStatusEx; DIMM/SMBus probing disabled";
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MemoryStatus
+    {
+        public uint Length;
+        public uint Load;
+        public ulong TotalPhysical;
+        public ulong AvailablePhysical;
+        public ulong TotalPageFile;
+        public ulong AvailablePageFile;
+        public ulong TotalVirtual;
+        public ulong AvailableVirtual;
+        public ulong AvailableExtendedVirtual;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GlobalMemoryStatusEx(ref MemoryStatus status);
+
+    internal static Snapshot ReadWindows()
+    {
+        var status = new MemoryStatus { Length = (uint)Marshal.SizeOf<MemoryStatus>() };
+        if (!GlobalMemoryStatusEx(ref status)) throw new Win32Exception(Marshal.GetLastWin32Error());
+        return new(status.TotalPhysical, status.AvailablePhysical, status.TotalPageFile, status.AvailablePageFile);
+    }
+
+    private sealed class MemorySensor : ISensor
+    {
+        internal MemorySensor(IHardware hardware, string name, SensorType type, int index)
+        {
+            Hardware = hardware;
+            Name = name;
+            SensorType = type;
+            Index = index;
+            Identifier = new Identifier(hardware.Identifier, type.ToString().ToLowerInvariant(), index.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+        internal void Set(float? value)
+        {
+            Value = value;
+            if (value is not { } v) return;
+            Min = Min.HasValue ? Math.Min(Min.Value, v) : v;
+            Max = Max.HasValue ? Math.Max(Max.Value, v) : v;
+        }
+        public IHardware Hardware { get; }
+        public Identifier Identifier { get; }
+        public string Name { get; set; }
+        public SensorType SensorType { get; }
+        public int Index { get; }
+        public float? Value { get; private set; }
+        public float? Min { get; private set; }
+        public float? Max { get; private set; }
+        public bool IsDefaultHidden => false;
+        public IControl Control => null!;
+        public IReadOnlyList<IParameter> Parameters => [];
+        public IEnumerable<SensorValue> Values => [];
+        public TimeSpan ValuesTimeWindow { get; set; } = TimeSpan.Zero;
+        public void Accept(IVisitor visitor) => visitor.VisitSensor(this);
+        public void Traverse(IVisitor visitor) { }
+        public void ResetMin() => Min = Value;
+        public void ResetMax() => Max = Value;
+        public void ClearValues() { }
+    }
+}

--- a/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
+++ b/HardwareMonitor/HardwareMonitor/PresentMon/PresentMonPoller.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -205,6 +205,8 @@ public class PresentMonPoller(ILogger logger)
     // first thing it does.
     internal void InitializeSensors()
     {
+        // The pipe-first host initializes these before accepting commands.
+        if (Displayed != null) return;
         _cultureInfo.NumberFormat.NumberDecimalSeparator = ".";
 
         Displayed = new PresentMonSensor(_hardware, "displayed", 0, "Displayed Frames");

--- a/HardwareMonitor/HardwareMonitor/Sockets/PipeHost.cs
+++ b/HardwareMonitor/HardwareMonitor/Sockets/PipeHost.cs
@@ -1,13 +1,13 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using Microsoft.Extensions.Logging;
 // ReSharper disable FieldCanBeMadeReadOnly.Local
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
 namespace HardwareMonitor.Sockets;
 
-public class PipeHost(ILogger logger)
+public class PipeHost(ILogger logger, string pipeName = "HardwareMonitor_31337")
 {
-    private readonly string _pipeName = "HardwareMonitor_31337";
+    private readonly string _pipeName = pipeName;
     private List<NamedPipeServerStream> _clients = [];
     private CancellationTokenSource _cancellationTokenSource = new();
     private Task _serverTask;

--- a/docs/windows-startup-investigation.md
+++ b/docs/windows-startup-investigation.md
@@ -53,3 +53,26 @@ The independent logs distinguish these next outcomes:
 See [test instructions](windows-startup-test.md) for log locations and the
 acceptance check. Sensor readings on the affected PC, not a green build or a
 connected pipe, determine whether this resolves that user's issue.
+
+## Follow-up: screenshot from startup.2
+
+The affected PC now reports a connected pipe and **Discovering memory sensors
+has not finished**. That stage surrounds `Computer.IsMemoryEnabled = true`,
+which constructs LibreHardwareMonitor 0.9.6's MemoryGroup. Earlier motherboard
+and CPU discovery calls have returned by this point (possibly with logged
+exceptions); this screenshot does not establish that all their readings work.
+
+MemoryGroup constructs the ordinary memory counters, then synchronously calls
+RAMSPDToolkit's driver loading and DIMM/SMBus discovery before its constructor
+returns. The screenshot cannot distinguish driver loading from a later DIMM
+probe, but it does identify this constructor as the blocked operation.
+
+Startup.3 avoids that constructor altogether. WindowsMemoryHardware reads
+GlobalMemoryStatusEx and publishes the existing physical (`/ram`) and committed
+memory (`/vram`) sensor IDs. It removes per-stick temperature/detail probing from
+this build; it does not disable RAM usage monitoring or replace PawnIO for other
+hardware. The next affected-PC test must confirm that discovery passes this stage
+and actual CPU/GPU/RAM readings arrive.
+
+Sources: [LHM MemoryGroup](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/v0.9.6/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs),
+[Windows GlobalMemoryStatusEx](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-globalmemorystatusex).

--- a/docs/windows-startup-investigation.md
+++ b/docs/windows-startup-investigation.md
@@ -1,0 +1,55 @@
+# Windows startup investigation
+
+The affected PC is reported as Windows 11, i7-14700K, RTX 4080 Super,
+32 GB RAM, and ASUS ROG Strix B760-F Gaming WiFi, without overclocking.
+Reported outcomes: v2.2.13 works; v2.2.14, v2.2.16, v2.2.17, and a build
+containing PR #67 fail. HardwareMonitor remains visible in Task Manager.
+The reported console output is "Starting monitor"; the original log is not
+available here. Whether any readings appear before the error is still unknown.
+
+## Release binary comparison
+
+Downloaded the actual GitHub release installers for v2.2.13 and v2.2.14 and
+extracted their NSIS resources. Parsed the .NET single-file bundle manifests
+using the .NET 8 HostModel format and compared the embedded file contents.
+
+- PawnIO_setup.exe is byte-identical (SHA-256
+  `a3a46226c5e2824f4cdd42be0eecbabfc672c86f7889710f5ab1e6ad385b47a0`).
+- presentmon.exe is byte-identical (SHA-256
+  `0ab15984223e84b2aa17be4a5a63b8097f006a74a281968cddc60f85f2149438`).
+- Both sidecar bundles contain 220 files; 219 are byte-identical, including
+  LibreHardwareMonitorLib.dll, dependency manifests, and runtime configuration.
+- Both bundle .NET runtime 8.0.28.
+- HardwareMonitor.dll differs in 94 bytes. Metadata inspection using
+  System.Reflection.Metadata found identical signatures for all 160 method
+  definitions and identical IL, stack sizes, local-signature tokens, and exception
+  regions for all 158 method bodies. Build revision strings and module IDs differ.
+- The Rust lockfile change in this version window is rustls-webpki
+  0.103.9 -> 0.103.13, not a Tauri/WebView2 dependency update.
+
+This does not identify the runtime failure. It does establish that a changed
+PawnIO installer, sensor-library DLL, .NET runtime, or C# method body is not the
+binary difference in this reported version boundary. Different launch timing,
+application behavior, installation state, security decisions, or extraction
+state still require runtime evidence; none is established as the cause.
+
+## What the test build addresses
+
+PR #67 handles EOF after a pipe reader disconnects. It does not establish a
+connection to a server that has not started, nor recover a native hardware call
+that never returns. The new build starts transport first, discovers sensor
+categories sequentially, isolates thrown discovery errors, and reports blocked
+stages without accessing hardware concurrently. A permanent native hang remains
+unresolved until its cause can be identified.
+
+The independent logs distinguish these next outcomes:
+
+- No named-pipe server startup: failure before transport startup.
+- Server waiting, client connection errors: investigate connection/launch state.
+- Connected, hardware stage delayed: identify the named hardware probe.
+- Rust logs a first sensor packet but the UI has no readings: investigate event
+  delivery or rendering rather than hardware discovery.
+
+See [test instructions](windows-startup-test.md) for log locations and the
+acceptance check. Sensor readings on the affected PC, not a green build or a
+connected pipe, determine whether this resolves that user's issue.

--- a/docs/windows-startup-test.md
+++ b/docs/windows-startup-test.md
@@ -1,0 +1,64 @@
+# Windows startup test build
+
+This build includes PR #67's reconnect fix plus independent pipe startup and
+hardware-stage reporting. It keeps PawnIO. It is a test build, not a release or
+a confirmed fix for the reported PC.
+
+Reported configuration: Windows 11, Intel Core i7-14700K, NVIDIA RTX 4080 Super,
+32 GB RAM, ASUS ROG Strix B760-F Gaming WiFi; no overclocking reported. The user
+reports v2.2.13 works, v2.2.14/.16/.17 fail, and a build containing #67 still fails.
+The exact failing native call has not been established.
+
+## Install and test
+
+1. Quit Cleanmeter from its tray menu, then install the included setup executable.
+2. Launch Cleanmeter and allow up to a minute for hardware discovery.
+3. Check for actual changing CPU, GPU, RAM and FPS readings. A connected pipe
+   alone is not a successful sensor test.
+4. If readings remain unavailable, the settings banner should name the stage
+   that has not finished (or failed). Capture that text.
+5. In Task Manager, right-click the **HardwareMonitor.exe** belonging to this
+   Cleanmeter installation and select **Open file location**. Open
+   `LogFiles/<date>/Log.txt` beside it. Share this log with the stage text.
+   It includes process ID and startup milestones. Review it before sharing;
+   it can include hardware names and running application names.
+
+The installer has no new signing certificate; it is an unsigned development
+build if repository signing is not configured. This workflow does not publish a
+release or change anyone else's installed version. Do not disable Windows
+security settings to test it.
+
+## What changed
+
+The named pipe starts before hardware enumeration. Sensor operations and cleanup
+remain on one worker; a delayed native call is never cancelled, retried in
+parallel, or closed by another thread. Slow discovery can complete later and
+send readings through the already connected pipe. Separate status packets report
+the current stage, including stalls during later sensor reads. No dummy sensor
+packets are sent to suppress the failure banner.
+
+Discovery enables the same sensor categories in the same order, but separately,
+using LibreHardwareMonitor 0.9.6's supported enable-after-open setters. An exception
+in motherboard discovery or an initial device read no longer skips all remaining
+categories/devices. Logs identify each category before calling its probe.
+
+A permanently blocked hardware call still prevents sensor readings. The build
+does not claim that starting PresentMon independently makes its FPS readings
+reach the overlay before hardware initialization; sensor publication still uses
+the hardware worker. Stage reporting is intended to identify the next specific
+fix if the ordering change is insufficient.
+
+## Validation and limits
+
+The Windows workflow runs the real named-pipe server with simulated blocked
+hardware, checks command and status traffic, releases the blocked operation and
+checks late publication. It also checks shutdown during a blocked operation.
+A mutation moving pipe startup behind the blocked operation must fail that
+regression test. Other checks cover C#, Rust, and frontend code, followed by a
+full Windows installer build.
+
+The simulated stall is a regression test, not a reproduction of this exact
+motherboard/driver failure. Real sensor success on the affected PC remains the
+acceptance test. The frontend build currently has unrelated existing standalone
+TypeScript type-check errors; the repository's lint, unit tests, and Vite build
+remain the checked baseline.

--- a/docs/windows-startup-test.md
+++ b/docs/windows-startup-test.md
@@ -22,6 +22,9 @@ The exact failing native call has not been established.
    `LogFiles/<date>/Log.txt` beside it. Share this log with the stage text.
    It includes process ID and startup milestones. Review it before sharing;
    it can include hardware names and running application names.
+6. Also collect `%LOCALAPPDATA%\Cleanmeter\Logs\cleanmeter.log`. This records
+   the app version, executable paths, sidecar PID, pipe errors, and whether a
+   first sensor packet reached the Rust client. Paths can contain your username.
 
 The installer has no new signing certificate; it is an unsigned development
 build if repository signing is not configured. This workflow does not publish a

--- a/docs/windows-startup-test.md
+++ b/docs/windows-startup-test.md
@@ -1,7 +1,7 @@
 # Windows startup test build
 
-This build includes PR #67's reconnect fix plus independent pipe startup and
-hardware-stage reporting. It keeps PawnIO. It is a test build, not a release or
+This build (2.2.17-startup.3) includes PR #67's reconnect fix, independent pipe startup,
+hardware-stage reporting, and a targeted replacement for stalled memory discovery. It keeps PawnIO. It is a test build, not a release or
 a confirmed fix for the reported PC.
 
 Reported configuration: Windows 11, Intel Core i7-14700K, NVIDIA RTX 4080 Super,
@@ -40,10 +40,12 @@ send readings through the already connected pipe. Separate status packets report
 the current stage, including stalls during later sensor reads. No dummy sensor
 packets are sent to suppress the failure banner.
 
-Discovery enables the same sensor categories in the same order, but separately,
-using LibreHardwareMonitor 0.9.6's supported enable-after-open setters. An exception
-in motherboard discovery or an initial device read no longer skips all remaining
-categories/devices. Logs identify each category before calling its probe.
+The affected PC reported a stall at **Discovering memory sensors** in startup.2.
+This build leaves LibreHardwareMonitor's MemoryGroup disabled and uses Windows'
+GlobalMemoryStatusEx for physical RAM and system committed-memory usage instead.
+It preserves the existing sensor IDs and GiB/percentage units. Per-DIMM
+identification and RAM-stick temperatures are not collected. CPU/GPU monitoring
+and PawnIO stay enabled. Other sensor categories are still discovered separately.
 
 A permanently blocked hardware call still prevents sensor readings. The build
 does not claim that starting PresentMon independently makes its FPS readings
@@ -60,7 +62,8 @@ A mutation moving pipe startup behind the blocked operation must fail that
 regression test. Other checks cover C#, Rust, and frontend code, followed by a
 full Windows installer build.
 
-The simulated stall is a regression test, not a reproduction of this exact
+The Windows check also verifies all six OS memory sensor identifiers and finite
+values through the published sidecar's real pipe. The simulated stall is a regression test, not a reproduction of this exact
 motherboard/driver failure. Real sensor success on the affected PC remains the
 acceptance test. The frontend build currently has unrelated existing standalone
 TypeScript type-check errors; the repository's lint, unit tests, and Vite build

--- a/scripts/test-windows-sidecar.ps1
+++ b/scripts/test-windows-sidecar.ps1
@@ -1,0 +1,50 @@
+$ErrorActionPreference = 'Stop'
+$publish = Resolve-Path 'HardwareMonitor/HardwareMonitor/bin/Release/net8.0/win-x64/publish'
+$evidence = New-Item -ItemType Directory -Force evidence
+$child = $null
+$pipe = $null
+$timeout = [Threading.CancellationTokenSource]::new([TimeSpan]::FromSeconds(90))
+
+function Read-Bytes([int]$count) {
+    $buffer = [byte[]]::new($count)
+    $offset = 0
+    while ($offset -lt $count) {
+        $read = $pipe.ReadAsync($buffer, $offset, $count - $offset, $timeout.Token).GetAwaiter().GetResult()
+        if ($read -eq 0) { throw 'Sidecar closed its pipe before verification completed' }
+        $offset += $read
+    }
+    return ,$buffer
+}
+
+try {
+    $child = Start-Process (Join-Path $publish 'HardwareMonitor.exe') -PassThru -WorkingDirectory $publish -RedirectStandardOutput "$evidence/sidecar-stdout.log" -RedirectStandardError "$evidence/sidecar-stderr.log"
+    $pipe = [IO.Pipes.NamedPipeClientStream]::new('.', 'HardwareMonitor_31337', [IO.Pipes.PipeDirection]::InOut, [IO.Pipes.PipeOptions]::Asynchronous)
+    $pipe.ConnectAsync($timeout.Token).GetAwaiter().GetResult()
+    $statusSeen = $false
+    $readingsSeen = $false
+    while (-not ($statusSeen -and $readingsSeen)) {
+        $header = Read-Bytes 6
+        $command = [BitConverter]::ToInt16($header, 0)
+        $length = [BitConverter]::ToInt32($header, 2)
+        if ($length -lt 0 -or $length -gt 4194304) { throw "Invalid frame length $length" }
+        $payload = Read-Bytes $length
+        if ($command -eq 6) {
+            $status = [Text.Encoding]::UTF8.GetString($payload)
+            $status | Add-Content "$evidence/live-hardware-status.jsonl"
+            $statusSeen = $true
+        }
+        if ($command -eq 0 -and $length -ge 8) {
+            $hardware = [BitConverter]::ToInt32($payload, 0)
+            $sensors = [BitConverter]::ToInt32($payload, 4)
+            "Hardware entries: $hardware; sensors: $sensors" | Add-Content "$evidence/live-sensor-counts.txt"
+            # Five PresentMon sensors alone do not demonstrate LHM success.
+            $readingsSeen = $hardware -gt 0 -and $sensors -gt 5
+        }
+    }
+    Write-Host 'Published Windows sidecar connected, reported progress, and sent real hardware sensor entries.'
+} finally {
+    if ($pipe) { $pipe.Dispose() }
+    if ($child -and -not $child.HasExited) { Stop-Process -Id $child.Id -Force }
+    $timeout.Dispose()
+    if (Test-Path "$publish/LogFiles") { Copy-Item "$publish/LogFiles" "$evidence/LogFiles" -Recurse -Force }
+}

--- a/scripts/test-windows-sidecar.ps1
+++ b/scripts/test-windows-sidecar.ps1
@@ -39,6 +39,35 @@ try {
             "Hardware entries: $hardware; sensors: $sensors" | Add-Content "$evidence/live-sensor-counts.txt"
             # Five PresentMon sensors alone do not demonstrate LHM success.
             $readingsSeen = $hardware -gt 0 -and $sensors -gt 5
+            if ($readingsSeen) {
+                $reader = [IO.BinaryReader]::new([IO.MemoryStream]::new([byte[]]$payload))
+                try {
+                    $null = $reader.ReadInt32(); $null = $reader.ReadInt32()
+                    for ($i = 0; $i -lt $hardware; $i++) {
+                        $nameLength = $reader.ReadInt16(); $idLength = $reader.ReadInt16()
+                        $null = $reader.ReadBytes($nameLength + $idLength)
+                        $null = $reader.ReadInt32()
+                    }
+                    $memory = @{}
+                    for ($i = 0; $i -lt $sensors; $i++) {
+                        $nameLength = $reader.ReadInt16(); $idLength = $reader.ReadInt16(); $hardwareLength = $reader.ReadInt16()
+                        $null = $reader.ReadBytes($nameLength)
+                        $id = [Text.Encoding]::UTF8.GetString($reader.ReadBytes($idLength))
+                        $null = $reader.ReadBytes($hardwareLength)
+                        $null = $reader.ReadInt32()
+                        $value = $reader.ReadSingle()
+                        if ($id.StartsWith('/ram/') -or $id.StartsWith('/vram/')) { $memory[$id] = $value }
+                    }
+                    $expected = @('/ram/load/0', '/ram/data/0', '/ram/data/1', '/vram/load/1', '/vram/data/2', '/vram/data/3')
+                    foreach ($id in $expected) {
+                        if (-not $memory.ContainsKey($id)) { throw "Missing OS memory sensor $id" }
+                        if ([float]::IsNaN($memory[$id]) -or [float]::IsInfinity($memory[$id])) { throw "Invalid value for $id" }
+                    }
+                    if ($memory['/ram/load/0'] -lt 0 -or $memory['/ram/load/0'] -gt 100) { throw 'RAM load outside percentage range' }
+                    if (($memory['/ram/data/0'] + $memory['/ram/data/1']) -le 0) { throw 'No physical memory reported' }
+                    $memory | ConvertTo-Json | Set-Content "$evidence/live-memory-values.json"
+                } finally { $reader.Dispose() }
+            }
         }
     }
     Write-Host 'Published Windows sidecar connected, reported progress, and sent real hardware sensor entries.'

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -255,7 +255,26 @@ pub fn run() {
         return;
     }
 
-    env_logger::init();
+    // A packaged GUI has no console. Persist connection/spawn diagnostics so
+    // a report can distinguish "server never opened" from a client failure.
+    let mut logger = env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("info"),
+    );
+    if let Some(base) = dirs::data_local_dir() {
+        let dir = base.join("Cleanmeter").join("Logs");
+        if std::fs::create_dir_all(&dir).is_ok() {
+            let path = dir.join("cleanmeter.log");
+            // Keep the previous log when rotating; never truncate on every
+            // launch (a second-instance invocation could erase the evidence).
+            if path.metadata().map(|m| m.len() > 2 * 1024 * 1024).unwrap_or(false) {
+                let _ = std::fs::rename(&path, dir.join("cleanmeter.previous.log"));
+            }
+            if let Ok(file) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+                logger.target(env_logger::Target::Pipe(Box::new(file)));
+            }
+        }
+    }
+    let _ = logger.try_init();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
@@ -272,7 +291,8 @@ pub fn run() {
             }
         }))
         .setup(|app| {
-            info!("Cleanmeter starting up...");
+            info!("Cleanmeter {} starting (pid {}, executable {:?})",
+                app.package_info().version, std::process::id(), std::env::current_exe());
 
             // Initialize the settings manager early so startup can read the
             // start_minimized preference before deciding whether to show the
@@ -409,6 +429,7 @@ pub fn run() {
                             .and_then(|p| p.parent().map(|d| d.join("HardwareMonitor.exe")))
                     })
                     .unwrap_or_else(|| std::path::PathBuf::from("HardwareMonitor.exe"));
+                info!("HardwareMonitor executable: {}", hw_exe.display());
 
                 // The PawnIO installer is bundled beside the sidecar as a Tauri
                 // resource; resolve it the same way so first-launch driver setup

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod pipe_client;
+mod pipe_input;
 mod shortcuts;
 mod settings;
 mod tray;

--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -421,16 +421,18 @@ pub async fn run_pipe_client(
                 });
 
                 // Async loop: forward events to Tauri and handle outgoing commands
-                loop {
-                    tokio::select! {
-                        Some(cmd) = cmd_rx.recv() => {
+                while let Some(input) =
+                    crate::pipe_input::next_input(&mut cmd_rx, &mut event_rx).await
+                {
+                    match input {
+                        crate::pipe_input::PipeInput::Command(cmd) => {
                             let bytes = build_command(&cmd);
                             if let Err(e) = writer.write_all(&bytes) {
                                 error!("Failed to send command: {}", e);
                                 break;
                             }
                         }
-                        Some(event) = event_rx.recv() => {
+                        crate::pipe_input::PipeInput::Event(event) => {
                             match event {
                                 ParsedEvent::SensorData(data) => {
                                     let _ = app_for_read.emit("sensor-data", &data);
@@ -440,7 +442,6 @@ pub async fn run_pipe_client(
                                 }
                             }
                         }
-                        else => break,
                     }
 
                     if !running.load(Ordering::Relaxed) {
@@ -448,6 +449,10 @@ pub async fn run_pipe_client(
                     }
                 }
 
+                // Report the lost connection before waiting or retrying. On
+                // reader EOF its task has finished and joining cannot stall.
+                let _ = app.emit("pipe-status", PipeStatus { connected: false });
+                announced_disconnect = true;
                 let _ = read_handle.await;
                 // The connection just ended: start a fresh fast-poll window so a
                 // sidecar crash reconnects as quickly as a cold start does.

--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -430,6 +430,7 @@ pub async fn run_pipe_client(
                 });
 
                 // Async loop: forward events to Tauri and handle outgoing commands
+                let mut received_sensor_data = false;
                 while let Some(input) =
                     crate::pipe_input::next_input(&mut cmd_rx, &mut event_rx).await
                 {
@@ -444,6 +445,11 @@ pub async fn run_pipe_client(
                         crate::pipe_input::PipeInput::Event(event) => {
                             match event {
                                 ParsedEvent::SensorData(data) => {
+                                    if !received_sensor_data {
+                                        info!("First sensor packet received: {} hardware entries, {} sensors",
+                                            data.hardwares.len(), data.sensors.len());
+                                        received_sensor_data = true;
+                                    }
                                     let _ = app_for_read.emit("sensor-data", &data);
                                 }
                                 ParsedEvent::HardwareStatus(status) => {

--- a/tauri-app/src-tauri/src/pipe_client.rs
+++ b/tauri-app/src-tauri/src/pipe_client.rs
@@ -35,6 +35,7 @@ const PRESENT_MON_APP_STRIDE: usize = 128;
 /// Events parsed from the pipe read thread
 enum ParsedEvent {
     SensorData(HardwareMonitorData),
+    HardwareStatus(HardwareStatus),
     PresentMonApps(Vec<String>),
 }
 
@@ -407,6 +408,14 @@ pub async fn run_pipe_client(
                                     Err(e) => error!("Failed to parse data packet: {}", e),
                                 }
                             }
+                            Ok(Command::HardwareStatus) => {
+                                match serde_json::from_slice::<HardwareStatus>(&payload) {
+                                    Ok(status) => {
+                                        let _ = event_tx.blocking_send(ParsedEvent::HardwareStatus(status));
+                                    }
+                                    Err(e) => error!("Failed to parse hardware status: {}", e),
+                                }
+                            }
                             Ok(Command::PresentMonApps) => {
                                 match parse_present_mon_apps(&payload) {
                                     Ok(apps) => {
@@ -436,6 +445,9 @@ pub async fn run_pipe_client(
                             match event {
                                 ParsedEvent::SensorData(data) => {
                                     let _ = app_for_read.emit("sensor-data", &data);
+                                }
+                                ParsedEvent::HardwareStatus(status) => {
+                                    let _ = app_for_read.emit("hardware-status", &status);
                                 }
                                 ParsedEvent::PresentMonApps(apps) => {
                                     let _ = app_for_read.emit("present-mon-apps", &apps);

--- a/tauri-app/src-tauri/src/pipe_input.rs
+++ b/tauri-app/src-tauri/src/pipe_input.rs
@@ -1,0 +1,80 @@
+use tokio::sync::mpsc;
+
+pub(crate) enum PipeInput<C, E> {
+    Command(C),
+    Event(E),
+}
+
+/// Reader EOF ends this connection even while the app's command sender lives.
+/// Matching only `Some(event)` inside select would disable that branch at EOF
+/// and wait indefinitely for a user command instead of reconnecting.
+pub(crate) async fn next_input<C, E>(
+    commands: &mut mpsc::Receiver<C>,
+    events: &mut mpsc::Receiver<E>,
+) -> Option<PipeInput<C, E>> {
+    tokio::select! {
+        Some(command) = commands.recv() => Some(PipeInput::Command(command)),
+        event = events.recv() => event.map(PipeInput::Event),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn reader_eof_ends_connection_with_command_sender_still_alive() {
+        let (command_tx, mut commands) = mpsc::channel::<()>(1);
+        let (event_tx, mut events) = mpsc::channel::<()>(1);
+        drop(event_tx);
+
+        let input = timeout(Duration::from_secs(1), next_input(&mut commands, &mut events))
+            .await
+            .expect("reader EOF must not wait for a user command");
+        assert!(input.is_none());
+        assert!(!command_tx.is_closed());
+    }
+
+    #[tokio::test]
+    async fn queued_sensor_events_are_drained_before_eof() {
+        let (_command_tx, mut commands) = mpsc::channel::<()>(1);
+        let (event_tx, mut events) = mpsc::channel(1);
+        event_tx.send(42).await.unwrap();
+        drop(event_tx);
+
+        assert!(matches!(
+            next_input(&mut commands, &mut events).await,
+            Some(PipeInput::Event(42))
+        ));
+        assert!(next_input(&mut commands, &mut events).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn commands_still_flow_while_reader_is_idle() {
+        let (command_tx, mut commands) = mpsc::channel(1);
+        let (_event_tx, mut events) = mpsc::channel::<()>(1);
+        command_tx.send(7).await.unwrap();
+
+        assert!(matches!(
+            next_input(&mut commands, &mut events).await,
+            Some(PipeInput::Command(7))
+        ));
+    }
+
+    #[tokio::test]
+    async fn closed_command_channel_does_not_drop_sensor_events() {
+        let (command_tx, mut commands) = mpsc::channel::<()>(1);
+        let (event_tx, mut events) = mpsc::channel(1);
+        drop(command_tx);
+        event_tx.send(42).await.unwrap();
+        drop(event_tx);
+
+        assert!(matches!(
+            next_input(&mut commands, &mut events).await,
+            Some(PipeInput::Event(42))
+        ));
+        assert!(next_input(&mut commands, &mut events).await.is_none());
+    }
+}

--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -9,6 +9,7 @@ pub enum Command {
     SelectPresentMonApp = 2,
     PresentMonApps = 3,
     SelectPollingRate = 4,
+    HardwareStatus = 6,
 }
 
 impl TryFrom<u16> for Command {
@@ -20,6 +21,7 @@ impl TryFrom<u16> for Command {
             2 => Ok(Command::SelectPresentMonApp),
             3 => Ok(Command::PresentMonApps),
             4 => Ok(Command::SelectPollingRate),
+            6 => Ok(Command::HardwareStatus),
             _ => Err(format!("Unknown command: {}", value)),
         }
     }
@@ -544,4 +546,23 @@ mod tests {
 
         assert_eq!(loaded.selected_gpu_id, "");
     }
+}
+
+/// Sidecar progress is independent of sensor packets: a connected pipe is not
+/// proof that a hardware read succeeded. Unknown states fail deserialization.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HardwareStatus {
+    pub state: HardwareState,
+    pub stage: String,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HardwareState {
+    Starting,
+    Ready,
+    Delayed,
+    Failed,
 }

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -59,7 +59,7 @@ function MonitoringBanner() {
 
   if (hardwareStatus && hardwareStatus.state !== "ready") {
     return (
-      <div className="border-b border-[var(--borderSubtle)] bg-[var(--bgSurfaceRaised)] px-4 py-2.5 text-[13px] leading-snug text-[var(--textBody)]" role="status">
+      <div className="border-b border-[var(--borderSubtle)] bg-[var(--bgSurfaceRaised)] px-4 py-2.5 text-[13px] leading-snug text-[var(--textParagraph1)]" role="status">
         <strong>Hardware readings unavailable.</strong>{" "}
         {hardwareStatus.stage} has {hardwareStatus.state === "failed" ? "failed" : "not finished"}.
         {" "}Cleanmeter is connected, but sensors are not ready. If this persists, share the HardwareMonitor log from its LogFiles folder.

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -21,6 +21,7 @@ function MonitoringBanner() {
   const sensorData = useSettingsStore((s) => s.sensorData);
   const pipeStatus = useSettingsStore((s) => s.pipeStatus);
   const sidecarStatus = useSettingsStore((s) => s.sidecarStatus);
+  const hardwareStatus = useSettingsStore((s) => s.hardwareStatus);
   const [graceExpired, setGraceExpired] = useState(false);
   const [dotnetMissing, setDotnetMissing] = useState(false);
 
@@ -40,20 +41,31 @@ function MonitoringBanner() {
     hasSensorData: !!sensorData,
     sidecar: sidecarStatus,
     graceExpired,
+    hardware: hardwareStatus,
   });
 
   // Only a failing verdict is worth telling the user about, and only then is it
   // worth paying for the .NET probe.
   useEffect(() => {
-    if (verdict !== "failed") return;
+    if (verdict !== "failed" || hardwareStatus) return;
     checkDotnetRuntime()
       .then((ok) => {
         if (!ok) setDotnetMissing(true);
       })
       .catch(() => {});
-  }, [verdict]);
+  }, [verdict, hardwareStatus]);
 
   if (verdict !== "failed") return null;
+
+  if (hardwareStatus && hardwareStatus.state !== "ready") {
+    return (
+      <div className="border-b border-[var(--borderSubtle)] bg-[var(--bgSurfaceRaised)] px-4 py-2.5 text-[13px] leading-snug text-[var(--textBody)]" role="status">
+        <strong>Hardware readings unavailable.</strong>{" "}
+        {hardwareStatus.stage} has {hardwareStatus.state === "failed" ? "failed" : "not finished"}.
+        {" "}Cleanmeter is connected, but sensors are not ready. If this persists, share the HardwareMonitor log from its LogFiles folder.
+      </div>
+    );
+  }
 
   return (
     <div className="border-b border-yellow-400 bg-yellow-50 px-4 py-2.5 text-[13px] leading-snug text-yellow-900 dark:border-yellow-700 dark:bg-yellow-950 dark:text-yellow-200">

--- a/tauri-app/src/hooks/useSensorData.ts
+++ b/tauri-app/src/hooks/useSensorData.ts
@@ -4,6 +4,7 @@ import {
   onPresentMonApps,
   onPipeStatus,
   onSidecarStatus,
+  onHardwareStatus,
 } from "@/lib/tauri";
 import { useSettingsStore } from "@/stores/settings-store";
 import type { HardwareMonitorData } from "@/lib/types";
@@ -12,6 +13,7 @@ export function useSensorData() {
   const setSensorData = useSettingsStore((s) => s.setSensorData);
   const setPresentMonApps = useSettingsStore((s) => s.setPresentMonApps);
   const setPipeStatus = useSettingsStore((s) => s.setPipeStatus);
+  const setHardwareStatus = useSettingsStore((s) => s.setHardwareStatus);
   const setSidecarStatus = useSettingsStore((s) => s.setSidecarStatus);
   const loadSidecarStatus = useSettingsStore((s) => s.loadSidecarStatus);
 
@@ -29,6 +31,9 @@ export function useSensorData() {
       const u3 = await onPipeStatus((status) => setPipeStatus(status));
       if (mounted) unlisteners.push(u3); else u3();
 
+      const u5 = await onHardwareStatus(setHardwareStatus);
+      if (mounted) unlisteners.push(u5); else u5();
+
       const u4 = await onSidecarStatus((status) => setSidecarStatus(status));
       if (mounted) unlisteners.push(u4); else u4();
 
@@ -44,7 +49,7 @@ export function useSensorData() {
       mounted = false;
       unlisteners.forEach((u) => u());
     };
-  }, [setSensorData, setPresentMonApps, setPipeStatus, setSidecarStatus, loadSidecarStatus]);
+  }, [setSensorData, setPresentMonApps, setPipeStatus, setSidecarStatus, setHardwareStatus, loadSidecarStatus]);
 }
 
 /** Hook for overlay — keeps a rolling buffer of frametime values */

--- a/tauri-app/src/hooks/useSensorData.ts
+++ b/tauri-app/src/hooks/useSensorData.ts
@@ -31,7 +31,13 @@ export function useSensorData() {
       const u3 = await onPipeStatus((status) => setPipeStatus(status));
       if (mounted) unlisteners.push(u3); else u3();
 
-      const u5 = await onHardwareStatus(setHardwareStatus);
+      const u5 = await onHardwareStatus((status) => {
+        // Pipe-first startup can connect before this webview subscribes to
+        // the one-shot pipe-status event. This heartbeat arrived over that
+        // pipe, so it also repairs missed initial connection state.
+        setPipeStatus({ connected: true });
+        setHardwareStatus(status);
+      });
       if (mounted) unlisteners.push(u5); else u5();
 
       const u4 = await onSidecarStatus((status) => setSidecarStatus(status));
@@ -82,4 +88,3 @@ export function useFrametimeHistory(maxPoints = 30) {
 
   return history;
 }
-

--- a/tauri-app/src/lib/monitoring.test.ts
+++ b/tauri-app/src/lib/monitoring.test.ts
@@ -97,3 +97,26 @@ describe("STARTUP_GRACE_MS", () => {
     expect(STARTUP_GRACE_MS).toBeGreaterThan(slowestObservedMs * 2);
   });
 });
+
+describe("hardware progress", () => {
+  it("does not treat a connected sidecar's startup as successful sensor data", () => {
+    expect(monitoringVerdict({
+      hasSensorData: true, sidecar: healthy, graceExpired: false,
+      hardware: { state: "starting", stage: "Opening hardware sensors", elapsedMs: 1000 },
+    })).toBe("starting");
+  });
+
+  it.each(["delayed", "failed"] as const)("reports %s despite an old sensor snapshot", (state) => {
+    expect(monitoringVerdict({
+      hasSensorData: true, sidecar: healthy, graceExpired: true,
+      hardware: { state, stage: "Reading CPU sensors", elapsedMs: 45000 },
+    })).toBe("failed");
+  });
+
+  it("recovers when late hardware readings become available", () => {
+    expect(monitoringVerdict({
+      hasSensorData: true, sidecar: healthy, graceExpired: true,
+      hardware: { state: "ready", stage: "Hardware readings available", elapsedMs: 0 },
+    })).toBe("ok");
+  });
+});

--- a/tauri-app/src/lib/monitoring.ts
+++ b/tauri-app/src/lib/monitoring.ts
@@ -1,4 +1,4 @@
-import type { SidecarStatus } from "./types";
+import type { HardwareStatus, SidecarStatus } from "./types";
 
 /**
  * How long a launch may go without a reading before we call it broken.
@@ -46,8 +46,12 @@ export function monitoringVerdict(input: {
   hasSensorData: boolean;
   sidecar: SidecarStatus;
   graceExpired: boolean;
+  hardware?: HardwareStatus | null;
 }): MonitoringVerdict {
-  // A reading settles it, whatever happened on the way here.
+  // An old snapshot does not override a current blocked/failed hardware read.
+  if (input.hardware?.state === "delayed" || input.hardware?.state === "failed") return "failed";
+  if (input.hardware?.state === "starting") return input.graceExpired ? "failed" : "starting";
+  // A reading settles it when the hardware worker has reported no problem.
   if (input.hasSensorData) return "ok";
   // Evidence of real failure, worth saying so without waiting.
   if (input.sidecar.spawnError) return "failed";

--- a/tauri-app/src/lib/tauri.ts
+++ b/tauri-app/src/lib/tauri.ts
@@ -2,6 +2,7 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
 import type {
   OverlaySettings,
   HardwareMonitorData,
+  HardwareStatus,
   PipeStatus,
   MonitorInfo,
   AppPreferences,
@@ -274,3 +275,8 @@ export const pickImageAttachment = async (): Promise<
   const name = selected.split(/[/\\]/).pop() ?? "attachment";
   return { path: selected, name };
 };
+
+export const onHardwareStatus = (
+  callback: (status: HardwareStatus) => void
+): Promise<UnlistenFn> =>
+  safeListen<HardwareStatus>("hardware-status", (event) => callback(event.payload));

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -271,3 +271,10 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
     downRate: { isEnabled: true, customReadingId: "" },
   },
 };
+
+/** Hardware progress, sent even when no sensor readings can be produced. */
+export interface HardwareStatus {
+  state: "starting" | "ready" | "delayed" | "failed";
+  stage: string;
+  elapsedMs: number;
+}

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type {
   OverlaySettings,
   HardwareMonitorData,
+  HardwareStatus,
   PipeStatus,
   SidecarStatus,
   SensorKey,
@@ -234,6 +235,8 @@ interface SettingsStore {
   presentMonApps: string[];
   pipeStatus: PipeStatus;
   sidecarStatus: SidecarStatus;
+  hardwareStatus: HardwareStatus | null;
+  setHardwareStatus: (status: HardwareStatus) => void;
   overlayVisible: boolean;
   appVersion: string;
   /**
@@ -298,6 +301,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   sensorData: null,
   presentMonApps: [],
   pipeStatus: { connected: false },
+  hardwareStatus: null,
+  setHardwareStatus: (status) => set({ hardwareStatus: status }),
   // Nothing has gone wrong until the supervisor says so, so a launch reads as
   // "still starting" rather than as a failure.
   sidecarStatus: { exits: 0, spawnError: null },
@@ -562,7 +567,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   },
   setPipeStatus: (status) => {
     const wasConnected = get().pipeStatus.connected;
-    set({ pipeStatus: status });
+    set({ pipeStatus: status, ...(!status.connected ? { hardwareStatus: null } : {}) });
     // After a (re)connect, resync the target-app filter — the C# poller
     // restarts with `_currentSelectedApp = NONE`, so without this it would
     // count every app's frames again until the next dropdown change.


### PR DESCRIPTION
The affected PC now connects to HardwareMonitor in approximately 0.5 seconds, but reports “Discovering memory sensors has not finished.” LibreHardwareMonitor 0.9.6 performs RAM-driver and DIMM/SMBus discovery inside that stage, even when only ordinary RAM usage is needed. Replace that memory group with Windows GlobalMemoryStatusEx readings so this optional discovery no longer blocks CPU/GPU/RAM publication.

Preserve existing physical RAM and committed-memory sensor IDs and GiB/percentage units. PawnIO remains in use for other hardware. Individual DIMM temperatures and details are no longer collected. The screenshot identifies the stalled stage, not the exact driver or SMBus operation inside it; successful testing on the affected ASUS board remains required.

This PR also starts the pipe independently of hardware discovery, reports the active hardware stage to the UI and persistent logs, and includes #67's EOF reconnect fix. Hardware access and cleanup remain serialized on one worker. No timed-out native call is abandoned and then accessed concurrently. The affected user already tested #67 without success; the newer startup.2 build exposed the memory-discovery stall that this revision addresses.

Validation includes Windows unit tests for memory values, stable IDs, zero totals, and a direct OS memory read; a published-sidecar test requiring all six real memory readings over the named pipe; blocked-startup and shutdown tests; and a mutation check proving the connection test rejects hardware-first startup. The Windows runner is a VM, not a reproduction on the affected i7-14700K / RTX 4080 Super / ROG Strix B760-F Gaming WiFi PC.

[Build and test evidence](https://github.com/SupaStellar/Cleanmeter/actions/runs/34157574753). The development installer is version 2.2.17-startup.3; no release is published and this PR is not merged. [Test instructions](docs/windows-startup-test.md) and [investigation details](docs/windows-startup-investigation.md).

Acceptance on the affected PC requires actual changing CPU/GPU/RAM readings. A connected pipe alone is not success. Other native discovery stages can still stall; stage reporting remains available if another blocker appears.

Completed validation for 0ddbc3e: 41 C# tests, 30 Rust tests, 135 frontend tests, lint, and full Windows NSIS build passed. The published sidecar sent 61 sensors across seven hardware entries, including physical RAM usage of 3.13 GiB / 19.60% on the runner. The installer checksum was verified after download.
