### PR TITLE
Allow app logs as Help feedback attachments

### DIFF
--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -575,32 +575,9 @@ pub async fn submit_feedback(input: FeedbackInput) -> Result<(), String> {
         .text("os", std::env::consts::OS);
 
     if let Some(path) = input.attachment_path.as_deref() {
-        let bytes = tokio::fs::read(path)
-            .await
-            .map_err(|e| format!("read attachment: {e}"))?;
         let file_path = std::path::Path::new(path);
-        let filename = file_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("attachment")
-            .to_string();
-        // The portal validates the part's content type against an image
-        // allowlist; reqwest defaults to application/octet-stream, so the
-        // mime must be set explicitly (extensions per pickImageAttachment).
-        let mime = match file_path
-            .extension()
-            .and_then(|e| e.to_str())
-            .map(|e| e.to_ascii_lowercase())
-            .as_deref()
-        {
-            Some("png") => "image/png",
-            Some("jpg") | Some("jpeg") => "image/jpeg",
-            Some("webp") => "image/webp",
-            Some("gif") => "image/gif",
-            // The portal would reject anything else anyway (opaque 400);
-            // fail fast with an actionable message instead.
-            _ => return Err("attachment must be a png, jpg, webp, or gif image".to_string()),
-        };
+        let (bytes, mime) = crate::feedback_attachment::read(file_path).await?;
+        let filename = file_path.file_name().and_then(|n| n.to_str()).unwrap_or("attachment").to_string();
         let part = reqwest::multipart::Part::bytes(bytes)
             .file_name(filename)
             .mime_str(mime)

--- a/tauri-app/src-tauri/src/feedback_attachment.rs
+++ b/tauri-app/src-tauri/src/feedback_attachment.rs
@@ -1,0 +1,61 @@
+use std::path::Path;
+use tokio::io::AsyncReadExt;
+
+const MAX_BYTES: u64 = 8 * 1024 * 1024;
+
+fn attachment_mime(path: &Path) -> Result<&'static str, String> {
+    match path.extension().and_then(|e| e.to_str()).map(str::to_ascii_lowercase).as_deref() {
+        Some("png") => Ok("image/png"),
+        Some("jpg" | "jpeg") => Ok("image/jpeg"),
+        Some("webp") => Ok("image/webp"),
+        Some("gif") => Ok("image/gif"),
+        Some("log" | "txt") => Ok("text/plain"),
+        _ => Err("Choose a PNG, JPG, WebP, GIF, .log or .txt file.".into()),
+    }
+}
+
+fn validate(bytes: &[u8], mime: &str) -> Result<(), String> {
+    if bytes.is_empty() { return Err("The attachment is empty.".into()); }
+    if bytes.len() as u64 > MAX_BYTES { return Err("The attachment must be 8 MiB or smaller.".into()); }
+    if mime == "text/plain" && (bytes.contains(&0) || std::str::from_utf8(bytes).is_err()) {
+        return Err("Log attachments must be UTF-8 text (.log or .txt).".into());
+    }
+    Ok(())
+}
+
+pub async fn read(path: &Path) -> Result<(Vec<u8>, &'static str), String> {
+    let mime = attachment_mime(path)?;
+    let file = tokio::fs::File::open(path).await.map_err(|e| format!("Cannot open attachment: {e}"))?;
+    let metadata = file.metadata().await.map_err(|e| format!("Cannot inspect attachment: {e}"))?;
+    if !metadata.is_file() { return Err("Choose a regular file.".into()); }
+    if metadata.len() > MAX_BYTES { return Err("The attachment must be 8 MiB or smaller.".into()); }
+    // Bound the read too: a live log can grow after the metadata check.
+    let mut bytes = Vec::new();
+    file.take(MAX_BYTES + 1).read_to_end(&mut bytes).await.map_err(|e| format!("Cannot read attachment: {e}"))?;
+    validate(&bytes, mime)?;
+    Ok((bytes, mime))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logs_and_images_have_explicit_portal_mime_types() {
+        assert_eq!(attachment_mime(Path::new("HardwareMonitor.LOG")).unwrap(), "text/plain");
+        assert_eq!(attachment_mime(Path::new("cleanmeter.txt")).unwrap(), "text/plain");
+        assert_eq!(attachment_mime(Path::new("screenshot.JPEG")).unwrap(), "image/jpeg");
+        assert!(attachment_mime(Path::new("report.html")).is_err());
+        assert!(attachment_mime(Path::new("report.exe")).is_err());
+    }
+
+    #[test]
+    fn validates_text_and_size_without_rejecting_binary_images() {
+        assert!(validate(b"[INFO] Starting monitor\r\n", "text/plain").is_ok());
+        assert!(validate(&[0xff], "text/plain").is_err());
+        assert!(validate(b"binary\0", "text/plain").is_err());
+        assert!(validate(b"", "text/plain").is_err());
+        assert!(validate(&vec![b'a'; MAX_BYTES as usize + 1], "text/plain").is_err());
+        assert!(validate(&[0xff, 0], "image/jpeg").is_ok());
+    }
+}

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod feedback_attachment;
 mod pipe_client;
 mod pipe_input;
 mod shortcuts;

--- a/tauri-app/src/components/settings/settings/FeedbackDialog.tsx
+++ b/tauri-app/src/components/settings/settings/FeedbackDialog.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/app/components/Input";
 import { Textarea } from "@/app/components/Textarea";
 import { Button } from "@/app/components/Button";
 import { cn } from "@/lib/utils";
-import { submitFeedback, pickImageAttachment } from "@/lib/tauri";
+import { submitFeedback, pickFeedbackAttachment } from "@/lib/tauri";
 
 // Close icon — Figma 2488:5953 (20×20, #61646C → iconBolderActive).
 function CloseIcon({ className }: { className?: string }) {
@@ -63,11 +63,12 @@ export interface FeedbackDialogProps {
 export function FeedbackDialog({
   open,
   onOpenChange,
-  pickAttachment = pickImageAttachment,
+  pickAttachment = pickFeedbackAttachment,
 }: FeedbackDialogProps) {
   const [name, setName] = React.useState("");
   const [message, setMessage] = React.useState("");
   const [attachment, setAttachment] = React.useState<Attachment | null>(null);
+  const [error, setError] = React.useState("");
   const [status, setStatus] = React.useState<Status>("idle");
 
   // Reset everything whenever the dialog closes.
@@ -77,14 +78,20 @@ export function FeedbackDialog({
       setMessage("");
       setAttachment(null);
       setStatus("idle");
+      setError("");
     }
   }, [open]);
 
   const canSubmit = message.trim() !== "" && status !== "submitting";
 
   const handlePick = async () => {
-    const picked = await pickAttachment();
-    if (picked) setAttachment(picked);
+    try {
+      const picked = await pickAttachment();
+      if (picked) { setAttachment(picked); setStatus("idle"); setError(""); }
+    } catch (err) {
+      setError(`Couldn’t select an attachment: ${String(err)}`);
+      setStatus("error");
+    }
   };
 
   const handleSubmit = async () => {
@@ -101,6 +108,7 @@ export function FeedbackDialog({
       // Surface the underlying Rust error (e.g. "request failed", "portal
       // returned 401") so failures are diagnosable instead of opaque.
       console.error("submit_feedback failed:", err);
+      setError(String(err));
       setStatus("error");
     }
   };
@@ -177,6 +185,7 @@ export function FeedbackDialog({
                 <button
                   type="button"
                   aria-label="Remove attachment"
+                  disabled={status === "submitting"}
                   onClick={() => setAttachment(null)}
                   className="flex size-5 shrink-0 items-center justify-center rounded-[4px] text-[var(--iconBolderActive)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
@@ -187,16 +196,18 @@ export function FeedbackDialog({
 
             <button
               type="button"
+              disabled={status === "submitting"}
               onClick={handlePick}
               className="flex w-fit items-center gap-2 rounded-[4px] text-[var(--textHeading)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <PlusIcon className="size-5" />
-              <span className="text-body-sm-medium">Add attachment</span>
+              <span className="text-body-sm-medium">Attach image or log</span>
             </button>
 
+            <p className="text-body-sm-regular text-[var(--textParagraph1)]">One image or UTF-8 .log/.txt file, up to 8 MiB. Choose the app or HardwareMonitor log you want to share.</p>
             {status === "error" && (
               <p className="text-body-sm-regular text-[var(--iconDanger)]">
-                Couldn’t send feedback. Please try again.
+                Couldn’t complete feedback: {error || "Please try again."}
               </p>
             )}
 

--- a/tauri-app/src/lib/tauri.ts
+++ b/tauri-app/src/lib/tauri.ts
@@ -259,9 +259,9 @@ export const submitFeedback = (input: {
   return safeInvoke("submit_feedback", { input });
 };
 
-// Opens the OS image picker and returns the absolute path + display name.
+// Opens the OS attachment picker and returns the absolute path + display name.
 // Browser preview has no Tauri runtime, so it returns null (no-op).
-export const pickImageAttachment = async (): Promise<
+export const pickFeedbackAttachment = async (): Promise<
   { path: string; name: string } | null
 > => {
   if (isBrowser) return null;
@@ -269,7 +269,11 @@ export const pickImageAttachment = async (): Promise<
   const selected = await open({
     multiple: false,
     directory: false,
-    filters: [{ name: "Image", extensions: ["png", "jpg", "jpeg", "webp", "gif"] }],
+    filters: [
+      { name: "Images and logs", extensions: ["png", "jpg", "jpeg", "webp", "gif", "log", "txt"] },
+      { name: "Log files", extensions: ["log", "txt"] },
+      { name: "Images", extensions: ["png", "jpg", "jpeg", "webp", "gif"] },
+    ],
   });
   if (typeof selected !== "string") return null;
   const name = selected.split(/[/\\]/).pop() ?? "attachment";


### PR DESCRIPTION
Allow a user-selected UTF-8 .log/.txt file in Help → Give feedback, alongside the existing PNG/JPG/WebP/GIF attachments. The picker exposes log filters, the selected filename remains removable, and the form explains the single-file 8 MiB limit. Picker/upload errors stay visible without losing the report text.

The Rust command sends logs as text/plain, rejects unsupported/empty/binary/oversized files, and bounds the read even if a live log grows after its initial size check. No log is collected or sent automatically.

Server companion: https://github.com/SupaStellar/cleanmeter-feedback-portal/pull/3. Deploy the portal PR before releasing this app change; it accepts text attachments and presents them as downloads. Both changes retain existing screenshot support.

Validation: frontend lint, unit tests, and production build pass locally. Added Rust MIME/text/size validation tests, run by Windows PR checks. The portal companion passes 60 tests, TypeScript checking and its production build, including multipart upload/download tests. No live feedback was submitted.

Browser checks passed for selecting/removing a log filename and preserving report text on submission failure. Windows clippy and unit tests pass.

All [Windows PR checks](https://github.com/SupaStellar/Cleanmeter/actions/runs/34160191430) passed: frontend lint/tests/build, sidecar build/tests, and Rust clippy/tests.
