### PR TITLE
Bump version to 2.2.18

### DIFF
--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cleanmeter",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cleanmeter",
-      "version": "2.2.17",
+      "version": "2.2.18",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@fluentui/react-components": "^9.73.4",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleanmeter",
   "private": true,
-  "version": "2.2.17",
+  "version": "2.2.18",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "scripts": {

--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "cleanmeter"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "byteorder",
  "dirs",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cleanmeter"
-version = "2.2.17"
+version = "2.2.18"
 description = "Gaming performance overlay"
 authors = ["Cleanmeter"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui/toolkits/refs/heads/main/tauri/schema.json",
   "productName": "Cleanmeter",
   "identifier": "com.cleanmeter.desktop",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump only, ahead of cutting the 2.2.18 draft release.

## What changed

Bumps `2.2.17` → `2.2.18` in the five files that carry the version:

| File | Entries |
|---|---|
| `tauri-app/src-tauri/tauri.conf.json` | 1 |
| `tauri-app/package.json` | 1 |
| `tauri-app/package-lock.json` | 2 (both root entries) |
| `tauri-app/src-tauri/Cargo.toml` | 1 |
| `tauri-app/src-tauri/Cargo.lock` | 1 (`cleanmeter` package entry) |

## What it ships

The release carries #69, which replaces LibreHardwareMonitor's memory discovery with Windows memory counters so RAM-driver and DIMM/SMBus probing can no longer stall CPU/GPU/RAM publication, starts the pipe independently of hardware discovery, reports the active hardware stage to the UI and to a persistent log, and reconnects after the sidecar restarts. The affected user has confirmed the 2.2.17-startup.3 build resolves their issue.

## Not included

No functional changes. Nothing else was touched.

## Verification

- `cargo metadata --locked --no-deps` in `src-tauri` passes, so `cargo build --locked` will not disagree with its manifest in CI.
- `npm ci --dry-run` in `tauri-app` passes.
- No `2.2.17` string remains in any of the five files.