### PR TITLE
Add CPU and GPU clock speed readings to the overlay

### DIFF
--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -265,6 +265,8 @@ pub struct SensorsConfig {
     pub cpu_usage: GraphSensorConfig,
     #[serde(rename = "cpuConsumption")]
     pub cpu_consumption: SensorConfig,
+    #[serde(rename = "cpuClock", default = "sensor_config_disabled")]
+    pub cpu_clock: SensorConfig,
     #[serde(rename = "gpuTemp")]
     pub gpu_temp: GraphSensorConfig,
     #[serde(rename = "gpuUsage")]
@@ -273,6 +275,8 @@ pub struct SensorsConfig {
     pub vram_usage: GraphSensorConfig,
     #[serde(rename = "gpuConsumption")]
     pub gpu_consumption: SensorConfig,
+    #[serde(rename = "gpuClock", default = "sensor_config_disabled")]
+    pub gpu_clock: SensorConfig,
     #[serde(rename = "totalVramUsed")]
     pub total_vram_used: SensorConfig,
     #[serde(rename = "ramUsage")]
@@ -293,10 +297,12 @@ impl Default for SensorsConfig {
             cpu_temp: GraphSensorConfig::default(),
             cpu_usage: GraphSensorConfig::default(),
             cpu_consumption: SensorConfig::default(),
+            cpu_clock: sensor_config_disabled(),
             gpu_temp: GraphSensorConfig::default(),
             gpu_usage: GraphSensorConfig::default(),
             vram_usage: GraphSensorConfig::default(),
             gpu_consumption: SensorConfig::default(),
+            gpu_clock: sensor_config_disabled(),
             total_vram_used: SensorConfig::default(),
             ram_usage: GraphSensorConfig::default(),
             up_rate: SensorConfig::default(),
@@ -506,6 +512,21 @@ pub struct MonitorInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clock_settings_upgrade_and_round_trip() {
+        let mut value = serde_json::to_value(OverlaySettings::default()).unwrap();
+        value["sensors"].as_object_mut().unwrap().remove("cpuClock");
+        value["sensors"].as_object_mut().unwrap().remove("gpuClock");
+        let mut loaded: OverlaySettings = serde_json::from_value(value).unwrap();
+        assert!(!loaded.sensors.cpu_clock.is_enabled);
+        assert!(!loaded.sensors.gpu_clock.is_enabled);
+        loaded.sensors.gpu_clock.is_enabled = true;
+        loaded.sensors.gpu_clock.custom_reading_id = "/gpu-nvidia/0/clock/0".into();
+        let restored: OverlaySettings = serde_json::from_str(&serde_json::to_string(&loaded).unwrap()).unwrap();
+        assert!(restored.sensors.gpu_clock.is_enabled);
+        assert_eq!(restored.sensors.gpu_clock.custom_reading_id, "/gpu-nvidia/0/clock/0");
+    }
 
     /// The settings file is written by deserialising the app's JSON into
     /// OverlaySettings and serialising it straight back out, so any field the

--- a/tauri-app/src/components/overlay/CpuSection.tsx
+++ b/tauri-app/src/components/overlay/CpuSection.tsx
@@ -17,11 +17,13 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
   const labelFontSize = settings.fontSizeLabel ?? 12;
   const valueFontWeight = settings.fontWeight ?? 500;
   const labelFontWeight = settings.labelFontWeight ?? 500;
-  const { cpuTemp, cpuUsage, cpuConsumption } = settings.sensors;
+  const { cpuTemp, cpuUsage, cpuConsumption, cpuClock } = settings.sensors;
+  const clock = findSensorById(sensors, cpuClock.customReadingId);
+  const clockLabel = clock && Number.isFinite(clock.value) && clock.value >= 0 ? formatValue(clock.value) : "—";
   const progressType = settings.progressType;
 
   const anyEnabled =
-    cpuTemp.isEnabled || cpuUsage.isEnabled || cpuConsumption.isEnabled;
+    cpuTemp.isEnabled || cpuUsage.isEnabled || cpuConsumption.isEnabled || cpuClock.isEnabled;
 
   if (!anyEnabled) return null;
 
@@ -80,6 +82,12 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
             {formatValue(cpuPowerVal)}
           </span>
           <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>W</span>
+        </div>
+      )}
+      {cpuClock.isEnabled && (
+        <div className="flex items-center gap-1" title={clock?.name ?? "Clock unavailable"}>
+          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">{clockLabel}</span>
+          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>MHz</span>
         </div>
       )}
     </Pill>

--- a/tauri-app/src/components/overlay/CpuSection.tsx
+++ b/tauri-app/src/components/overlay/CpuSection.tsx
@@ -2,7 +2,7 @@ import { Pill } from "./Pill";
 import { ProgressRing } from "./ProgressRing";
 import { ProgressBar } from "./ProgressBar";
 import { useSettingsStore } from "@/stores/settings-store";
-import { findSensorById, formatValue, formatTemperature } from "@/lib/utils";
+import { findSensorById, formatClockLabel, formatValue, formatTemperature } from "@/lib/utils";
 
 interface CpuSectionProps {
   isHorizontal: boolean;
@@ -19,7 +19,7 @@ export function CpuSection({ isHorizontal }: CpuSectionProps) {
   const labelFontWeight = settings.labelFontWeight ?? 500;
   const { cpuTemp, cpuUsage, cpuConsumption, cpuClock } = settings.sensors;
   const clock = findSensorById(sensors, cpuClock.customReadingId);
-  const clockLabel = clock && Number.isFinite(clock.value) && clock.value >= 0 ? formatValue(clock.value) : "—";
+  const clockLabel = formatClockLabel(clock);
   const progressType = settings.progressType;
 
   const anyEnabled =

--- a/tauri-app/src/components/overlay/GpuSection.tsx
+++ b/tauri-app/src/components/overlay/GpuSection.tsx
@@ -19,8 +19,10 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
   const labelFontSize = settings.fontSizeLabel ?? 12;
   const valueFontWeight = settings.fontWeight ?? 500;
   const labelFontWeight = settings.labelFontWeight ?? 500;
-  const { gpuTemp, gpuUsage, vramUsage, totalVramUsed, gpuConsumption } =
+  const { gpuTemp, gpuUsage, vramUsage, totalVramUsed, gpuConsumption, gpuClock } =
     settings.sensors;
+  const clock = findSensorById(sensors, gpuClock.customReadingId);
+  const clockLabel = clock && Number.isFinite(clock.value) && clock.value >= 0 ? formatValue(clock.value) : "—";
   const progressType = settings.progressType;
 
   const anyEnabled =
@@ -28,7 +30,7 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
     gpuUsage.isEnabled ||
     vramUsage.isEnabled ||
     totalVramUsed.isEnabled ||
-    gpuConsumption.isEnabled;
+    gpuConsumption.isEnabled || gpuClock.isEnabled;
 
   if (!anyEnabled) return null;
 
@@ -148,6 +150,12 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
             {formatValue(gpuPowerVal)}
           </span>
           <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>W</span>
+        </div>
+      )}
+      {gpuClock.isEnabled && (
+        <div className="flex items-center gap-1" title={clock?.name ?? "Clock unavailable"}>
+          <span style={{ fontSize: valueFontSize, fontWeight: valueFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "-0.02em" }} className="tabular-nums">{clockLabel}</span>
+          <span style={{ fontSize: labelFontSize, fontWeight: labelFontWeight, color: "var(--overlay-text)", fontFamily: "Inter", letterSpacing: "0.04em" }}>MHz</span>
         </div>
       )}
     </Pill>

--- a/tauri-app/src/components/overlay/GpuSection.tsx
+++ b/tauri-app/src/components/overlay/GpuSection.tsx
@@ -4,7 +4,7 @@ import { ProgressBar } from "./ProgressBar";
 import { useSettingsStore } from "@/stores/settings-store";
 import { SensorType } from "@/lib/types";
 import type { Sensor } from "@/lib/types";
-import { findSensorById, formatValue, formatTemperature } from "@/lib/utils";
+import { findSensorById, formatClockLabel, formatValue, formatTemperature } from "@/lib/utils";
 
 interface GpuSectionProps {
   isHorizontal: boolean;
@@ -22,7 +22,7 @@ export function GpuSection({ isHorizontal }: GpuSectionProps) {
   const { gpuTemp, gpuUsage, vramUsage, totalVramUsed, gpuConsumption, gpuClock } =
     settings.sensors;
   const clock = findSensorById(sensors, gpuClock.customReadingId);
-  const clockLabel = clock && Number.isFinite(clock.value) && clock.value >= 0 ? formatValue(clock.value) : "—";
+  const clockLabel = formatClockLabel(clock);
   const progressType = settings.progressType;
 
   const anyEnabled =

--- a/tauri-app/src/components/settings/stats/CpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/CpuSection.tsx
@@ -15,9 +15,9 @@ export function CpuSection({ sensors, hardwares }: Props) {
   const settings = useSettingsStore((s) => s.settings);
   const updateSensor = useSettingsStore((s) => s.updateSensor);
   const updateBoundary = useSettingsStore((s) => s.updateBoundary);
-  const { cpuUsage, cpuTemp, cpuConsumption } = settings.sensors;
+  const { cpuUsage, cpuTemp, cpuConsumption, cpuClock } = settings.sensors;
   const anyEnabled =
-    cpuUsage.isEnabled || cpuTemp.isEnabled || cpuConsumption.isEnabled;
+    cpuUsage.isEnabled || cpuTemp.isEnabled || cpuConsumption.isEnabled || cpuClock.isEnabled;
 
   const cpuHwIds = new Set(
     hardwares.filter((h) => h.hardwareType === HardwareType.Cpu).map((h) => h.identifier),
@@ -32,10 +32,13 @@ export function CpuSection({ sensors, hardwares }: Props) {
     (s) => cpuHwIds.has(s.hardwareIdentifier) && s.sensorType === SensorType.Power,
   );
 
+  const cpuClockSensors = sensors.filter((s) => cpuHwIds.has(s.hardwareIdentifier) && s.sensorType === SensorType.Clock);
+
   const prevState = useRef<{
     cpuUsage: boolean;
     cpuTemp: boolean;
     cpuConsumption: boolean;
+    cpuClock: boolean;
   } | null>(null);
 
   const handleMaster = (enabled: boolean) => {
@@ -44,15 +47,18 @@ export function CpuSection({ sensors, hardwares }: Props) {
         cpuUsage: cpuUsage.isEnabled,
         cpuTemp: cpuTemp.isEnabled,
         cpuConsumption: cpuConsumption.isEnabled,
+        cpuClock: cpuClock.isEnabled,
       };
       updateSensor("cpuUsage", { isEnabled: false });
       updateSensor("cpuTemp", { isEnabled: false });
       updateSensor("cpuConsumption", { isEnabled: false });
+      updateSensor("cpuClock", { isEnabled: false });
     } else {
       const prev = prevState.current;
       updateSensor("cpuUsage", { isEnabled: prev ? prev.cpuUsage : true });
       updateSensor("cpuTemp", { isEnabled: prev ? prev.cpuTemp : true });
       updateSensor("cpuConsumption", { isEnabled: prev ? prev.cpuConsumption : true });
+      updateSensor("cpuClock", { isEnabled: prev ? prev.cpuClock : false });
     }
   };
 
@@ -115,6 +121,17 @@ export function CpuSection({ sensors, hardwares }: Props) {
               }
             />
           )}
+        </SubCollapsible>
+        <SubCollapsible
+          label="CPU Clock"
+          checked={cpuClock.isEnabled}
+          onCheckedChange={(v) => updateSensor("cpuClock", { isEnabled: v })}
+        >
+          {cpuClockSensors.length > 0 ? (
+            <SensorSelect label="CPU Clock" value={cpuClock.customReadingId}
+              options={cpuClockSensors} onChange={(v) => updateSensor("cpuClock", { customReadingId: v })} />
+          ) : <p className="text-body-sm-regular text-[var(--textParagraph1)]">No clock sensor is available yet.</p>}
+          <p className="text-body-sm-regular text-[var(--textParagraph1)]">Clock speed in MHz; choose the CPU core to display.</p>
         </SubCollapsible>
       </div>
     </SectionCard>

--- a/tauri-app/src/components/settings/stats/GpuSection.tsx
+++ b/tauri-app/src/components/settings/stats/GpuSection.tsx
@@ -25,7 +25,7 @@ export function GpuSection({ sensors, hardwares }: Props) {
   const updateSensor = useSettingsStore((s) => s.updateSensor);
   const updateBoundary = useSettingsStore((s) => s.updateBoundary);
   const selectGpu = useSettingsStore((s) => s.selectGpu);
-  const { gpuUsage, gpuTemp, gpuConsumption, vramUsage } = settings.sensors;
+  const { gpuUsage, gpuTemp, gpuConsumption, gpuClock, vramUsage } = settings.sensors;
 
   const gpus = listGpus(hardwares);
   // Every row below draws from one GPU. Scoping the option lists is what makes
@@ -47,12 +47,15 @@ export function GpuSection({ sensors, hardwares }: Props) {
     gpuUsage.isEnabled ||
     gpuTemp.isEnabled ||
     gpuConsumption.isEnabled ||
-    vramUsage.isEnabled;
+    vramUsage.isEnabled || gpuClock.isEnabled;
+
+  const gpuClockSensors = gpuSensors.filter((s) => s.sensorType === SensorType.Clock);
 
   const prevState = useRef<{
     gpuUsage: boolean;
     gpuTemp: boolean;
     gpuConsumption: boolean;
+    gpuClock: boolean;
     vramUsage: boolean;
   } | null>(null);
 
@@ -62,11 +65,13 @@ export function GpuSection({ sensors, hardwares }: Props) {
         gpuUsage: gpuUsage.isEnabled,
         gpuTemp: gpuTemp.isEnabled,
         gpuConsumption: gpuConsumption.isEnabled,
+        gpuClock: gpuClock.isEnabled,
         vramUsage: vramUsage.isEnabled,
       };
       updateSensor("gpuUsage", { isEnabled: false });
       updateSensor("gpuTemp", { isEnabled: false });
       updateSensor("gpuConsumption", { isEnabled: false });
+      updateSensor("gpuClock", { isEnabled: false });
       updateSensor("vramUsage", { isEnabled: false });
       // totalVramUsed (the VRAM GB reading) rides along with vramUsage so the
       // overlay's GB cluster stays in sync — they're one "VRAM" control.
@@ -76,6 +81,7 @@ export function GpuSection({ sensors, hardwares }: Props) {
       updateSensor("gpuUsage", { isEnabled: prev ? prev.gpuUsage : true });
       updateSensor("gpuTemp", { isEnabled: prev ? prev.gpuTemp : true });
       updateSensor("gpuConsumption", { isEnabled: prev ? prev.gpuConsumption : true });
+      updateSensor("gpuClock", { isEnabled: prev ? prev.gpuClock : false });
       updateSensor("vramUsage", { isEnabled: prev ? prev.vramUsage : true });
       updateSensor("totalVramUsed", { isEnabled: prev ? prev.vramUsage : true });
     }
@@ -194,6 +200,17 @@ export function GpuSection({ sensors, hardwares }: Props) {
             boundaries={vramUsage.boundaries}
             onChange={(b) => updateBoundary("vramUsage", b)}
           />
+        </SubCollapsible>
+        <SubCollapsible
+          label="GPU Clock"
+          checked={gpuClock.isEnabled}
+          onCheckedChange={(v) => updateSensor("gpuClock", { isEnabled: v })}
+        >
+          {gpuClockSensors.length > 0 ? (
+            <SensorSelect label="GPU Clock" value={gpuClock.customReadingId}
+              options={gpuClockSensors} onChange={(v) => updateSensor("gpuClock", { customReadingId: v })} />
+          ) : <p className="text-body-sm-regular text-[var(--textParagraph1)]">No clock sensor is available yet.</p>}
+          <p className="text-body-sm-regular text-[var(--textParagraph1)]">Clock speed in MHz.</p>
         </SubCollapsible>
       </div>
     </SectionCard>

--- a/tauri-app/src/lib/preview-fixture.ts
+++ b/tauri-app/src/lib/preview-fixture.ts
@@ -70,6 +70,11 @@ export function previewSensorData(): HardwareMonitorData {
       sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/2", "GPU Memory Total", SensorType.SmallData, 4096),
       sensor("/gpu-nvidia/0", "/gpu-nvidia/0/smalldata/9", "D3D Dedicated Memory Used", SensorType.SmallData, 2048),
 
+      // Representative clock readings for exercising the optional HUD controls.
+      sensor("/intelcpu/0", "/intelcpu/0/clock/1", "CPU Core #1", SensorType.Clock, 4200),
+      sensor("/gpu-nvidia/0", "/gpu-nvidia/0/clock/0", "GPU Core", SensorType.Clock, 1755),
+      sensor("/gpu-intel/0", "/gpu-intel/0/clock/0", "GPU Core", SensorType.Clock, 900),
+
       // Integrated GPU: load through D3D engine nodes, and its only "memory
       // total" is system memory it may borrow.
       sensor("/gpu-intel/0", "/gpu-intel/0/load/0", "D3D 3D", SensorType.Load, 7),

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -70,10 +70,12 @@ export interface SensorsConfig {
   cpuTemp: GraphSensorConfig;
   cpuUsage: GraphSensorConfig;
   cpuConsumption: SensorConfig;
+  cpuClock: SensorConfig;
   gpuTemp: GraphSensorConfig;
   gpuUsage: GraphSensorConfig;
   vramUsage: GraphSensorConfig;
   gpuConsumption: SensorConfig;
+  gpuClock: SensorConfig;
   totalVramUsed: SensorConfig;
   ramUsage: GraphSensorConfig;
   upRate: SensorConfig;
@@ -261,10 +263,12 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
     cpuTemp: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     cpuUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     cpuConsumption: { isEnabled: true, customReadingId: "" },
+    cpuClock: { isEnabled: false, customReadingId: "" },
     gpuTemp: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     gpuUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     vramUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     gpuConsumption: { isEnabled: true, customReadingId: "" },
+    gpuClock: { isEnabled: false, customReadingId: "" },
     totalVramUsed: { isEnabled: true, customReadingId: "" },
     ramUsage: { isEnabled: true, customReadingId: "", boundaries: { low: 60, medium: 80, high: 90 } },
     upRate: { isEnabled: true, customReadingId: "" },

--- a/tauri-app/src/lib/utils.test.ts
+++ b/tauri-app/src/lib/utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { getBoundaryColor, formatValue } from "./utils";
+import { getBoundaryColor, formatValue, formatClockLabel } from "./utils";
+import type { Sensor } from "./types";
+import { SensorType } from "./types";
 
 const GREEN = "var(--green500)";
 const YELLOW = "var(--yellow300)";
@@ -44,5 +46,41 @@ describe("getBoundaryColor", () => {
 
     expect(formatValue(40.4)).toBe("40");
     expect(getBoundaryColor(40.4, B)).toBe(RED);
+  });
+});
+
+describe("formatClockLabel", () => {
+  const clock = (value: number): Sensor => ({
+    name: "Cores _Average_",
+    identifier: "/amdcpu/0/clock/1",
+    hardwareIdentifier: "/amdcpu/0",
+    sensorType: SensorType.Clock,
+    value,
+  });
+
+  it("prints whole MHz for a real reading", () => {
+    expect(formatClockLabel(clock(4347))).toBe("4347");
+    // GPU memory clocks arrive fractional off the wire (5001.99 on an
+    // RTX 4080 SUPER); the pill shows integer MHz.
+    expect(formatClockLabel(clock(5001.99))).toBe("5002");
+  });
+
+  it("dashes when the sensor is absent from the frame", () => {
+    // An unsupported CPU exposes no Clock sensors, and a modern AMD GPU
+    // reports none until ADL's PMLog block has updated once.
+    expect(formatClockLabel(undefined)).toBe("—");
+  });
+
+  it("dashes on 0, which is how a failed read arrives", () => {
+    // The sidecar coalesces a null or NaN sensor value to 0f in MapSensor, so
+    // 0 means "no reading". Nothing reports 0 MHz while it is running, and a
+    // ">= 0" guard here would print "0 MHz" on a dead sensor instead.
+    expect(formatClockLabel(clock(0))).toBe("—");
+  });
+
+  it("dashes on values that cannot be rendered", () => {
+    expect(formatClockLabel(clock(NaN))).toBe("—");
+    expect(formatClockLabel(clock(Infinity))).toBe("—");
+    expect(formatClockLabel(clock(-1))).toBe("—");
   });
 });

--- a/tauri-app/src/lib/utils.ts
+++ b/tauri-app/src/lib/utils.ts
@@ -82,6 +82,23 @@ export function formatNetworkRate(bytesPerSec: number): string {
   return `${value} ${unit}`;
 }
 
+/**
+ * Render a clock sensor as whole MHz, or an em dash when there is no reading.
+ *
+ * The dash covers both ways a clock can be missing, which are not the same
+ * thing. The sensor can be absent from the frame entirely (an unsupported CPU
+ * exposes no Clock sensors at all, and a modern AMD GPU reports none until
+ * ADL's PMLog block has been updated once), or it can be present and reading
+ * nothing. The second case arrives as 0, because the sidecar coalesces a null
+ * or NaN sensor value to 0f in MapSensor, so 0 has to be treated as "no
+ * reading" rather than as a value: no CPU or GPU runs at 0 MHz while it is
+ * reporting. Hence "> 0" and not ">= 0".
+ */
+export function formatClockLabel(clock: Sensor | undefined): string {
+  if (!clock || !Number.isFinite(clock.value) || clock.value <= 0) return "—";
+  return formatValue(clock.value);
+}
+
 export function findSensorByTypeAndHardware(
   sensors: Sensor[],
   sensorType: SensorType,

--- a/tauri-app/src/stores/settings-store.gpu.test.ts
+++ b/tauri-app/src/stores/settings-store.gpu.test.ts
@@ -389,3 +389,31 @@ describe("single-GPU machines", () => {
       .toBe("/amdcpu/0/load/0");
   });
 });
+
+describe("clock readings", () => {
+  it("prefers a CPU core and selected GPU core over bus and memory clocks", () => {
+    const clocks = {
+      ...DATA,
+      hardwares: [...DATA.hardwares, { name: "CPU", identifier: "/cpu", hardwareType: HardwareType.Cpu }],
+      sensors: [...DATA.sensors,
+        sensor("/cpu", "/cpu/clock/0", "Bus Speed", SensorType.Clock, 100),
+        sensor("/cpu", "/cpu/clock/1", "CPU Core #1", SensorType.Clock, 5400),
+        sensor(NVIDIA.identifier, "/gpu-nvidia/0/clock/1", "GPU Memory", SensorType.Clock, 10000),
+        sensor(NVIDIA.identifier, "/gpu-nvidia/0/clock/0", "GPU Core", SensorType.Clock, 2500),
+        sensor(INTEL.identifier, "/gpu-intel/0/clock/0", "GPU Core", SensorType.Clock, 900),
+      ],
+    };
+    useSettingsStore.getState().setSensorData(clocks);
+    let rows = useSettingsStore.getState().settings.sensors;
+    expect(rows.cpuClock.customReadingId).toBe("/cpu/clock/1");
+    expect(rows.gpuClock.customReadingId).toBe("/gpu-nvidia/0/clock/0");
+    expect(rows.cpuClock.isEnabled).toBe(false);
+    expect(rows.gpuClock.isEnabled).toBe(false);
+    useSettingsStore.getState().selectGpu(INTEL.identifier);
+    rows = useSettingsStore.getState().settings.sensors;
+    expect(rows.gpuClock.customReadingId).toBe("/gpu-intel/0/clock/0");
+    useSettingsStore.getState().setSensorData({ ...clocks, sensors: clocks.sensors.filter(s => !s.identifier.startsWith('/gpu-intel/0/clock')) });
+    // Preserve the chosen sensor during a transient absence; the HUD shows —.
+    expect(useSettingsStore.getState().settings.sensors.gpuClock.customReadingId).toBe("/gpu-intel/0/clock/0");
+  });
+});

--- a/tauri-app/src/stores/settings-store.gpu.test.ts
+++ b/tauri-app/src/stores/settings-store.gpu.test.ts
@@ -397,7 +397,7 @@ describe("clock readings", () => {
       hardwares: [...DATA.hardwares, { name: "CPU", identifier: "/cpu", hardwareType: HardwareType.Cpu }],
       sensors: [...DATA.sensors,
         sensor("/cpu", "/cpu/clock/0", "Bus Speed", SensorType.Clock, 100),
-        sensor("/cpu", "/cpu/clock/1", "CPU Core #1", SensorType.Clock, 5400),
+        sensor("/cpu", "/cpu/clock/1", "CPU Core _1", SensorType.Clock, 5400),
         sensor(NVIDIA.identifier, "/gpu-nvidia/0/clock/1", "GPU Memory", SensorType.Clock, 10000),
         sensor(NVIDIA.identifier, "/gpu-nvidia/0/clock/0", "GPU Core", SensorType.Clock, 2500),
         sensor(INTEL.identifier, "/gpu-intel/0/clock/0", "GPU Core", SensorType.Clock, 900),
@@ -415,5 +415,57 @@ describe("clock readings", () => {
     useSettingsStore.getState().setSensorData({ ...clocks, sensors: clocks.sensors.filter(s => !s.identifier.startsWith('/gpu-intel/0/clock')) });
     // Preserve the chosen sensor during a transient absence; the HUD shows —.
     expect(useSettingsStore.getState().settings.sensors.gpuClock.customReadingId).toBe("/gpu-intel/0/clock/0");
+  });
+
+  /**
+   * Sensor names below are written the way the SIDECAR emits them, not the way
+   * LibreHardwareMonitor spells them: MonitorPoller.RemoveSpecialCharacters
+   * rewrites [^a-zA-Z0-9_ .]+ to "_", so "Core #1" becomes "Core _1",
+   * "Cores (Average)" becomes "Cores _Average_" and "P-Core #1" becomes
+   * "P_Core _1". Testing the unsanitised spelling would exercise a match that
+   * cannot happen on a real machine.
+   */
+  const cpuOnly = (...clocks: Sensor[]): HardwareMonitorData => ({
+    ...DATA,
+    hardwares: [...DATA.hardwares, { name: "CPU", identifier: "/cpu", hardwareType: HardwareType.Cpu }],
+    sensors: [...DATA.sensors, ...clocks],
+  });
+
+  it("picks the average core clock on Zen, never the bus or the effective clock", () => {
+    // Amd17Cpu activates Bus Speed(0), Cores (Average)(1) and
+    // Cores (Average Effective)(2) in that index order, and the average pair
+    // before any per-core sensor. The effective readings sit near-idle (they
+    // count halted cycles) so selecting one would look broken in the HUD.
+    seed({});
+    useSettingsStore.getState().setSensorData(cpuOnly(
+      sensor("/cpu", "/amdcpu/0/clock/0", "Bus Speed", SensorType.Clock, 100),
+      sensor("/cpu", "/amdcpu/0/clock/1", "Cores _Average_", SensorType.Clock, 4347),
+      sensor("/cpu", "/amdcpu/0/clock/2", "Cores _Average Effective_", SensorType.Clock, 285),
+      sensor("/cpu", "/amdcpu/0/clock/3", "Core _1", SensorType.Clock, 5150),
+      sensor("/cpu", "/amdcpu/0/clock/4", "Core _1 _Effective_", SensorType.Clock, 253),
+    ));
+    expect(useSettingsStore.getState().settings.sensors.cpuClock.customReadingId)
+      .toBe("/amdcpu/0/clock/1");
+  });
+
+  it("picks a P-Core on hybrid Intel, where no name contains \"CPU Core\"", () => {
+    // 12th gen and newer name cores "P-Core #N"/"E-Core #N" (IntelCpu.cs), so
+    // the "CPU Core" pattern misses entirely and only "Core" can match.
+    seed({});
+    useSettingsStore.getState().setSensorData(cpuOnly(
+      sensor("/cpu", "/intelcpu/0/clock/0", "Bus Speed", SensorType.Clock, 100),
+      sensor("/cpu", "/intelcpu/0/clock/1", "P_Core _1", SensorType.Clock, 5200),
+      sensor("/cpu", "/intelcpu/0/clock/9", "E_Core _1", SensorType.Clock, 4000),
+    ));
+    expect(useSettingsStore.getState().settings.sensors.cpuClock.customReadingId)
+      .toBe("/intelcpu/0/clock/1");
+  });
+
+  it("leaves the row empty when the CPU exposes no clock at all", () => {
+    // GenericCpu declares no Clock sensors, so an unsupported CPU or a VM has
+    // nothing to select and the HUD falls back to the dash.
+    seed({});
+    useSettingsStore.getState().setSensorData(cpuOnly());
+    expect(useSettingsStore.getState().settings.sensors.cpuClock.customReadingId).toBe("");
   });
 });

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -136,11 +136,13 @@ function autoSelectSensors(
 
   tryFill("cpuUsage", cpuHw, SensorType.Load, ["CPU Total", "CPU Package", "CPU"]);
   tryFill("cpuTemp", cpuHw, SensorType.Temperature, ["CPU Package", "CPU Core", "CPU"]);
+  tryFill("cpuClock", cpuHw, SensorType.Clock, ["CPU Core #1", "CPU Core", "Core #1", "Core"]);
   tryFill("cpuConsumption", cpuHw, SensorType.Power, ["CPU Package", "CPU"]);
   fillOnGpu("gpuUsage", SensorType.Load, ["GPU Core", "D3D 3D", "GPU"]);
   fillOnGpu("gpuTemp", SensorType.Temperature, ["GPU Core", "GPU"]);
   fillOnGpu("vramUsage", SensorType.Load, ["GPU Memory", "Memory"]);
   fillOnGpu("totalVramUsed", SensorType.SmallData, ["GPU Memory Used", "Memory Used", "VRAM"]);
+  fillOnGpu("gpuClock", SensorType.Clock, ["GPU Core", "Graphics", "GPU"]);
   fillOnGpu("gpuConsumption", SensorType.Power, ["GPU Package", "GPU Power", "GPU"]);
   tryFill("ramUsage", [HardwareType.Memory], SensorType.Load, ["Memory Used", "Memory"]);
   // For network, pick the most active non-virtual adapter

--- a/tauri-app/src/stores/settings-store.ts
+++ b/tauri-app/src/stores/settings-store.ts
@@ -136,7 +136,15 @@ function autoSelectSensors(
 
   tryFill("cpuUsage", cpuHw, SensorType.Load, ["CPU Total", "CPU Package", "CPU"]);
   tryFill("cpuTemp", cpuHw, SensorType.Temperature, ["CPU Package", "CPU Core", "CPU"]);
-  tryFill("cpuClock", cpuHw, SensorType.Clock, ["CPU Core #1", "CPU Core", "Core #1", "Core"]);
+  // No "#" in these patterns: the sidecar runs every sensor name through
+  // RemoveSpecialCharacters ([^a-zA-Z0-9_ .]+ -> "_"), so LHM's "Core #1"
+  // arrives here as "Core _1" and a "#" pattern can never match on any machine.
+  // These two cover every family LHM 0.9.6 reports a core clock for:
+  // "CPU Core" hits non-hybrid Intel and pre-Zen AMD ("CPU Core #N"), and
+  // "Core" hits Zen ("Cores (Average)", which Amd17Cpu activates first) and
+  // hybrid Intel ("P-Core #N"). "Bus Speed" contains neither, so the bus clock
+  // is never selected.
+  tryFill("cpuClock", cpuHw, SensorType.Clock, ["CPU Core", "Core"]);
   tryFill("cpuConsumption", cpuHw, SensorType.Power, ["CPU Package", "CPU"]);
   fillOnGpu("gpuUsage", SensorType.Load, ["GPU Core", "D3D 3D", "GPU"]);
   fillOnGpu("gpuTemp", SensorType.Temperature, ["GPU Core", "GPU"]);


### PR DESCRIPTION
Adds optional CPU and GPU clock readings in MHz, and closes two defects found while reviewing the selection logic against the pinned LibreHardwareMonitor 0.9.6 sources.

## 1. Clock readings (feature)

**Gap:** the overlay had no clock readout, so there was no way to see core or GPU frequency alongside temperature, load and power.

**Added:** a CPU Clock and a GPU Clock row in Stats and in the overlay pills, both off by default. Each has a sensor picker, participates in its section's master toggle, and preserves a custom selection. CPU selection prefers a core over the bus clock; GPU selection follows the existing selected-GPU setting and prefers the core over memory clocks. The sidecar protocol is unchanged, and existing settings gain the two disabled fields without resetting anything else (`serde` default plus a migration round-trip test).

## 2. Sensor-selection patterns that could never match

**Defect:** the sidecar runs every sensor name through `RemoveSpecialCharacters`, which rewrites `[^a-zA-Z0-9_ .]+` to `_`, so LHM's `Core #1` reaches the frontend as `Core _1`. `bestOf` matches by substring, so the `"CPU Core #1"` and `"Core #1"` entries in the `cpuClock` prefer list were unreachable on every machine. The test that covered this used the unsanitised `"CPU Core #1"`, so it was asserting on a match production cannot reach.

**Fix:** dropped the two dead patterns. Selection already fell through to the surviving pair, so the change is behaviour-preserving. The test now uses the name the sidecar actually emits, and adds coverage for Zen, hybrid Intel, and a CPU that exposes no clock at all.

The surviving pair covers every family LHM 0.9.6 reports a core clock for:

| Family | Clock sensors as they reach the frontend | Matches | Selected |
|---|---|---|---|
| AMD Zen (all current Ryzen, Threadripper, EPYC) | `Bus Speed`, `Cores _Average_`, `Cores _Average Effective_`, `Core _N`, `Core _N _Effective_` | `Core` | `Cores _Average_` |
| Intel hybrid (12th gen and newer) | `Bus Speed`, `P_Core _N`, `E_Core _N` | `Core` | `P_Core _1` |
| Intel non-hybrid, Xeon | `Bus Speed`, `CPU Core _N` | `CPU Core` | `CPU Core _1` |
| AMD K8/K10 | `Bus Speed`, `CPU Core _N` | `CPU Core` | `CPU Core _1` |
| Unsupported CPU or VM | none | none | empty, pill shows the dash |

Two properties hold on every family: `Bus Speed` contains neither `core` nor `cpu core`, so the bus clock is unselectable by any pattern; and on Zen, `_avgClock` is activated unconditionally at `Amd17Cpu.cs:144`, before `_avgClockEffcetive` at `:145` and before every per-core and bus clock, so `Cores _Average_` is always first in the active set rather than depending on enumeration order.

GPU needs no fallback at all: NVIDIA (`NvidiaGpu.cs:145-149`), AMD (`AmdGpu.cs:86-88`), Intel discrete (`IntelDiscreteGpu.cs:97-98`) and Intel integrated (`IntelIntegratedGpu.cs:56`) each expose a sensor named literally `GPU Core`, matched by the first prefer entry.

## 3. A failed reading printed "0 MHz"

**Defect:** `MapSensor` coalesces a null or NaN sensor value to `0f`, so a clock that is present but reading nothing arrives at the frontend as `0`, not as a missing sensor. The label guard tested `value >= 0` and treated that as a real reading, printing `0 MHz`. AMD nulls its GPU core clock on the legacy path (`AmdGpu.cs:550`, `:578`), so this was reachable.

**Fix:** `0` now takes the dash branch alongside an absent sensor, since nothing reports 0 MHz while it is running. Both overlay sections carried the same expression, so it moved to `formatClockLabel` in `lib/utils`, which removes the duplication and makes the guard unit-testable.

## Not included

- The Zen picker still lists LHM's Effective clock sensors (`Cores _Average Effective_`, `Core _N _Effective_`). They read 250 to 930 MHz at idle against 4300 to 5150 for the non-effective ones, because LHM's effective clock counts halted cycles. Correct per LHM, but a user who selects one will read it as broken. That is a copy or filtering decision, not a defect here. Intel exposes no Effective clock sensors.
- The four pre-existing clippy style warnings. `pr.yml` runs clippy without `-D warnings` by design.
- The duplicate `/gpu-nvidia/0/load/3` identifier, served once as `GPU Bus` (0) and once as `GPU Memory`. Latent and unrelated to clocks; the clock identifiers are the `NvGpuPublicClockId` enum values and are unique.

## Verification

Run on Windows 11, Ryzen 5 7600X and RTX 4080 SUPER, from an NSIS build of this branch.

| Gate | Command | Result |
|---|---|---|
| Lint | `npm run lint` | clean |
| Unit tests | `npm test` | 143 passed, 8 files |
| Frontend build | `npm run build` | built |
| Clippy | `cargo clippy --all-targets` | 4 pre-existing warnings, exit 0 |
| Rust tests | `cargo test --lib` | 31 passed |

The `0 MHz` guard was confirmed to fail without its fix: reverting to `>= 0` produces `expected '0' to be '—'` in `formatClockLabel > dashes on 0, which is how a failed read arrives`.

Accuracy was measured by attaching a second client to the live sidecar pipe, reading the exact frames the overlay renders, and comparing against `nvidia-smi` only while the clock was stationary, defined as the app reporting an unchanged value for 3 or more consecutive frames. Naive paired sampling is not usable here: at idle the core clock moves faster than either sampler, with `nvidia-smi`'s own readings going 930 to 735 MHz in 458 ms. Under the stationary gate the result was 12 of 12 exact with no disagreements, covering a low state (450 MHz) and sustained full boost (2640 MHz). Memory clock matched exactly whenever compared (5001.99/5001, 810/810, 405/405) and temperature stayed within 1 C. On the CPU side the selected `Cores _Average_` reading of 4347 MHz is the exact arithmetic mean of the six per-core sensors in the same frame, `(5150+5150+5150+5144+2606+2883)/6 = 4347.17`, and `Bus Speed` reads 100 MHz and is correctly not selected.
