### PR TITLE
Add Pixel Shift distance and timing controls

### DIFF
--- a/tauri-app/src-tauri/src/types.rs
+++ b/tauri-app/src-tauri/src/types.rs
@@ -372,6 +372,10 @@ pub struct OverlaySettings {
     // struct comment above).
     #[serde(rename = "pixelShift", default)]
     pub pixel_shift: bool,
+    #[serde(rename = "pixelShiftDistance", default = "default_pixel_shift_distance")]
+    pub pixel_shift_distance: u32,
+    #[serde(rename = "pixelShiftInterval", default = "default_pixel_shift_interval")]
+    pub pixel_shift_interval: u32,
     // Hardware identifier of the GPU every GPU reading is taken from, e.g.
     // "/gpu-nvidia/0". Empty means "not chosen yet", which the app resolves on
     // load. Machines with one GPU never show the control that sets this.
@@ -435,6 +439,8 @@ impl Default for OverlaySettings {
             polling_rate: 500,
             is_logging_enabled: false,
             pixel_shift: false,
+            pixel_shift_distance: default_pixel_shift_distance(),
+            pixel_shift_interval: default_pixel_shift_interval(),
             selected_gpu_id: String::new(),
             recording_shortcut: default_recording_shortcut(),
             overlay_shortcut: default_overlay_shortcut(),
@@ -507,6 +513,21 @@ pub struct MonitorInfo {
 mod tests {
     use super::*;
 
+    #[test]
+    fn pixel_shift_defaults_and_round_trip() {
+        let mut value = serde_json::to_value(OverlaySettings::default()).unwrap();
+        value.as_object_mut().unwrap().remove("pixelShiftDistance");
+        value.as_object_mut().unwrap().remove("pixelShiftInterval");
+        let mut loaded: OverlaySettings = serde_json::from_value(value).unwrap();
+        assert_eq!(loaded.pixel_shift_distance, 6);
+        assert_eq!(loaded.pixel_shift_interval, 3);
+        loaded.pixel_shift_distance = 12;
+        loaded.pixel_shift_interval = 30;
+        let restored: OverlaySettings = serde_json::from_str(&serde_json::to_string(&loaded).unwrap()).unwrap();
+        assert_eq!(restored.pixel_shift_distance, 12);
+        assert_eq!(restored.pixel_shift_interval, 30);
+    }
+
     /// The settings file is written by deserialising the app's JSON into
     /// OverlaySettings and serialising it straight back out, so any field the
     /// struct does not model is dropped on the first save. That is silent, and
@@ -566,3 +587,5 @@ pub enum HardwareState {
     Delayed,
     Failed,
 }
+fn default_pixel_shift_distance() -> u32 { 6 }
+fn default_pixel_shift_interval() -> u32 { 3 }

--- a/tauri-app/src/OverlayApp.tsx
+++ b/tauri-app/src/OverlayApp.tsx
@@ -1,3 +1,4 @@
+import { pixelShiftOptions, pixelShiftPosition } from "@/lib/pixel-shift";
 import { useEffect, useRef, useState } from "react";
 import { OverlayHud } from "@/components/overlay/OverlayHud";
 import { useSensorData } from "@/hooks/useSensorData";
@@ -199,25 +200,21 @@ export default function OverlayApp() {
       resetOffset();
       return;
     }
-    const AMPLITUDE = 6; // logical px per axis (12px span), scaled by DPI below
-    const TICK_MS = 3000; // one small step every 3s
-    const D_PHASE = 0.1; // keeps each step <=1px at this amplitude
-    const RATIO = Math.SQRT2; // incommensurate -> path fills the box over time
-    let phase = 0;
+    resetOffset();
+    const { distance, interval } = pixelShiftOptions({ pixelShiftDistance: settings.pixelShiftDistance, pixelShiftInterval: settings.pixelShiftInterval });
+    let tick = 0;
     const id = setInterval(() => {
       // Never fight an in-progress drag (apply() also early-returns then).
       if (dragStart.current) return;
-      phase += D_PHASE;
-      const dpr = window.devicePixelRatio || 1;
-      const nx = Math.round(AMPLITUDE * Math.sin(phase) * dpr);
-      const ny = Math.round(AMPLITUDE * Math.sin(phase * RATIO) * dpr);
+      tick += 1;
+      const { x: nx, y: ny } = pixelShiftPosition(tick, distance, window.devicePixelRatio || 1);
       if (nx !== pixelShiftOffset.current.x || ny !== pixelShiftOffset.current.y) {
         pixelShiftOffset.current = { x: nx, y: ny };
         applyPositionRef.current();
       }
-    }, TICK_MS);
+    }, interval * 1000);
     return () => clearInterval(id);
-  }, [settings.pixelShift]);
+  }, [settings.pixelShift, settings.pixelShiftDistance, settings.pixelShiftInterval]);
 
   // Manual drag. startDragging() needed an async dynamic import that lost the
   // button-down window on Windows before WM_NCLBUTTONDOWN could post, so drag

--- a/tauri-app/src/components/settings/settings/PixelShiftControls.tsx
+++ b/tauri-app/src/components/settings/settings/PixelShiftControls.tsx
@@ -1,0 +1,31 @@
+import { Input } from "@/components/shadcn/input";
+import { useSettingsStore } from "@/stores/settings-store";
+import { boundedInteger, pixelShiftOptions } from "@/lib/pixel-shift";
+
+export function PixelShiftControls() {
+  const settings = useSettingsStore((s) => s.settings);
+  const update = useSettingsStore((s) => s.updateSettings);
+  const { distance, interval } = pixelShiftOptions(settings);
+  return (
+    <fieldset disabled={!settings.pixelShift} className="flex flex-col gap-[var(--spacingS)] disabled:opacity-50">
+      <legend className="sr-only">Pixel Shift controls</legend>
+      {([
+        ["pixelShiftDistance", "Maximum shift (px)", distance, 20],
+        ["pixelShiftInterval", "Move every (seconds)", interval, 60],
+      ] as const).map(([key, label, value, max]) => (
+        <label key={key} className="flex items-center justify-between gap-[var(--spacingS)] text-body-sm-medium text-[var(--textHeading)]">
+          {label}
+          <Input key={value} type="number" min={1} max={max} step={1} defaultValue={value}
+            className="w-24" aria-label={label}
+            onKeyDown={(event) => { if (event.key === "Enter") event.currentTarget.blur(); }}
+            onBlur={(event) => {
+              const next = boundedInteger(event.currentTarget.valueAsNumber, 1, max, value);
+              event.currentTarget.value = String(next);
+              update({ [key]: next });
+            }} />
+        </label>
+      ))}
+      <p className="text-body-sm-regular text-[var(--textParagraph1)]">Up to {distance}px in each direction, taking a small step every {interval}s. Your saved overlay position stays unchanged.</p>
+    </fieldset>
+  );
+}

--- a/tauri-app/src/components/settings/settings/PixelShiftControls.tsx
+++ b/tauri-app/src/components/settings/settings/PixelShiftControls.tsx
@@ -16,7 +16,7 @@ export function PixelShiftControls() {
         <label key={key} className="flex items-center justify-between gap-[var(--spacingS)] text-body-sm-medium text-[var(--textHeading)]">
           {label}
           <Input key={value} type="number" min={1} max={max} step={1} defaultValue={value}
-            className="w-24" aria-label={label}
+            className="w-24 focus-visible:shadow-focus-default" aria-label={label}
             onKeyDown={(event) => { if (event.key === "Enter") event.currentTarget.blur(); }}
             onBlur={(event) => {
               const next = boundedInteger(event.currentTarget.valueAsNumber, 1, max, value);

--- a/tauri-app/src/components/settings/settings/SettingsTab.tsx
+++ b/tauri-app/src/components/settings/settings/SettingsTab.tsx
@@ -1,3 +1,4 @@
+import { PixelShiftControls } from "./PixelShiftControls";
 import * as React from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { Checkbox } from "@/components/shadcn/checkbox";
@@ -118,6 +119,7 @@ function GeneralSection() {
           aria-label="Pixel Shift"
         />
       </div>
+      <PixelShiftControls />
     </SectionCard>
   );
 }

--- a/tauri-app/src/lib/pixel-shift.test.ts
+++ b/tauri-app/src/lib/pixel-shift.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { pixelShiftOptions, pixelShiftPosition } from "./pixel-shift";
+
+describe("pixel shift", () => {
+  it("uses the shipped defaults for missing or invalid saved values", () => {
+    expect(pixelShiftOptions({ pixelShiftDistance: undefined!, pixelShiftInterval: NaN })).toEqual({ distance: 6, interval: 3 });
+    expect(pixelShiftOptions({ pixelShiftDistance: -50, pixelShiftInterval: 10000 })).toEqual({ distance: 1, interval: 60 });
+  });
+  it("stays bounded and takes small steps across distances and DPI scales", () => {
+    for (const distance of [1, 6, 20]) for (const dpr of [1, 1.5, 2]) {
+      let previous = { x: 0, y: 0 };
+      for (let tick = 1; tick < 1000; tick++) {
+        const next = pixelShiftPosition(tick, distance, dpr);
+        expect(Math.abs(next.x)).toBeLessThanOrEqual(Math.ceil(distance * dpr));
+        expect(Math.abs(next.y)).toBeLessThanOrEqual(Math.ceil(distance * dpr));
+        expect(Math.abs(next.x - previous.x)).toBeLessThanOrEqual(Math.ceil(dpr));
+        expect(Math.abs(next.y - previous.y)).toBeLessThanOrEqual(Math.ceil(dpr));
+        previous = next;
+      }
+    }
+  });
+});

--- a/tauri-app/src/lib/pixel-shift.ts
+++ b/tauri-app/src/lib/pixel-shift.ts
@@ -1,0 +1,23 @@
+import type { OverlaySettings } from "./types";
+
+export function boundedInteger(value: number, min: number, max: number, fallback: number) {
+  return Number.isFinite(value) ? Math.min(max, Math.max(min, Math.round(value))) : fallback;
+}
+
+export function pixelShiftOptions(settings: Pick<OverlaySettings, "pixelShiftDistance" | "pixelShiftInterval">) {
+  return {
+    distance: boundedInteger(settings.pixelShiftDistance, 1, 20, 6),
+    interval: boundedInteger(settings.pixelShiftInterval, 1, 60, 3),
+  };
+}
+
+// Keep the same path as the old 6px/3s option. Larger distances take more
+// steps, rather than making each movement an abrupt jump. Output is physical
+// pixels; the user's distance is in logical pixels, like the rest of the UI.
+export function pixelShiftPosition(tick: number, distance: number, dpr: number) {
+  const phase = tick * Math.min(0.1, 0.6 / distance);
+  return {
+    x: Math.round(distance * Math.sin(phase) * dpr),
+    y: Math.round(distance * Math.sin(phase * Math.SQRT2) * dpr),
+  };
+}

--- a/tauri-app/src/lib/types.ts
+++ b/tauri-app/src/lib/types.ts
@@ -110,6 +110,8 @@ export interface OverlaySettings {
   // When true, the overlay is nudged a few pixels on a slow cycle to spread
   // OLED wear (burn-in mitigation). See pixel-shift logic in OverlayApp.
   pixelShift: boolean;
+  pixelShiftDistance: number;
+  pixelShiftInterval: number;
   /**
    * Hardware identifier of the GPU every GPU reading is taken from, e.g.
    * "/gpu-nvidia/0". Empty means "not chosen yet".
@@ -246,6 +248,8 @@ export const DEFAULT_SETTINGS: OverlaySettings = {
   pollingRate: 500,
   isLoggingEnabled: false,
   pixelShift: false,
+  pixelShiftDistance: 6,
+  pixelShiftInterval: 3,
   selectedGpuId: "",
   recordingShortcut: RECORDING_SHORTCUT_DEFAULT,
   overlayShortcut: OVERLAY_SHORTCUT_DEFAULT,


### PR DESCRIPTION
Expose Pixel Shift's maximum distance (1–20 logical pixels per axis) and step interval (1–60 seconds) in Settings. Existing installs retain the current 6px / 3-second defaults. Controls are disabled when Pixel Shift is off, normalize invalid input, and save without changing the user's base overlay position.

Changing either value resets the offset and replaces the previous timer. Larger distances still take small steps; movement remains DPI-aware and uses the existing screen-edge clamp and drag pause.

Validation: frontend lint, 137 unit tests, and production build pass locally. Tests cover movement bounds and step sizes across distances/DPI scales; a Rust test covers old-settings defaults and persistence. Windows PR checks run Rust validation. Browser checks passed for disabled controls, clamping invalid input, live setting changes, replacing the active interval, and clearing it when Pixel Shift is disabled. Input focus uses the design-system shadow.

All [Windows PR checks](https://github.com/SupaStellar/Cleanmeter/actions/runs/34160723669) passed: frontend lint/tests/build, sidecar build/tests, and Rust clippy/tests.
